### PR TITLE
While in Release build upon login the empty while loop is optimized out and the app hangs.

### DIFF
--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -13,6 +13,7 @@ using Framework.Logging;
 using HermesProxy.World.Enums;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Threading;
 using Framework.Networking;
 using HermesProxy.World.Server;
 
@@ -73,7 +74,9 @@ namespace HermesProxy.World.Client
             }
 
             while (_isSuccessful == null)
-            { }
+            {
+                Thread.Sleep(1);
+            }
 
             return (bool)_isSuccessful;
         }


### PR DESCRIPTION
Log <details>

```
[My build version]
23:38:38 | Debug | WorldSocket | C<P S | Sending opcode SMSG_AUTH_CHALLENGE (12360).
23:38:38 | Debug | WorldSocket | C>P S | Received opcode CMSG_AUTH_SESSION (14181).
23:38:38 | Server | WorldSocket | WorldSocket:HandleAuthSession: Client 'RGOP13' authenticated successfully from 127.0.0.1:55799.
23:38:38 | Network | WorldClient | Connecting to world server...
23:38:38 | Network | WorldClient | World Server address 127.0.0.1:8085 resolved as 127.0.0.1:8085
23:38:38 | Network | WorldClient | Connection established!
23:38:38 | Debug | WorldClient | C P<S | Received opcode SMSG_AUTH_CHALLENGE (492).
23:38:38 | Debug | WorldClient | C P>S | Sending opcode CMSG_AUTH_SESSION (493) with size 221.
23:38:38 | Debug | WorldClient | C P<S | Received opcode SMSG_WARDEN_DATA (742).
23:38:38 | Warning | WorldClient | C P<S | No handler for opcode SMSG_WARDEN_DATA (742) (Got unknown packet from WorldServer)
23:38:38 | Debug | WorldClient | C P<S | Received opcode SMSG_ADDON_INFO (751).
23:38:38 | Debug | WorldSocket | C<P S | Sending opcode SMSG_AUTH_RESPONSE (9581).
23:38:38 | Error | WorldSocket | The WorldClient failed to connect to the selected world server!
23:38:38 | Error | AuthClient | C P<S | Socket Closed By Server
23:38:38 | Debug | BnetServices | [BnetTcp][127.0.0.1:55785, Account: RGOP13, Game account: RGOP13] Client requested service ConnectionService/m:7
23:38:38 | Error | WorldClient | C P<S | Socket Closed By GameWorldServer (header)

[Release version]
23:39:27 | Debug | WorldSocket | C<P S | Sending opcode SMSG_AUTH_CHALLENGE (12360).
23:39:27 | Debug | WorldSocket | C>P S | Received opcode CMSG_AUTH_SESSION (14181).
23:39:27 | Server | WorldSocket | WorldSocket:HandleAuthSession: Client 'RGOP13' authenticated successfully from 127.0.0.1:55869.
23:39:27 | Network | WorldClient | Connecting to world server...
23:39:27 | Network | WorldClient | World Server address 127.0.0.1:8085 resolved as 127.0.0.1:8085
23:39:27 | Network | WorldClient | Connection established!
23:39:27 | Debug | WorldClient | C P<S | Received opcode SMSG_AUTH_CHALLENGE (492).
23:39:27 | Debug | WorldClient | C P>S | Sending opcode CMSG_AUTH_SESSION (493) with size 221.
23:39:27 | Debug | WorldClient | C P<S | Received opcode SMSG_WARDEN_DATA (742).
23:39:27 | Debug | WorldClient | C P>S | Sending opcode CMSG_WARDEN_DATA (743) with size 5.
23:39:27 | Debug | WorldClient | C P<S | Received opcode SMSG_ADDON_INFO (751).
23:39:27 | Debug | WorldClient | C P<S | Received opcode SMSG_AUTH_RESPONSE (494).
23:39:27 | Network | WorldClient | Authentication succeeded!
````
</details>

During Release build the busy wait will optimized out thus the client hangs before make it to the character selection screen.

should fix
* https://github.com/WowLegacyCore/HermesProxy/issues/375
* https://github.com/WowLegacyCore/HermesProxy/issues/367

Note: in order to make the connection successfully i needed to disable cmangos anicheat in the config.