### PR TITLE
Fix npc movement zig-zag at tile boundaries

### DIFF
--- a/Framework/IO/ByteBuffer.cs
+++ b/Framework/IO/ByteBuffer.cs
@@ -426,10 +426,12 @@ namespace Framework.IO
 
         public void WritePackXYZ(Vector3 pos)
         {
+            // Cast to int first to preserve negative values (two's complement),
+            // then mask to extract the correct number of bits
             uint packed = 0;
-            packed |= ((uint)(pos.X / 0.25f) & 0x7FF);
-            packed |= ((uint)(pos.Y / 0.25f) & 0x7FF) << 11;
-            packed |= ((uint)(pos.Z / 0.25f) & 0x3FF) << 22;
+            packed |= (uint)((int)(pos.X / 0.25f)) & 0x7FF;
+            packed |= ((uint)((int)(pos.Y / 0.25f)) & 0x7FF) << 11;
+            packed |= ((uint)((int)(pos.Z / 0.25f)) & 0x3FF) << 22;
             WriteUInt32(packed);
         }
 


### PR DESCRIPTION
`WritePackXYZ` was casting negative floats directly to uint, which is undefined behavior and produces garbage values. This caused spline waypoint deltas to be corrupted when they were negative (i.e., when waypoints were between the midpoint and destination).

Fix: Cast to int first to preserve negative values via two's complement, then mask the bits for packing.