### PR TITLE
Replace Thread.Sleep spell delay with queue-based tracking

### DIFF
--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -27,8 +27,6 @@ namespace Framework
         public static int InstancePort;
         public static bool DebugOutput;
         public static bool PacketsLog;
-        public static int ServerSpellDelay;
-        public static int ClientSpellDelay;
 
         public static bool LoadAndVerifyFrom(ConfigurationParser config)
         {
@@ -50,8 +48,6 @@ namespace Framework
             InstancePort = config.GetInt("InstancePort", 8086);
             DebugOutput = config.GetBoolean("DebugOutput", false);
             PacketsLog = config.GetBoolean("PacketsLog", true);
-            ServerSpellDelay = config.GetInt("ServerSpellDelay", 0);
-            ClientSpellDelay = config.GetInt("ClientSpellDelay", 0);
 
             return VerifyConfig();
         }
@@ -103,18 +99,6 @@ namespace Framework
             if (!IsValidPortNumber(InstancePort))
             {
                 Log.Print(LogType.Server, $"Specified battle.net port ({InstancePort}) out of allowed range (1-65535)");
-                return false;
-            }
-
-            if (ServerSpellDelay < 0)
-            {
-                Log.Print(LogType.Server, "ServerSpellDelay must be larger than or equal to 0");
-                return false;
-            }
-
-            if (ClientSpellDelay < 0)
-            {
-                Log.Print(LogType.Server, "ClientSpellDelay must be larger than or equal to 0");
                 return false;
             }
 

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -4,6 +4,7 @@ using HermesProxy.World.Client;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -83,11 +84,9 @@ namespace HermesProxy
         public uint LastWhoRequestId;
         public WowGuid128 CurrentPetGuid;
         public uint[] CurrentArenaTeamIds = new uint[3];
-        public ClientCastRequest CurrentClientNormalCast;  // regular spell casts
-        public ClientCastRequest CurrentClientSpecialCast; // next melee or auto repeat spells
-        public ClientCastRequest CurrentClientPetCast;
-        public List<ClientCastRequest> PendingClientCasts = new List<ClientCastRequest>();
-        public List<ClientCastRequest> PendingClientPetCasts = new List<ClientCastRequest>();
+        public ConcurrentQueue<ClientCastRequest> PendingNormalCasts = new();  // regular spell casts (queue for proper FIFO handling)
+        public ClientCastRequest CurrentClientSpecialCast; // next melee or auto repeat spells (exclusive, only one at a time)
+        public ConcurrentQueue<ClientCastRequest> PendingPetCasts = new();  // pet spell casts (queue for proper FIFO handling)
         public WowGuid64 LastLootTargetGuid;
         public List<int> ActionButtons = new();
         public Dictionary<WowGuid128, Dictionary<byte, int>> UnitAuraDurationUpdateTime = new();
@@ -505,6 +504,211 @@ namespace HermesProxy
 
             return default;
         }
+
+        // Spell Cast Queue Helper Methods
+
+        /// <summary>
+        /// Try to find and dequeue a pending cast by SpellId.
+        /// Uses FIFO order since TCP guarantees packet ordering.
+        /// </summary>
+        public bool TryDequeuePendingNormalCast(uint spellId, out ClientCastRequest cast)
+        {
+            // Since TCP preserves order, the first matching SpellId is the correct one
+            var pending = new List<ClientCastRequest>();
+            cast = null;
+
+            while (PendingNormalCasts.TryDequeue(out var current))
+            {
+                if (cast == null && current.SpellId == spellId)
+                {
+                    cast = current;
+                }
+                else
+                {
+                    pending.Add(current);
+                }
+            }
+
+            // Re-enqueue non-matching casts
+            foreach (var item in pending)
+            {
+                PendingNormalCasts.Enqueue(item);
+            }
+
+            return cast != null;
+        }
+
+        /// <summary>
+        /// Try to find a pending cast by SpellId and mark it as started (for SPELL_START).
+        /// </summary>
+        public bool TryMarkPendingNormalCastStarted(uint spellId, out ClientCastRequest cast)
+        {
+            // Peek through queue to find matching SpellId
+            var items = PendingNormalCasts.ToArray();
+            cast = null;
+
+            foreach (var item in items)
+            {
+                if (item.SpellId == spellId && !item.HasStarted)
+                {
+                    item.HasStarted = true;
+                    cast = item;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Clear all pending normal casts (used on timeout or disconnect).
+        /// </summary>
+        public void ClearPendingNormalCasts()
+        {
+            while (PendingNormalCasts.TryDequeue(out _)) { }
+        }
+
+        /// <summary>
+        /// Clear only pending normal casts that haven't started yet.
+        /// Keeps started casts so SPELL_GO can dequeue them later.
+        /// Returns the cleared casts so they can be failed.
+        /// </summary>
+        public List<ClientCastRequest> ClearNonStartedNormalCasts()
+        {
+            var cleared = new List<ClientCastRequest>();
+            var keep = new List<ClientCastRequest>();
+
+            while (PendingNormalCasts.TryDequeue(out var current))
+            {
+                if (current.HasStarted)
+                    keep.Add(current);
+                else
+                    cleared.Add(current);
+            }
+
+            // Re-enqueue started casts
+            foreach (var item in keep)
+            {
+                PendingNormalCasts.Enqueue(item);
+            }
+
+            return cleared;
+        }
+
+        /// <summary>
+        /// Try to find and dequeue a pending pet cast by SpellId.
+        /// </summary>
+        public bool TryDequeuePendingPetCast(uint spellId, out ClientCastRequest cast)
+        {
+            var pending = new List<ClientCastRequest>();
+            cast = null;
+
+            while (PendingPetCasts.TryDequeue(out var current))
+            {
+                if (cast == null && current.SpellId == spellId)
+                {
+                    cast = current;
+                }
+                else
+                {
+                    pending.Add(current);
+                }
+            }
+
+            foreach (var item in pending)
+            {
+                PendingPetCasts.Enqueue(item);
+            }
+
+            return cast != null;
+        }
+
+        /// <summary>
+        /// Try to find a pending pet cast by SpellId and mark it as started.
+        /// </summary>
+        public bool TryMarkPendingPetCastStarted(uint spellId, out ClientCastRequest cast)
+        {
+            var items = PendingPetCasts.ToArray();
+            cast = null;
+
+            foreach (var item in items)
+            {
+                if (item.SpellId == spellId && !item.HasStarted)
+                {
+                    item.HasStarted = true;
+                    cast = item;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Clear all pending pet casts.
+        /// </summary>
+        public void ClearPendingPetCasts()
+        {
+            while (PendingPetCasts.TryDequeue(out _)) { }
+        }
+
+        /// <summary>
+        /// Clear only pending pet casts that haven't started yet.
+        /// Keeps started casts so SPELL_GO can dequeue them later.
+        /// Returns the cleared casts so they can be failed.
+        /// </summary>
+        public List<ClientCastRequest> ClearNonStartedPetCasts()
+        {
+            var cleared = new List<ClientCastRequest>();
+            var keep = new List<ClientCastRequest>();
+
+            while (PendingPetCasts.TryDequeue(out var current))
+            {
+                if (current.HasStarted)
+                    keep.Add(current);
+                else
+                    cleared.Add(current);
+            }
+
+            // Re-enqueue started casts
+            foreach (var item in keep)
+            {
+                PendingPetCasts.Enqueue(item);
+            }
+
+            return cleared;
+        }
+
+        /// <summary>
+        /// Try to find and dequeue a pending cast by ItemGUID (for item use failures).
+        /// Only matches casts that haven't started yet.
+        /// </summary>
+        public bool TryDequeueItemCast(WowGuid128 itemGuid, out ClientCastRequest cast)
+        {
+            var pending = new List<ClientCastRequest>();
+            cast = null;
+
+            while (PendingNormalCasts.TryDequeue(out var current))
+            {
+                if (cast == null && !current.HasStarted && current.ItemGUID == itemGuid)
+                {
+                    cast = current;
+                }
+                else
+                {
+                    pending.Add(current);
+                }
+            }
+
+            // Re-enqueue non-matching casts
+            foreach (var item in pending)
+            {
+                PendingNormalCasts.Enqueue(item);
+            }
+
+            return cast != null;
+        }
+
         public void StorePlayerGuildId(WowGuid128 guid, uint guildId)
         {
             if (PlayerGuildIds.ContainsKey(guid))

--- a/HermesProxy/HermesProxy.config
+++ b/HermesProxy/HermesProxy.config
@@ -93,21 +93,5 @@
             Default:     "true"
     -->
     <add key="PacketsLog" value="true" />
-    <!--
-            Option:      ServerSpellDelay
-            Description: The amount of spell delay for Proxy <=> ModernClient in milliseconds (0 = disabled).
-                         If you experience "stuck" spell animations/sounds try values above 0. (Like 20)
-                         Warning: Adding a delay might cause you to lose optimal DPS.
-            Default:     "15"
-    -->
-    <add key="ServerSpellDelay" value="15" />
-    <!--
-            Option:      ClientSpellDelay
-            Description: The amount of spell delay for GameServer <=> Proxy in milliseconds (0 = disabled).
-                         If you experience "stuck" spell animations/sounds try values above 0. (Like 20)
-                         Warning: Adding a delay might cause you to lose optimal DPS.
-            Default:     "15"
-    -->
-    <add key="ClientSpellDelay" value="15" />
   </appSettings>
 </configuration>

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -134,12 +134,10 @@ namespace HermesProxy.World.Client
 
             SendPacketToClient(failure);
 
-            if (GetSession().GameState.CurrentClientNormalCast != null &&
-               !GetSession().GameState.CurrentClientNormalCast.HasStarted &&
-                GetSession().GameState.CurrentClientNormalCast.ItemGUID == failure.Item[0])
+            // Check if item use cast failed (queue-based)
+            if (GetSession().GameState.TryDequeueItemCast(failure.Item[0], out var pendingCast))
             {
-                GetSession().InstanceSocket.SendCastRequestFailed(GetSession().GameState.CurrentClientNormalCast, false);
-                GetSession().GameState.CurrentClientNormalCast = null;
+                GetSession().InstanceSocket.SendCastRequestFailed(pendingCast, false);
             }
         }
         [PacketHandler(Opcode.SMSG_INVENTORY_CHANGE_FAILURE, ClientVersionBuild.V2_0_1_6180)]
@@ -173,12 +171,10 @@ namespace HermesProxy.World.Client
             }
             SendPacketToClient(failure);
 
-            if (GetSession().GameState.CurrentClientNormalCast != null &&
-               !GetSession().GameState.CurrentClientNormalCast.HasStarted &&
-                GetSession().GameState.CurrentClientNormalCast.ItemGUID == failure.Item[0])
+            // Check if item use cast failed (queue-based)
+            if (GetSession().GameState.TryDequeueItemCast(failure.Item[0], out var pendingCast))
             {
-                GetSession().InstanceSocket.SendCastRequestFailed(GetSession().GameState.CurrentClientNormalCast, false);
-                GetSession().GameState.CurrentClientNormalCast = null;
+                GetSession().InstanceSocket.SendCastRequestFailed(pendingCast, false);
             }
         }
         [PacketHandler(Opcode.SMSG_DURABILITY_DAMAGE_DEATH)]

--- a/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
@@ -15,7 +15,7 @@ namespace HermesProxy.World.Client
         {
             WowGuid64 guid = packet.ReadGuid();
             GetSession().GameState.CurrentPetGuid = guid.To128(GetSession().GameState);
-            GetSession().GameState.CurrentClientPetCast = null;
+            GetSession().GameState.ClearPendingPetCasts();
 
             // Equal to "Clear spells" pre cataclysm
             if (guid.IsEmpty())

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -3,7 +3,7 @@ using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Server.Packets;
 using System;
-using System.Threading;
+using System.Linq;
 
 namespace HermesProxy.World.Client
 {
@@ -126,11 +126,6 @@ namespace HermesProxy.World.Client
         [PacketHandler(Opcode.SMSG_CAST_FAILED)]
         void HandleCastFailed(WorldPacket packet)
         {
-            // Artificial lag is needed for spell packets,
-            // or spells will bug out and glow if spammed.
-            if (Settings.ClientSpellDelay > 0)
-                Thread.Sleep(Settings.ClientSpellDelay);
-
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
                 packet.ReadUInt8(); // cast count
 
@@ -152,6 +147,7 @@ namespace HermesProxy.World.Client
             if (packet.CanRead())
                 arg2 = packet.ReadInt32();
 
+            // Check special casts first (next melee / auto repeat)
             if (GetSession().GameState.CurrentClientSpecialCast != null &&
                 GetSession().GameState.CurrentClientSpecialCast.SpellId == spellId)
             {
@@ -165,55 +161,45 @@ namespace HermesProxy.World.Client
                 SendPacketToClient(failed);
                 GetSession().GameState.CurrentClientSpecialCast = null;
             }
-            else if (GetSession().GameState.CurrentClientNormalCast != null &&
-                    GetSession().GameState.CurrentClientNormalCast.SpellId == spellId)
+            // Look up pending normal cast by SpellId (queue-based, FIFO order)
+            else if (GetSession().GameState.TryDequeuePendingNormalCast(spellId, out var pendingCast))
             {
-                if (!GetSession().GameState.CurrentClientNormalCast.HasStarted)
+                if (!pendingCast.HasStarted)
                 {
                     SpellPrepare prepare2 = new SpellPrepare();
-                    prepare2.ClientCastID = GetSession().GameState.CurrentClientNormalCast.ClientGUID;
-                    prepare2.ServerCastID = GetSession().GameState.CurrentClientNormalCast.ServerGUID;
+                    prepare2.ClientCastID = pendingCast.ClientGUID;
+                    prepare2.ServerCastID = pendingCast.ServerGUID;
                     SendPacketToClient(prepare2);
                 }
 
                 CastFailed failed = new();
-                failed.SpellID = GetSession().GameState.CurrentClientNormalCast.SpellId;
-                failed.SpellXSpellVisualID = GetSession().GameState.CurrentClientNormalCast.SpellXSpellVisualId;
+                failed.SpellID = pendingCast.SpellId;
+                failed.SpellXSpellVisualID = pendingCast.SpellXSpellVisualId;
                 failed.Reason = LegacyVersion.ConvertSpellCastResult(reason);
-                failed.CastID = GetSession().GameState.CurrentClientNormalCast.ServerGUID;
+                failed.CastID = pendingCast.ServerGUID;
                 failed.FailedArg1 = arg1;
                 failed.FailedArg2 = arg2;
                 SendPacketToClient(failed);
-
-                GetSession().GameState.CurrentClientNormalCast = null;
-                foreach (var pending in GetSession().GameState.PendingClientCasts)
-                    GetSession().InstanceSocket.SendCastRequestFailed(pending, false);
-                GetSession().GameState.PendingClientCasts.Clear();
             }
         }
 
         [PacketHandler(Opcode.SMSG_PET_CAST_FAILED, ClientVersionBuild.Zero, ClientVersionBuild.V2_0_1_6180)]
         void HandlePetCastFailed(WorldPacket packet)
         {
-            // Artificial lag is needed for spell packets,
-            // or spells will bug out and glow if spammed.
-            if (Settings.ClientSpellDelay > 0)
-                Thread.Sleep(Settings.ClientSpellDelay);
-
             uint spellId = packet.ReadUInt32();
             var status = packet.ReadUInt8();
             if (status != 2)
                 return;
 
-            if (GetSession().GameState.CurrentClientPetCast == null ||
-                GetSession().GameState.CurrentClientPetCast.SpellId != spellId)
+            // Look up pending pet cast by SpellId (queue-based, FIFO order)
+            if (!GetSession().GameState.TryDequeuePendingPetCast(spellId, out var pendingCast))
                 return;
 
-            if (!GetSession().GameState.CurrentClientPetCast.HasStarted)
+            if (!pendingCast.HasStarted)
             {
                 SpellPrepare prepare2 = new SpellPrepare();
-                prepare2.ClientCastID = GetSession().GameState.CurrentClientPetCast.ClientGUID;
-                prepare2.ServerCastID = GetSession().GameState.CurrentClientPetCast.ServerGUID;
+                prepare2.ClientCastID = pendingCast.ClientGUID;
+                prepare2.ServerCastID = pendingCast.ServerGUID;
                 SendPacketToClient(prepare2);
             }
 
@@ -221,36 +207,27 @@ namespace HermesProxy.World.Client
             spell.SpellID = spellId;
             uint reason = packet.ReadUInt8();
             spell.Reason = LegacyVersion.ConvertSpellCastResult(reason);
-            spell.CastID = GetSession().GameState.CurrentClientPetCast.ServerGUID;
+            spell.CastID = pendingCast.ServerGUID;
             SendPacketToClient(spell);
-
-            foreach (var pending in GetSession().GameState.PendingClientPetCasts)
-                GetSession().InstanceSocket.SendCastRequestFailed(pending, true);
-            GetSession().GameState.PendingClientPetCasts.Clear();
         }
 
         [PacketHandler(Opcode.SMSG_PET_CAST_FAILED, ClientVersionBuild.V2_0_1_6180)]
         void HandlePetCastFailedTBC(WorldPacket packet)
         {
-            // Artificial lag is needed for spell packets,
-            // or spells will bug out and glow if spammed.
-            if (Settings.ClientSpellDelay > 0)
-                Thread.Sleep(Settings.ClientSpellDelay);
-
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
                 packet.ReadUInt8(); // cast count
 
             uint spellId = packet.ReadUInt32();
 
-            if (GetSession().GameState.CurrentClientPetCast == null ||
-                GetSession().GameState.CurrentClientPetCast.SpellId != spellId)
+            // Look up pending pet cast by SpellId (queue-based, FIFO order)
+            if (!GetSession().GameState.TryDequeuePendingPetCast(spellId, out var pendingCast))
                 return;
 
-            if (!GetSession().GameState.CurrentClientPetCast.HasStarted)
+            if (!pendingCast.HasStarted)
             {
                 SpellPrepare prepare2 = new SpellPrepare();
-                prepare2.ClientCastID = GetSession().GameState.CurrentClientPetCast.ClientGUID;
-                prepare2.ServerCastID = GetSession().GameState.CurrentClientPetCast.ServerGUID;
+                prepare2.ClientCastID = pendingCast.ClientGUID;
+                prepare2.ServerCastID = pendingCast.ServerGUID;
                 SendPacketToClient(prepare2);
             }
 
@@ -258,7 +235,7 @@ namespace HermesProxy.World.Client
             failed.SpellID = spellId;
             uint reason = packet.ReadUInt8();
             failed.Reason = LegacyVersion.ConvertSpellCastResult(reason);
-            failed.CastID = GetSession().GameState.CurrentClientPetCast.ServerGUID;
+            failed.CastID = pendingCast.ServerGUID;
 
             if (packet.CanRead())
                 failed.FailedArg1 = packet.ReadInt32();
@@ -266,10 +243,6 @@ namespace HermesProxy.World.Client
                 failed.FailedArg2 = packet.ReadInt32();
 
             SendPacketToClient(failed);
-
-            foreach (var pending in GetSession().GameState.PendingClientPetCasts)
-                GetSession().InstanceSocket.SendCastRequestFailed(pending, true);
-            GetSession().GameState.PendingClientPetCasts.Clear();
         }
 
         [PacketHandler(Opcode.SMSG_SPELL_FAILED_OTHER)]
@@ -281,14 +254,6 @@ namespace HermesProxy.World.Client
             else
                 casterUnit = packet.ReadGuid().To128(GetSession().GameState);
 
-            if (casterUnit == GetSession().GameState.CurrentPlayerGuid)
-            {
-                // Artificial lag is needed for spell packets,
-                // or spells will bug out and glow if spammed.
-                if (Settings.ClientSpellDelay > 0)
-                    Thread.Sleep(Settings.ClientSpellDelay);
-            }
-
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
                 packet.ReadUInt8(); // Cast Count
 
@@ -299,19 +264,18 @@ namespace HermesProxy.World.Client
 
             WowGuid128 castId;
             uint spellVisual;
+            // Try to find pending cast info (peek, don't remove - this is informational)
             if (GetSession().GameState.CurrentPlayerGuid == casterUnit &&
-                GetSession().GameState.CurrentClientNormalCast != null &&
-                GetSession().GameState.CurrentClientNormalCast.SpellId == spellId)
+                GetSession().GameState.PendingNormalCasts.ToArray().FirstOrDefault(c => c.SpellId == spellId) is { } pendingNormal)
             {
-                castId = GetSession().GameState.CurrentClientNormalCast.ServerGUID;
-                spellVisual = GetSession().GameState.CurrentClientNormalCast.SpellXSpellVisualId;
+                castId = pendingNormal.ServerGUID;
+                spellVisual = pendingNormal.SpellXSpellVisualId;
             }
             else if (GetSession().GameState.CurrentPetGuid == casterUnit &&
-                     GetSession().GameState.CurrentClientPetCast != null &&
-                     GetSession().GameState.CurrentClientPetCast.SpellId == spellId)
+                     GetSession().GameState.PendingPetCasts.ToArray().FirstOrDefault(c => c.SpellId == spellId) is { } pendingPet)
             {
-                castId = GetSession().GameState.CurrentClientPetCast.ServerGUID;
-                spellVisual = GetSession().GameState.CurrentClientPetCast.SpellXSpellVisualId;
+                castId = pendingPet.ServerGUID;
+                spellVisual = pendingPet.SpellXSpellVisualId;
             }
             else
             {
@@ -345,34 +309,39 @@ namespace HermesProxy.World.Client
             SpellStart spell = new SpellStart();
             spell.Cast = HandleSpellStartOrGo(packet, false);
 
-            byte failPending = 0;
+            // Mark pending cast as started (queue-based, FIFO order)
             if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
-                GetSession().GameState.CurrentClientNormalCast != null &&
-                GetSession().GameState.CurrentClientNormalCast.SpellId == spell.Cast.SpellID)
+                GetSession().GameState.TryMarkPendingNormalCastStarted((uint)spell.Cast.SpellID, out var pendingCast))
             {
-                spell.Cast.CastID = GetSession().GameState.CurrentClientNormalCast.ServerGUID;
-                spell.Cast.SpellXSpellVisualID = GetSession().GameState.CurrentClientNormalCast.SpellXSpellVisualId;
-                GetSession().GameState.CurrentClientNormalCast.HasStarted = true;
+                spell.Cast.CastID = pendingCast.ServerGUID;
+                spell.Cast.SpellXSpellVisualID = pendingCast.SpellXSpellVisualId;
 
                 SpellPrepare prepare = new();
-                prepare.ClientCastID = GetSession().GameState.CurrentClientNormalCast.ClientGUID;
+                prepare.ClientCastID = pendingCast.ClientGUID;
                 prepare.ServerCastID = spell.Cast.CastID;
                 SendPacketToClient(prepare);
-                failPending = 1;
+
+                // Clear non-started casts and send failures for them
+                // (keeps the started cast so SPELL_GO can dequeue it)
+                var failedCasts = GetSession().GameState.ClearNonStartedNormalCasts();
+                foreach (var failed in failedCasts)
+                    GetSession().InstanceSocket.SendCastRequestFailed(failed, false);
             }
             else if (GetSession().GameState.CurrentPetGuid == spell.Cast.CasterUnit &&
-                     GetSession().GameState.CurrentClientPetCast != null &&
-                     GetSession().GameState.CurrentClientPetCast.SpellId == spell.Cast.SpellID)
+                     GetSession().GameState.TryMarkPendingPetCastStarted((uint)spell.Cast.SpellID, out var pendingPetCast))
             {
-                spell.Cast.CastID = GetSession().GameState.CurrentClientPetCast.ServerGUID;
-                spell.Cast.SpellXSpellVisualID = GetSession().GameState.CurrentClientPetCast.SpellXSpellVisualId;
-                GetSession().GameState.CurrentClientPetCast.HasStarted = true;
+                spell.Cast.CastID = pendingPetCast.ServerGUID;
+                spell.Cast.SpellXSpellVisualID = pendingPetCast.SpellXSpellVisualId;
 
                 SpellPrepare prepare = new();
-                prepare.ClientCastID = GetSession().GameState.CurrentClientPetCast.ClientGUID;
+                prepare.ClientCastID = pendingPetCast.ClientGUID;
                 prepare.ServerCastID = spell.Cast.CastID;
                 SendPacketToClient(prepare);
-                failPending = 2;
+
+                // Clear non-started pet casts and send failures for them
+                var failedPetCasts = GetSession().GameState.ClearNonStartedPetCasts();
+                foreach (var failed in failedPetCasts)
+                    GetSession().InstanceSocket.SendCastRequestFailed(failed, true);
             }
 
             if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
@@ -383,19 +352,6 @@ namespace HermesProxy.World.Client
             }
 
             SendPacketToClient(spell);
-
-            if (failPending == 1)
-            {
-                foreach (var pending in GetSession().GameState.PendingClientCasts)
-                    GetSession().InstanceSocket.SendCastRequestFailed(pending, false);
-                GetSession().GameState.PendingClientCasts.Clear();
-            }
-            else if (failPending == 2)
-            {
-                foreach (var pending in GetSession().GameState.PendingClientPetCasts)
-                    GetSession().InstanceSocket.SendCastRequestFailed(pending, true);
-                GetSession().GameState.PendingClientPetCasts.Clear();
-            }
         }
 
         [PacketHandler(Opcode.SMSG_SPELL_GO)]
@@ -406,14 +362,23 @@ namespace HermesProxy.World.Client
 
             SpellGo spell = new SpellGo();
             spell.Cast = HandleSpellStartOrGo(packet, true);
-            if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
-                GetSession().GameState.CurrentClientNormalCast != null &&
-                GetSession().GameState.CurrentClientNormalCast.SpellId == spell.Cast.SpellID)
-            {
-                spell.Cast.CastID = GetSession().GameState.CurrentClientNormalCast.ServerGUID;
-                spell.Cast.SpellXSpellVisualID = GetSession().GameState.CurrentClientNormalCast.SpellXSpellVisualId;
-                GetSession().GameState.CurrentClientNormalCast = null;
 
+            // Dequeue completed cast (queue-based, FIFO order)
+            if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
+                GetSession().GameState.TryDequeuePendingNormalCast((uint)spell.Cast.SpellID, out var pendingCast))
+            {
+                spell.Cast.CastID = pendingCast.ServerGUID;
+                spell.Cast.SpellXSpellVisualID = pendingCast.SpellXSpellVisualId;
+
+                // For instant spells that skip SPELL_START, we need to send SpellPrepare
+                // before SpellGo so the client knows which cast completed
+                if (!pendingCast.HasStarted)
+                {
+                    SpellPrepare prepare = new();
+                    prepare.ClientCastID = pendingCast.ClientGUID;
+                    prepare.ServerCastID = spell.Cast.CastID;
+                    SendPacketToClient(prepare);
+                }
             }
             else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
                 GetSession().GameState.CurrentClientSpecialCast != null &&
@@ -422,22 +387,29 @@ namespace HermesProxy.World.Client
                 spell.Cast.CastID = GetSession().GameState.CurrentClientSpecialCast.ServerGUID;
                 spell.Cast.SpellXSpellVisualID = GetSession().GameState.CurrentClientSpecialCast.SpellXSpellVisualId;
                 GetSession().GameState.CurrentClientSpecialCast = null;
-
             }
             else if (GetSession().GameState.CurrentPetGuid == spell.Cast.CasterUnit &&
-                     GetSession().GameState.CurrentClientPetCast != null &&
-                     GetSession().GameState.CurrentClientPetCast.SpellId == spell.Cast.SpellID)
+                     GetSession().GameState.TryDequeuePendingPetCast((uint)spell.Cast.SpellID, out var pendingPetCast))
             {
-                spell.Cast.CastID = GetSession().GameState.CurrentClientPetCast.ServerGUID;
-                spell.Cast.SpellXSpellVisualID = GetSession().GameState.CurrentClientPetCast.SpellXSpellVisualId;
-                GetSession().GameState.CurrentClientPetCast = null;
+                spell.Cast.CastID = pendingPetCast.ServerGUID;
+                spell.Cast.SpellXSpellVisualID = pendingPetCast.SpellXSpellVisualId;
+
+                // For instant pet spells that skip SPELL_START
+                if (!pendingPetCast.HasStarted)
+                {
+                    SpellPrepare prepare = new();
+                    prepare.ClientCastID = pendingPetCast.ClientGUID;
+                    prepare.ServerCastID = spell.Cast.CastID;
+                    SendPacketToClient(prepare);
+                }
             }
+
             if (!spell.Cast.CasterUnit.IsEmpty() && GameData.AuraSpells.Contains((uint)spell.Cast.SpellID))
             {
                 foreach (WowGuid128 target in spell.Cast.HitTargets)
                     GetSession().GameState.StoreLastAuraCasterOnTarget(target, (uint)spell.Cast.SpellID, spell.Cast.CasterUnit);
             }
-                
+
             SendPacketToClient(spell);
         }
 
@@ -448,13 +420,9 @@ namespace HermesProxy.World.Client
             dbdata.CasterGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
             dbdata.CasterUnit = packet.ReadPackedGuid().To128(GetSession().GameState);
 
-            if (dbdata.CasterUnit == GetSession().GameState.CurrentPlayerGuid)
-            {
-                // Artificial lag is needed for spell packets,
-                // or spells will bug out and glow if spammed.
-                if (Settings.ClientSpellDelay > 0)
-                    Thread.Sleep(Settings.ClientSpellDelay);
-            }
+            // Queue-based spell tracking replaces the need for artificial delay.
+            // The old Thread.Sleep workaround was needed because single-variable tracking
+            // would get overwritten when spamming spells, causing CastID mismatches.
 
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
                 packet.ReadUInt8(); // cast count
@@ -630,10 +598,7 @@ namespace HermesProxy.World.Client
         [PacketHandler(Opcode.SMSG_CANCEL_AUTO_REPEAT)]
         void HandleCancelAutoRepeat(WorldPacket packet)
         {
-            // Artificial lag is needed for spell packets,
-            // or spells will bug out and glow if spammed.
-            if (Settings.ClientSpellDelay > 0)
-                Thread.Sleep(Settings.ClientSpellDelay);
+            // Queue-based spell tracking replaces the need for artificial delay.
 
             if (GetSession().GameState.CurrentClientSpecialCast != null &&
                 GameData.AutoRepeatSpells.Contains(GetSession().GameState.CurrentClientSpecialCast.SpellId))

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -6,7 +6,6 @@ using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
-using System.Threading;
 using Framework.Logging;
 
 namespace HermesProxy.World.Server
@@ -110,20 +109,16 @@ namespace HermesProxy.World.Server
         [PacketHandler(Opcode.CMSG_CAST_SPELL)]
         void HandleCastSpell(CastSpell cast)
         {
-            // Artificial lag is needed for spell packets,
-            // or spells will bug out and glow if spammed.
-            if (Settings.ServerSpellDelay > 0)
-                Thread.Sleep(Settings.ServerSpellDelay);
-
             if (GameData.NextMeleeSpells.Contains(cast.Cast.SpellID) ||
                 GameData.AutoRepeatSpells.Contains(cast.Cast.SpellID))
             {
+                // Special casts (next melee / auto repeat) are exclusive - only one at a time
                 ClientCastRequest castRequest = new ClientCastRequest();
                 castRequest.Timestamp = Environment.TickCount;
                 castRequest.SpellId = cast.Cast.SpellID;
                 castRequest.SpellXSpellVisualId = cast.Cast.SpellXSpellVisualID;
                 castRequest.ClientGUID = cast.Cast.CastID;
-                
+
                 if (GetSession().GameState.CurrentClientSpecialCast != null)
                 {
                     castRequest.ServerGUID = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId, cast.Cast.SpellID, 10000 + cast.Cast.CastID.GetCounter());
@@ -140,10 +135,11 @@ namespace HermesProxy.World.Server
                     SendPacket(prepare);
 
                     GetSession().GameState.CurrentClientSpecialCast = castRequest;
-                } 
+                }
             }
             else
             {
+                // Normal casts - use queue for proper FIFO handling of rapid casts
                 ClientCastRequest castRequest = new ClientCastRequest();
                 castRequest.Timestamp = Environment.TickCount;
                 castRequest.SpellId = cast.Cast.SpellID;
@@ -151,33 +147,8 @@ namespace HermesProxy.World.Server
                 castRequest.ClientGUID = cast.Cast.CastID;
                 castRequest.ServerGUID = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId, cast.Cast.SpellID, 10000 + cast.Cast.CastID.GetCounter());
 
-                if (GetSession().GameState.CurrentClientNormalCast != null)
-                {
-                    if (GetSession().GameState.CurrentClientNormalCast.HasStarted)
-                    {
-                        SendCastRequestFailed(castRequest, false);
-                    }
-                    else
-                    {
-                        // Sometimes we dont clear the CurrentCast when we dont get the correct SMSG_SPELL_GO
-                        if (GetSession().GameState.CurrentClientNormalCast.Timestamp + 10000 < castRequest.Timestamp)
-                        {
-                            Log.Print(LogType.Warn, $"Clearing CurrentClientNormalCast because of 10 sec timeout! (oldSpell:{GetSession().GameState.CurrentClientNormalCast.SpellId} newSpell:{castRequest.SpellId})");
-                            Log.Print(LogType.Warn, "Are you playing on a server with another patch?");
-                            SendCastRequestFailed(GetSession().GameState.CurrentClientNormalCast, false);
-                            GetSession().GameState.CurrentClientNormalCast = null;
-                            foreach (var pending in GetSession().GameState.PendingClientCasts)
-                                SendCastRequestFailed(pending, false);
-                            GetSession().GameState.PendingClientCasts.Clear();
-                            SendCastRequestFailed(castRequest, false);
-                        }
-                        else
-                            GetSession().GameState.PendingClientCasts.Add(castRequest);
-                    }
-                    return;
-                }
-
-                GetSession().GameState.CurrentClientNormalCast = castRequest;
+                // Enqueue the cast - responses will be matched by SpellId in FIFO order
+                GetSession().GameState.PendingNormalCasts.Enqueue(castRequest);
             }
 
             SpellCastTargetFlags targetFlags = ConvertSpellTargetFlags(cast.Cast.Target);
@@ -204,11 +175,7 @@ namespace HermesProxy.World.Server
         [PacketHandler(Opcode.CMSG_PET_CAST_SPELL)]
         void HandlePetCastSpell(PetCastSpell cast)
         {
-            // Artificial lag is needed for spell packets,
-            // or spells will bug out and glow if spammed.
-            if (Settings.ServerSpellDelay > 0)
-                Thread.Sleep(Settings.ServerSpellDelay);
-
+            // Pet casts - use queue for proper FIFO handling
             ClientCastRequest castRequest = new ClientCastRequest();
             castRequest.Timestamp = Environment.TickCount;
             castRequest.SpellId = cast.Cast.SpellID;
@@ -216,32 +183,8 @@ namespace HermesProxy.World.Server
             castRequest.ClientGUID = cast.Cast.CastID;
             castRequest.ServerGUID = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId, cast.Cast.SpellID, 10000 + cast.Cast.CastID.GetCounter());
 
-            if (GetSession().GameState.CurrentClientPetCast != null)
-            {
-                if (GetSession().GameState.CurrentClientPetCast.HasStarted)
-                {
-                    SendCastRequestFailed(castRequest, true);
-                }
-                else
-                {
-                    // Sometimes we dont clear the CurrentCast when we dont get the correct SMSG_SPELL_GO
-                    if (GetSession().GameState.CurrentClientPetCast.Timestamp + 10000 < castRequest.Timestamp)
-                    {
-                        Log.Print(LogType.Warn, $"Clearing CurrentClientPetCast because of 10 sec timeout! (oldSpell:{GetSession().GameState.CurrentClientPetCast.SpellId} newSpell:{castRequest.SpellId})");
-                        SendCastRequestFailed(GetSession().GameState.CurrentClientPetCast, true);
-                        GetSession().GameState.CurrentClientPetCast = null;
-                        foreach (var pending in GetSession().GameState.PendingClientPetCasts)
-                            SendCastRequestFailed(pending, true);
-                        GetSession().GameState.PendingClientPetCasts.Clear();
-                        SendCastRequestFailed(castRequest, true);
-                    }
-                    else
-                        GetSession().GameState.PendingClientPetCasts.Add(castRequest);
-                }
-                return;
-            }
-
-            GetSession().GameState.CurrentClientPetCast = castRequest;
+            // Enqueue the cast - responses will be matched by SpellId in FIFO order
+            GetSession().GameState.PendingPetCasts.Enqueue(castRequest);
 
             SpellCastTargetFlags targetFlags = ConvertSpellTargetFlags(cast.Cast.Target);
 
@@ -258,11 +201,7 @@ namespace HermesProxy.World.Server
         [PacketHandler(Opcode.CMSG_USE_ITEM)]
         void HandleUseItem(UseItem use)
         {
-            // Artificial lag is needed for spell packets,
-            // or spells will bug out and glow if spammed.
-            if (Settings.ServerSpellDelay > 0)
-                Thread.Sleep(Settings.ServerSpellDelay);
-
+            // Item use - use queue for proper FIFO handling
             ClientCastRequest castRequest = new ClientCastRequest();
             castRequest.Timestamp = Environment.TickCount;
             castRequest.SpellId = use.Cast.SpellID;
@@ -271,32 +210,8 @@ namespace HermesProxy.World.Server
             castRequest.ServerGUID = WowGuid128.Create(HighGuidType703.Cast, SpellCastSource.Normal, (uint)GetSession().GameState.CurrentMapId, use.Cast.SpellID, 10000 + use.Cast.CastID.GetCounter());
             castRequest.ItemGUID = use.CastItem;
 
-            if (GetSession().GameState.CurrentClientNormalCast != null)
-            {
-                if (GetSession().GameState.CurrentClientNormalCast.HasStarted)
-                {
-                    SendCastRequestFailed(castRequest, false);
-                }
-                else
-                {
-                    // Sometimes we dont clear the CurrentCast when we dont get the correct SMSG_SPELL_GO
-                    if (GetSession().GameState.CurrentClientNormalCast.Timestamp + 10000 < castRequest.Timestamp)
-                    {
-                        Log.Print(LogType.Warn, $"Clearing CurrentClientNormalCast because of 10 sec timeout! (oldSpell:{GetSession().GameState.CurrentClientNormalCast.SpellId} newSpell:{castRequest.SpellId})");
-                        SendCastRequestFailed(GetSession().GameState.CurrentClientNormalCast, false);
-                        GetSession().GameState.CurrentClientNormalCast = null;
-                        foreach (var pending in GetSession().GameState.PendingClientCasts)
-                            SendCastRequestFailed(pending, false);
-                        GetSession().GameState.PendingClientCasts.Clear();
-                        SendCastRequestFailed(castRequest, false);
-                    }
-                    else
-                        GetSession().GameState.PendingClientCasts.Add(castRequest);
-                }
-                return;
-            }
-
-            GetSession().GameState.CurrentClientNormalCast = castRequest;
+            // Enqueue the cast - responses will be matched by SpellId in FIFO order
+            GetSession().GameState.PendingNormalCasts.Enqueue(castRequest);
 
             WorldPacket packet = new WorldPacket(Opcode.CMSG_USE_ITEM);
             byte containerSlot = use.PackSlot != Enums.Classic.InventorySlots.Bag0 ? ModernVersion.AdjustInventorySlot(use.PackSlot) : use.PackSlot;
@@ -316,11 +231,6 @@ namespace HermesProxy.World.Server
         [PacketHandler(Opcode.CMSG_CANCEL_CAST)]
         void HandleCancelCast(CancelCast cast)
         {
-            // Artificial lag is needed for spell packets,
-            // or spells will bug out and glow if spammed.
-            if (Settings.ServerSpellDelay > 0)
-                Thread.Sleep(Settings.ServerSpellDelay);
-
             WorldPacket packet = new WorldPacket(Opcode.CMSG_CANCEL_CAST);
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
                 packet.WriteUInt8(0);
@@ -330,11 +240,6 @@ namespace HermesProxy.World.Server
         [PacketHandler(Opcode.CMSG_CANCEL_CHANNELLING)]
         void HandleCancelChannelling(CancelChannelling cast)
         {
-            // Artificial lag is needed for spell packets,
-            // or spells will bug out and glow if spammed.
-            if (Settings.ServerSpellDelay > 0)
-                Thread.Sleep(Settings.ServerSpellDelay);
-
             WorldPacket packet = new WorldPacket(Opcode.CMSG_CANCEL_CHANNELLING);
             packet.WriteInt32(cast.SpellID);
             SendPacketToServer(packet);
@@ -342,11 +247,6 @@ namespace HermesProxy.World.Server
         [PacketHandler(Opcode.CMSG_CANCEL_AUTO_REPEAT_SPELL)]
         void HandleCancelAutoRepeatSpell(CancelAutoRepeatSpell spell)
         {
-            // Artificial lag is needed for spell packets,
-            // or spells will bug out and glow if spammed.
-            if (Settings.ServerSpellDelay > 0)
-                Thread.Sleep(Settings.ServerSpellDelay);
-
             WorldPacket packet = new WorldPacket(Opcode.CMSG_CANCEL_AUTO_REPEAT_SPELL);
             SendPacketToServer(packet);
         }


### PR DESCRIPTION
- Fix stuck spell animations when spamming spells (GitHub Issue https://github.com/WowLegacyCore/HermesProxy/issues/104)
- Replace single-variable spell tracking with ConcurrentQueue<ClientCastRequest>
- Add helper methods for FIFO spell cast management
- Send SpellPrepare for instant spells that skip SPELL_START
- Remove `ServerSpellDelay` and `ClientSpellDelay` config options.
   - **These settings could have introduced significant delays.**

The root cause was single-variable tracking getting overwritten during spell spam, causing CastID mismatches. Queue-based approach properly handles rapid spell casts using TCP packet ordering guarantees.

---

I've managed encounter similar issue by 
* Use Warrior Charge
* While the warrior is rushing towards the target Press Tab to switch target
* Most of the time the warrior auto attack was stuck, and never started attacking the initial target.
* The workaround was to deselect the target and reselect it.

With the current change i was unable reproduce the mentioned issue above.

---

Should fix: https://github.com/WowLegacyCore/HermesProxy/issues/265
Should fix: https://github.com/WowLegacyCore/HermesProxy/pull/311
Should fix: https://github.com/WowLegacyCore/HermesProxy/issues/347