### PR TITLE
Added metrics collection to measure opcode processing latency

### DIFF
--- a/Framework/Framework.csproj
+++ b/Framework/Framework.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="HermesProxy.Benchmarks" />
+    <InternalsVisibleTo Include="HermesProxy.Tests" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Framework/Metrics/ProxyMetrics.cs
+++ b/Framework/Metrics/ProxyMetrics.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Framework.Metrics
+{
+    /// <summary>
+    /// Thread-safe metrics collector for measuring proxy-introduced latency per opcode.
+    /// Tracks min, max, average, and percentiles (p50, p95, p99) for packet processing times.
+    /// </summary>
+    public class ProxyMetrics
+    {
+        private const int MaxSamplesPerOpcode = 1000;
+
+        // Conversion factor from ticks to milliseconds (cached for performance)
+        private static readonly double TicksToMs = 1000.0 / Stopwatch.Frequency;
+
+        // Per-opcode latency samples (circular buffer)
+        private readonly ConcurrentDictionary<int, LatencySamples> _clientToServerLatency = new();
+        private readonly ConcurrentDictionary<int, LatencySamples> _serverToClientLatency = new();
+
+        private readonly DateTime _startTime = DateTime.UtcNow;
+
+        /// <summary>
+        /// Record latency for a packet processed from modern client and forwarded to legacy server.
+        /// </summary>
+        /// <param name="opcode">The universal opcode</param>
+        /// <param name="elapsedTicks">Elapsed ticks from Stopwatch.GetTimestamp()</param>
+        public void RecordClientToServerLatency(Enum opcode, long elapsedTicks)
+        {
+            RecordClientToServerLatency(Convert.ToInt32(opcode), elapsedTicks * TicksToMs);
+        }
+
+        /// <summary>
+        /// Record latency for a packet processed from legacy server and forwarded to modern client.
+        /// </summary>
+        /// <param name="opcode">The universal opcode</param>
+        /// <param name="elapsedTicks">Elapsed ticks from Stopwatch.GetTimestamp()</param>
+        public void RecordServerToClientLatency(Enum opcode, long elapsedTicks)
+        {
+            RecordServerToClientLatency(Convert.ToInt32(opcode), elapsedTicks * TicksToMs);
+        }
+
+        /// <summary>
+        /// Record latency in milliseconds for a packet processed from modern client.
+        /// Internal overload for testing and direct ms values.
+        /// </summary>
+        internal void RecordClientToServerLatency(int opcode, double milliseconds)
+        {
+            var samples = _clientToServerLatency.GetOrAdd(opcode, _ => new LatencySamples(MaxSamplesPerOpcode));
+            samples.Add(milliseconds);
+        }
+
+        /// <summary>
+        /// Record latency in milliseconds for a packet processed from legacy server.
+        /// Internal overload for testing and direct ms values.
+        /// </summary>
+        internal void RecordServerToClientLatency(int opcode, double milliseconds)
+        {
+            var samples = _serverToClientLatency.GetOrAdd(opcode, _ => new LatencySamples(MaxSamplesPerOpcode));
+            samples.Add(milliseconds);
+        }
+
+        /// <summary>
+        /// Get latency statistics for client-to-server packets by opcode.
+        /// </summary>
+        public Dictionary<int, LatencyStats> GetClientToServerStats()
+        {
+            return _clientToServerLatency.ToDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Value.GetStats()
+            );
+        }
+
+        /// <summary>
+        /// Get latency statistics for server-to-client packets by opcode.
+        /// </summary>
+        public Dictionary<int, LatencyStats> GetServerToClientStats()
+        {
+            return _serverToClientLatency.ToDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Value.GetStats()
+            );
+        }
+
+        /// <summary>
+        /// Get latency stats for a specific client-to-server opcode.
+        /// </summary>
+        public LatencyStats? GetClientToServerStats(int opcode)
+        {
+            return _clientToServerLatency.TryGetValue(opcode, out var samples) ? samples.GetStats() : null;
+        }
+
+        /// <summary>
+        /// Get latency stats for a specific server-to-client opcode.
+        /// </summary>
+        public LatencyStats? GetServerToClientStats(int opcode)
+        {
+            return _serverToClientLatency.TryGetValue(opcode, out var samples) ? samples.GetStats() : null;
+        }
+
+        public TimeSpan Uptime => DateTime.UtcNow - _startTime;
+
+        public int ClientToServerOpcodeCount => _clientToServerLatency.Count;
+        public int ServerToClientOpcodeCount => _serverToClientLatency.Count;
+
+        /// <summary>
+        /// Reset all metrics.
+        /// </summary>
+        public void Reset()
+        {
+            _clientToServerLatency.Clear();
+            _serverToClientLatency.Clear();
+        }
+
+        /// <summary>
+        /// Get a formatted summary of the top N slowest opcodes.
+        /// </summary>
+        /// <param name="topN">Number of top opcodes to show</param>
+        /// <param name="opcodeResolver">Optional function to resolve opcode int to human-readable name</param>
+        public string GetSummary(int topN = 10, Func<int, string>? opcodeResolver = null)
+        {
+            opcodeResolver ??= (opcode => $"0x{opcode:X4}");
+
+            var c2sStats = GetClientToServerStats()
+                .OrderByDescending(x => x.Value.P99)
+                .Take(topN)
+                .ToList();
+
+            var s2cStats = GetServerToClientStats()
+                .OrderByDescending(x => x.Value.P99)
+                .Take(topN)
+                .ToList();
+
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine($"Proxy Latency Metrics (Uptime: {Uptime:hh\\:mm\\:ss})");
+            sb.AppendLine();
+
+            if (c2sStats.Count > 0)
+            {
+                sb.AppendLine("Client -> Server (top by p99):");
+                sb.AppendLine($"  {"Opcode",-40} {"Count",8} {"Min",9} {"Avg",9} {"P50",9} {"P95",9} {"P99",9} {"Max",9}");
+                sb.AppendLine($"  {new string('-', 40)} {new string('-', 8)} {new string('-', 9)} {new string('-', 9)} {new string('-', 9)} {new string('-', 9)} {new string('-', 9)} {new string('-', 9)}");
+                foreach (var (opcode, stats) in c2sStats)
+                {
+                    string opcodeName = opcodeResolver(opcode);
+                    if (opcodeName.Length > 40) opcodeName = opcodeName[..37] + "...";
+                    sb.AppendLine($"  {opcodeName,-40} {stats.Count,8} {stats.Min,8:F3}ms {stats.Average,8:F3}ms {stats.P50,8:F3}ms {stats.P95,8:F3}ms {stats.P99,8:F3}ms {stats.Max,8:F3}ms");
+                }
+                sb.AppendLine();
+            }
+
+            if (s2cStats.Count > 0)
+            {
+                sb.AppendLine("Server -> Client (top by p99):");
+                sb.AppendLine($"  {"Opcode",-40} {"Count",8} {"Min",9} {"Avg",9} {"P50",9} {"P95",9} {"P99",9} {"Max",9}");
+                sb.AppendLine($"  {new string('-', 40)} {new string('-', 8)} {new string('-', 9)} {new string('-', 9)} {new string('-', 9)} {new string('-', 9)} {new string('-', 9)} {new string('-', 9)}");
+                foreach (var (opcode, stats) in s2cStats)
+                {
+                    string opcodeName = opcodeResolver(opcode);
+                    if (opcodeName.Length > 40) opcodeName = opcodeName[..37] + "...";
+                    sb.AppendLine($"  {opcodeName,-40} {stats.Count,8} {stats.Min,8:F3}ms {stats.Average,8:F3}ms {stats.P50,8:F3}ms {stats.P95,8:F3}ms {stats.P99,8:F3}ms {stats.Max,8:F3}ms");
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Thread-safe circular buffer for latency samples.
+    /// </summary>
+    public class LatencySamples
+    {
+        private readonly double[] _samples;
+        private readonly object _lock = new();
+        private int _count;
+        private int _index;
+        private double _sum;
+        private double _min = double.MaxValue;
+        private double _max = double.MinValue;
+
+        public LatencySamples(int maxSamples)
+        {
+            _samples = new double[maxSamples];
+        }
+
+        public void Add(double milliseconds)
+        {
+            lock (_lock)
+            {
+                // Update running stats
+                if (_count < _samples.Length)
+                {
+                    _sum += milliseconds;
+                    _count++;
+                }
+                else
+                {
+                    // Remove old value from sum when overwriting
+                    _sum -= _samples[_index];
+                    _sum += milliseconds;
+                }
+
+                _samples[_index] = milliseconds;
+                _index = (_index + 1) % _samples.Length;
+
+                if (milliseconds < _min) _min = milliseconds;
+                if (milliseconds > _max) _max = milliseconds;
+            }
+        }
+
+        public LatencyStats GetStats()
+        {
+            lock (_lock)
+            {
+                if (_count == 0)
+                {
+                    return new LatencyStats();
+                }
+
+                // Copy samples for percentile calculation
+                var samplesCopy = new double[_count];
+                Array.Copy(_samples, samplesCopy, _count);
+                Array.Sort(samplesCopy);
+
+                return new LatencyStats
+                {
+                    Count = _count,
+                    Min = _min,
+                    Max = _max,
+                    Average = _sum / _count,
+                    P50 = GetPercentile(samplesCopy, 0.50),
+                    P95 = GetPercentile(samplesCopy, 0.95),
+                    P99 = GetPercentile(samplesCopy, 0.99)
+                };
+            }
+        }
+
+        private static double GetPercentile(double[] sortedSamples, double percentile)
+        {
+            if (sortedSamples.Length == 0) return 0;
+            if (sortedSamples.Length == 1) return sortedSamples[0];
+
+            double index = percentile * (sortedSamples.Length - 1);
+            int lower = (int)Math.Floor(index);
+            int upper = (int)Math.Ceiling(index);
+
+            if (lower == upper) return sortedSamples[lower];
+
+            // Linear interpolation
+            double fraction = index - lower;
+            return sortedSamples[lower] + (sortedSamples[upper] - sortedSamples[lower]) * fraction;
+        }
+    }
+
+    /// <summary>
+    /// Latency statistics for a single opcode.
+    /// </summary>
+    public struct LatencyStats
+    {
+        public int Count;
+        public double Min;
+        public double Max;
+        public double Average;
+        public double P50;
+        public double P95;
+        public double P99;
+
+        public override string ToString()
+        {
+            return $"Count={Count}, Min={Min:F3}ms, Avg={Average:F3}ms, P50={P50:F3}ms, P95={P95:F3}ms, P99={P99:F3}ms, Max={Max:F3}ms";
+        }
+    }
+}

--- a/HermesProxy.Tests/Framework/ProxyMetricsTests.cs
+++ b/HermesProxy.Tests/Framework/ProxyMetricsTests.cs
@@ -1,0 +1,162 @@
+using Framework.Metrics;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HermesProxy.Tests.Framework
+{
+    public class ProxyMetricsTests
+    {
+        [Fact]
+        public void RecordClientToServerLatency_TracksLatency()
+        {
+            var metrics = new ProxyMetrics();
+
+            metrics.RecordClientToServerLatency(0x1234, 1.5);
+            metrics.RecordClientToServerLatency(0x1234, 2.5);
+            metrics.RecordClientToServerLatency(0x1234, 3.5);
+
+            var stats = metrics.GetClientToServerStats(0x1234);
+            Assert.NotNull(stats);
+            Assert.Equal(3, stats.Value.Count);
+            Assert.Equal(1.5, stats.Value.Min);
+            Assert.Equal(3.5, stats.Value.Max);
+            Assert.Equal(2.5, stats.Value.Average, 2);
+        }
+
+        [Fact]
+        public void RecordServerToClientLatency_TracksLatency()
+        {
+            var metrics = new ProxyMetrics();
+
+            metrics.RecordServerToClientLatency(0x5678, 10.0);
+            metrics.RecordServerToClientLatency(0x5678, 20.0);
+
+            var stats = metrics.GetServerToClientStats(0x5678);
+            Assert.NotNull(stats);
+            Assert.Equal(2, stats.Value.Count);
+            Assert.Equal(10.0, stats.Value.Min);
+            Assert.Equal(20.0, stats.Value.Max);
+            Assert.Equal(15.0, stats.Value.Average, 2);
+        }
+
+        [Fact]
+        public void GetStats_ReturnsNullForUnknownOpcode()
+        {
+            var metrics = new ProxyMetrics();
+
+            var stats = metrics.GetClientToServerStats(0x9999);
+            Assert.Null(stats);
+        }
+
+        [Fact]
+        public void Percentiles_CalculatedCorrectly()
+        {
+            var metrics = new ProxyMetrics();
+
+            // Add 100 samples: 1, 2, 3, ..., 100
+            for (int i = 1; i <= 100; i++)
+            {
+                metrics.RecordClientToServerLatency(0x1234, i);
+            }
+
+            var stats = metrics.GetClientToServerStats(0x1234);
+            Assert.NotNull(stats);
+            Assert.Equal(100, stats.Value.Count);
+            Assert.Equal(1.0, stats.Value.Min);
+            Assert.Equal(100.0, stats.Value.Max);
+            Assert.Equal(50.5, stats.Value.Average, 2);
+            Assert.Equal(50.5, stats.Value.P50, 1); // Median
+            Assert.Equal(95.05, stats.Value.P95, 1); // 95th percentile
+            Assert.Equal(99.01, stats.Value.P99, 1); // 99th percentile
+        }
+
+        [Fact]
+        public void CircularBuffer_OverwritesOldSamples()
+        {
+            var samples = new LatencySamples(5);
+
+            // Add 10 samples, only last 5 should be kept
+            for (int i = 1; i <= 10; i++)
+            {
+                samples.Add(i);
+            }
+
+            var stats = samples.GetStats();
+            Assert.Equal(5, stats.Count);
+            // Average of 6, 7, 8, 9, 10 = 8
+            Assert.Equal(8.0, stats.Average, 2);
+        }
+
+        [Fact]
+        public void Reset_ClearsAllMetrics()
+        {
+            var metrics = new ProxyMetrics();
+
+            metrics.RecordClientToServerLatency(0x1234, 1.0);
+            metrics.RecordServerToClientLatency(0x5678, 2.0);
+
+            metrics.Reset();
+
+            Assert.Equal(0, metrics.ClientToServerOpcodeCount);
+            Assert.Equal(0, metrics.ServerToClientOpcodeCount);
+        }
+
+        [Fact]
+        public void ThreadSafety_ConcurrentRecording()
+        {
+            var metrics = new ProxyMetrics();
+            const int iterations = 10000;
+
+            Parallel.For(0, iterations, i =>
+            {
+                metrics.RecordClientToServerLatency(0x1234, i * 0.001);
+                metrics.RecordServerToClientLatency(0x5678, i * 0.001);
+            });
+
+            var c2sStats = metrics.GetClientToServerStats(0x1234);
+            var s2cStats = metrics.GetServerToClientStats(0x5678);
+
+            Assert.NotNull(c2sStats);
+            Assert.NotNull(s2cStats);
+            // Should have samples (may be less than iterations due to circular buffer)
+            Assert.True(c2sStats.Value.Count > 0);
+            Assert.True(s2cStats.Value.Count > 0);
+        }
+
+        [Fact]
+        public void GetSummary_ReturnsFormattedString()
+        {
+            var metrics = new ProxyMetrics();
+
+            metrics.RecordClientToServerLatency(0x1234, 1.5);
+            metrics.RecordServerToClientLatency(0x5678, 2.5);
+
+            var summary = metrics.GetSummary();
+
+            Assert.Contains("Client -> Server", summary);
+            Assert.Contains("Server -> Client", summary);
+            Assert.Contains("0x1234", summary);
+            Assert.Contains("0x5678", summary);
+        }
+
+        [Fact]
+        public void MultipleOpcodes_TrackedSeparately()
+        {
+            var metrics = new ProxyMetrics();
+
+            metrics.RecordClientToServerLatency(0x0001, 1.0);
+            metrics.RecordClientToServerLatency(0x0002, 2.0);
+            metrics.RecordClientToServerLatency(0x0003, 3.0);
+
+            Assert.Equal(3, metrics.ClientToServerOpcodeCount);
+
+            var stats1 = metrics.GetClientToServerStats(0x0001);
+            var stats2 = metrics.GetClientToServerStats(0x0002);
+            var stats3 = metrics.GetClientToServerStats(0x0003);
+
+            Assert.Equal(1.0, stats1?.Average);
+            Assert.Equal(2.0, stats2?.Average);
+            Assert.Equal(3.0, stats3?.Average);
+        }
+    }
+}

--- a/HermesProxy/Program.cs
+++ b/HermesProxy/Program.cs
@@ -23,6 +23,7 @@ public class Program
             CommandLineArgumentsTemplate.ConfigFileLocation,
             CommandLineArgumentsTemplate.DisableVersionCheck,
             CommandLineArgumentsTemplate.OverwrittenConfigValues,
+            CommandLineArgumentsTemplate.EnableMetrics,
         };
 
         var parser = new CommandLineBuilder(commandTree)
@@ -37,6 +38,7 @@ public class Program
                 ConfigFileLocation = result.GetValueForOption(CommandLineArgumentsTemplate.ConfigFileLocation),
                 DisableVersionCheck = result.GetValueForOption(CommandLineArgumentsTemplate.DisableVersionCheck),
                 OverwrittenConfigValues = ParseMultiArgument(result.GetValueForOption(CommandLineArgumentsTemplate.OverwrittenConfigValues)),
+                EnableMetrics = result.GetValueForOption(CommandLineArgumentsTemplate.EnableMetrics),
             };
             Server.ServerMain(commandLineArguments);
         });
@@ -108,6 +110,10 @@ public class Program
             name: "--set",
             description: "Overwrites a specific config value. Example: --set ServerAddress=logon.example.com"
             );
+        public static readonly Option<bool> EnableMetrics = new(
+            name: "--metrics",
+            description: "Enables per-opcode latency metrics collection"
+            );
     }
 }
 
@@ -116,6 +122,7 @@ public class CommandLineArguments
     public string? ConfigFileLocation { init; get; }
     public bool DisableVersionCheck { init; get; }
     public Dictionary<string, string> OverwrittenConfigValues { init; get; }
+    public bool EnableMetrics { init; get; }
 }
 
 internal static class OsSpecific

--- a/HermesProxy/Server.cs
+++ b/HermesProxy/Server.cs
@@ -1,5 +1,6 @@
 ﻿using BNetServer.Networking;
 using Framework.Logging;
+using Framework.Metrics;
 using Framework.Networking;
 using HermesProxy.World;
 using HermesProxy.World.Server;
@@ -18,11 +19,23 @@ using System.Threading.Tasks;
 using BNetServer;
 using Framework;
 using HermesProxy.Configuration;
+using HermesProxy.World.Enums;
 
 namespace HermesProxy
 {
     partial class Server
     {
+        /// <summary>
+        /// Global metrics collector for packet statistics.
+        /// Only active when --metrics command line argument is passed.
+        /// </summary>
+        public static readonly ProxyMetrics Metrics = new();
+
+        /// <summary>
+        /// Whether metrics collection is enabled via --metrics argument.
+        /// </summary>
+        public static bool MetricsEnabled { get; private set; }
+
         public static void ServerMain(CommandLineArguments args)
         {
 #if !DEBUG
@@ -34,8 +47,12 @@ namespace HermesProxy
             catch { /* ignore */ }
 #endif
 
+            MetricsEnabled = args.EnableMetrics;
+
             Log.Print(LogType.Server, "Starting Hermes Proxy...");
             Log.Print(LogType.Server, $"Version {GetVersionInformation()}");
+            if (MetricsEnabled)
+                Log.Print(LogType.Server, "Latency metrics collection enabled");
             Log.Start();
 
             if (Environment.CurrentDirectory != Path.GetDirectoryName(AppContext.BaseDirectory))
@@ -102,9 +119,34 @@ namespace HermesProxy
             // 4. Start the listener for world connections
             var worldSocketServer = StartServer<WorldSocket>(new IPEndPoint(bindIp, Settings.InstancePort));
 
+            int metricsLogCounter = 0;
+            const int metricsLogIntervalSeconds = 60;
+            const int loopIntervalSeconds = 10;
+            const int displayMetricCount = 20;
+
             while (restSocketServer.IsListening || bnetSocketServer.IsListening || realmSocketServer.IsListening || worldSocketServer.IsListening)
             {
-                Thread.Sleep(TimeSpan.FromSeconds(10));
+                Thread.Sleep(TimeSpan.FromSeconds(loopIntervalSeconds));
+
+                // Log metrics periodically (every 60 seconds) when enabled
+                if (MetricsEnabled)
+                {
+                    metricsLogCounter += loopIntervalSeconds;
+                    if (metricsLogCounter >= metricsLogIntervalSeconds)
+                    {
+                        metricsLogCounter = 0;
+                        if (Metrics.ClientToServerOpcodeCount > 0 || Metrics.ServerToClientOpcodeCount > 0)
+                        {
+                            Log.Print(LogType.Server, $"Latency Metrics: {Metrics.ClientToServerOpcodeCount} C->S opcodes, {Metrics.ServerToClientOpcodeCount} S->C opcodes tracked");
+
+                            foreach (var line in Metrics.GetSummary(displayMetricCount, ResolveOpcodeName).Split('\n'))
+                            {
+                                if (!string.IsNullOrWhiteSpace(line))
+                                    Log.Print(LogType.Server, line);
+                            }
+                        }
+                    }
+                }
             }
 
             Console.WriteLine($"(restSocketServer.IsListening: {restSocketServer.IsListening}");
@@ -168,6 +210,13 @@ namespace HermesProxy
             {
                 // ignore
             }
+        }
+
+        private static string ResolveOpcodeName(int opcode)
+        {
+            if (Enum.IsDefined(typeof(Opcode), (uint)opcode))
+                return ((Opcode)opcode).ToString();
+            return $"0x{opcode:X4}";
         }
 
         private static readonly string? _buildTag;

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using Framework.Networking;
 using HermesProxy.World.Server;
 using System.Collections.Frozen;
+using System.Diagnostics;
 
 namespace HermesProxy.World.Client
 {
@@ -390,6 +391,8 @@ namespace HermesProxy.World.Client
             Opcode universalOpcode = packet.GetUniversalOpcode(false);
             Log.PrintNet(LogType.Debug, LogNetDir.S2P, $"Received opcode {universalOpcode} ({packet.GetOpcode()}).");
 
+            long startTimestamp = HermesProxy.Server.MetricsEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
+
             switch (universalOpcode)
             {
                 case Opcode.SMSG_AUTH_CHALLENGE:
@@ -412,6 +415,11 @@ namespace HermesProxy.World.Client
                             _isSuccessful = false;
                     }
                     break;
+            }
+
+            if (HermesProxy.Server.MetricsEnabled)
+            {
+                HermesProxy.Server.Metrics.RecordServerToClientLatency(universalOpcode, Stopwatch.GetElapsedTime(startTimestamp).Ticks);
             }
 
             SendDelayedPacketsToServerOnOpcode(universalOpcode);

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -16,6 +16,7 @@
  */
 
 using System;
+using System.Diagnostics;
 using System.Net.Sockets;
 using System.Collections.Generic;
 using System.Reflection;
@@ -24,8 +25,8 @@ using System.Collections.Concurrent;
 using Framework.Constants;
 using Framework.Cryptography;
 using Framework.IO;
-using Framework.Networking;
 using Framework.Logging;
+using Framework.Networking;
 using Framework.Realm;
 
 using HermesProxy.World.Enums;
@@ -325,7 +326,18 @@ namespace HermesProxy.World.Server
             Opcode universalOpcode = packet.GetUniversalOpcode(isModern: true);
             var handler = GetHandler(universalOpcode);
             if (handler != null)
-                handler.Invoke(this, packet);
+            {
+                if (HermesProxy.Server.MetricsEnabled)
+                {
+                    long startTimestamp = Stopwatch.GetTimestamp();
+                    handler.Invoke(this, packet);
+                    HermesProxy.Server.Metrics.RecordClientToServerLatency(universalOpcode, Stopwatch.GetElapsedTime(startTimestamp).Ticks);
+                }
+                else
+                {
+                    handler.Invoke(this, packet);
+                }
+            }
             else
                 Log.PrintNet(LogType.Warn, LogNetDir.C2P, $"No handler for opcode {universalOpcode} ({packet.GetOpcode()}) (Got unknown packet from ModernClient)");
         }


### PR DESCRIPTION
When `--metrics` command line argument is passed, every minute dumps the following statistics about the processing latency of a given opcode.

This is from the `feature/dotnet10` branch
```
07:32:40 |  Server  | Server          | Latency Metrics: 57 C->S opcodes, 66 S->C opcodes tracked
07:32:40 |  Server  | Server          | Proxy Latency Metrics (Uptime: 00:08:02)
07:32:40 |  Server  | Server          | Client -> Server (top by p99):
07:32:40 |  Server  | Server          |   Opcode                                      Count       Min       Avg       P50       P95       P99       Max
07:32:40 |  Server  | Server          |   ---------------------------------------- -------- --------- --------- --------- --------- --------- ---------
07:32:40 |  Server  | Server          |   CMSG_PLAYER_LOGIN                               1   81.455ms   81.455ms   81.455ms   81.455ms   81.455ms   81.455ms
07:32:40 |  Server  | Server          |   CMSG_HOTFIX_REQUEST                             1   24.686ms   24.686ms   24.686ms   24.686ms   24.686ms   24.686ms
07:32:40 |  Server  | Server          |   CMSG_QUERY_PLAYER_NAME                          1    3.309ms    3.309ms    3.309ms    3.309ms    3.309ms    3.309ms
07:32:40 |  Server  | Server          |   CMSG_DB_QUERY_BULK                              2    1.168ms    1.844ms    1.844ms    2.453ms    2.507ms    2.520ms
07:32:40 |  Server  | Server          |   CMSG_CAST_SPELL                                67    0.048ms    0.135ms    0.075ms    0.221ms    1.374ms    3.235ms
07:32:40 |  Server  | Server          |   CMSG_REQUEST_LFG_LIST_BLACKLIST                 2    0.036ms    0.692ms    0.692ms    1.283ms    1.335ms    1.348ms
07:32:40 |  Server  | Server          |   CMSG_ARENA_TEAM_ROSTER                          6    0.013ms    0.291ms    0.050ms    1.070ms    1.279ms    1.331ms
07:32:40 |  Server  | Server          |   CMSG_QUEST_GIVER_STATUS_MULTIPLE_QUERY          5    0.028ms    0.277ms    0.058ms    0.945ms    1.117ms    1.160ms
07:32:40 |  Server  | Server          |   CMSG_ENUM_CHARACTERS                            1    1.038ms    1.038ms    1.038ms    1.038ms    1.038ms    1.038ms
07:32:40 |  Server  | Server          |   CMSG_BATTLENET_REQUEST                          1    0.974ms    0.974ms    0.974ms    0.974ms    0.974ms    0.974ms
07:32:40 |  Server  | Server          |   CMSG_LOOT_ITEM                                 22    0.006ms    0.114ms    0.047ms    0.280ms    0.966ms    1.147ms
07:32:40 |  Server  | Server          |   CMSG_GET_ACCOUNT_CHARACTER_LIST                 1    0.956ms    0.956ms    0.956ms    0.956ms    0.956ms    0.956ms
07:32:40 |  Server  | Server          |   CMSG_UPDATE_ACCOUNT_DATA                        1    0.915ms    0.915ms    0.915ms    0.915ms    0.915ms    0.915ms
07:32:40 |  Server  | Server          |   CMSG_REQUEST_ACCOUNT_DATA                       3    0.046ms    0.354ms    0.254ms    0.710ms    0.751ms    0.761ms
07:32:40 |  Server  | Server          |   CMSG_MOVE_SET_FACING                           91    0.036ms    0.093ms    0.053ms    0.228ms    0.612ms    1.771ms
07:32:40 |  Server  | Server          |   CMSG_LOOT_UNIT                                 19    0.040ms    0.140ms    0.058ms    0.322ms    0.497ms    0.541ms
07:32:40 |  Server  | Server          |   CMSG_SET_SELECTION                            114    0.007ms    0.055ms    0.041ms    0.077ms    0.485ms    0.960ms
07:32:40 |  Server  | Server          |   CMSG_ATTACK_STOP                               73    0.004ms    0.082ms    0.041ms    0.275ms    0.476ms    0.577ms
07:32:40 |  Server  | Server          |   CMSG_MOVE_START_FORWARD                       132    0.005ms    0.053ms    0.039ms    0.078ms    0.453ms    1.279ms
07:32:40 |  Server  | Server          |   CMSG_PARTY_INVITE_RESPONSE                      1    0.450ms    0.450ms    0.450ms    0.450ms    0.450ms    0.450ms
07:32:40 |  Server  | Server          | Server -> Client (top by p99):
07:32:40 |  Server  | Server          |   Opcode                                      Count       Min       Avg       P50       P95       P99       Max
07:32:40 |  Server  | Server          |   ---------------------------------------- -------- --------- --------- --------- --------- --------- ---------
07:32:40 |  Server  | Server          |   SMSG_ENUM_CHARACTERS_RESULT                     1   14.291ms   14.291ms   14.291ms   14.291ms   14.291ms   14.291ms
07:32:40 |  Server  | Server          |   SMSG_ITEM_QUERY_SINGLE_RESPONSE                34    0.153ms    1.129ms    0.265ms    4.987ms   11.777ms   12.097ms
07:32:40 |  Server  | Server          |   SMSG_COMPRESSED_UPDATE_OBJECT                 447    0.099ms    0.665ms    0.180ms    0.707ms    4.275ms  102.788ms
07:32:40 |  Server  | Server          |   SMSG_INIT_WORLD_STATES                          1    4.229ms    4.229ms    4.229ms    4.229ms    4.229ms    4.229ms
07:32:40 |  Server  | Server          |   SMSG_ACCOUNT_DATA_TIMES                         1    3.503ms    3.503ms    3.503ms    3.503ms    3.503ms    3.503ms
07:32:40 |  Server  | Server          |   SMSG_SPELL_START                               68    0.044ms    0.200ms    0.097ms    0.191ms    2.845ms    5.905ms
07:32:40 |  Server  | Server          |   SMSG_LOOT_RESPONSE                             19    0.060ms    0.262ms    0.091ms    0.457ms    2.693ms    3.252ms
07:32:40 |  Server  | Server          |   SMSG_AUTH_CHALLENGE                             1    2.533ms    2.533ms    2.533ms    2.533ms    2.533ms    2.533ms
07:32:40 |  Server  | Server          |   SMSG_CHAT                                       3    0.069ms    0.825ms    0.290ms    1.933ms    2.079ms    2.115ms
07:32:40 |  Server  | Server          |   SMSG_SPELL_PERIODIC_AURA_LOG                   22    0.030ms    0.170ms    0.060ms    0.087ms    1.938ms    2.430ms
07:32:40 |  Server  | Server          |   SMSG_QUERY_PLAYER_NAME_RESPONSE                 1    1.809ms    1.809ms    1.809ms    1.809ms    1.809ms    1.809ms
07:32:40 |  Server  | Server          |   SMSG_SPELL_GO                                  85    0.017ms    0.158ms    0.067ms    0.110ms    1.760ms    7.267ms
07:32:40 |  Server  | Server          |   SMSG_LOGIN_VERIFY_WORLD                         1    1.638ms    1.638ms    1.638ms    1.638ms    1.638ms    1.638ms
07:32:40 |  Server  | Server          |   SMSG_SET_FLAT_SPELL_MODIFIER                    1    1.470ms    1.470ms    1.470ms    1.470ms    1.470ms    1.470ms
07:32:40 |  Server  | Server          |   SMSG_SEND_KNOWN_SPELLS                          1    1.238ms    1.238ms    1.238ms    1.238ms    1.238ms    1.238ms
07:32:40 |  Server  | Server          |   SMSG_CHANNEL_NOTIFY                             3    0.033ms    0.433ms    0.087ms    1.071ms    1.159ms    1.181ms
07:32:40 |  Server  | Server          |   SMSG_ATTACKER_STATE_UPDATE                    129    0.020ms    0.093ms    0.069ms    0.132ms    0.972ms    1.523ms
07:32:40 |  Server  | Server          |   SMSG_UPDATE_OBJECT                             97    0.048ms    0.140ms    0.090ms    0.449ms    0.852ms    1.392ms
07:32:40 |  Server  | Server          |   SMSG_ITEM_PUSH_RESULT                          22    0.025ms    0.089ms    0.032ms    0.145ms    0.829ms    1.010ms
07:32:40 |  Server  | Server          |   SMSG_SPELL_FAILED_OTHER                         1    0.788ms    0.788ms    0.788ms    0.788ms    0.788ms    0.788ms
```

---

This is from the `master` branch
```
07:56:15 |  Server  | Server          | Latency Metrics: 62 C->S opcodes, 73 S->C opcodes tracked
07:56:15 |  Server  | Server          | Proxy Latency Metrics (Uptime: 00:08:03)
07:56:15 |  Server  | Server          | Client -> Server (top by p99):
07:56:15 |  Server  | Server          |   Opcode                                      Count       Min       Avg       P50       P95       P99       Max
07:56:15 |  Server  | Server          |   ---------------------------------------- -------- --------- --------- --------- --------- --------- ---------
07:56:15 |  Server  | Server          |   CMSG_PLAYER_LOGIN                               1   93.761ms   93.761ms   93.761ms   93.761ms   93.761ms   93.761ms
07:56:15 |  Server  | Server          |   CMSG_USE_ITEM                                   1   20.106ms   20.106ms   20.106ms   20.106ms   20.106ms   20.106ms
07:56:15 |  Server  | Server          |   CMSG_CAST_SPELL                               121   15.204ms   16.161ms   16.145ms   16.971ms   17.164ms   21.514ms
07:56:15 |  Server  | Server          |   CMSG_HOTFIX_REQUEST                             1   16.308ms   16.308ms   16.308ms   16.308ms   16.308ms   16.308ms
07:56:15 |  Server  | Server          |   CMSG_CANCEL_CAST                                1   15.917ms   15.917ms   15.917ms   15.917ms   15.917ms   15.917ms
07:56:15 |  Server  | Server          |   CMSG_DB_QUERY_BULK                              2    1.190ms    3.478ms    3.478ms    5.537ms    5.720ms    5.766ms
07:56:15 |  Server  | Server          |   CMSG_CHAT_MESSAGE_SAY                           3    0.063ms    1.168ms    0.079ms    3.035ms    3.298ms    3.363ms
07:56:15 |  Server  | Server          |   CMSG_MOVE_HEARTBEAT                            93    0.037ms    0.144ms    0.072ms    0.096ms    2.361ms    4.025ms
07:56:15 |  Server  | Server          |   CMSG_REQUEST_LFG_LIST_BLACKLIST                 1    1.990ms    1.990ms    1.990ms    1.990ms    1.990ms    1.990ms
07:56:15 |  Server  | Server          |   CMSG_MOVE_START_TURN_LEFT                       3    0.068ms    0.828ms    0.437ms    1.825ms    1.949ms    1.980ms
07:56:15 |  Server  | Server          |   CMSG_ARENA_TEAM_ROSTER                          3    0.038ms    0.693ms    0.070ms    1.781ms    1.933ms    1.972ms
07:56:15 |  Server  | Server          |   CMSG_AUTO_EQUIP_ITEM                            4    0.048ms    0.490ms    0.054ms    1.541ms    1.750ms    1.802ms
07:56:15 |  Server  | Server          |   CMSG_GET_ACCOUNT_CHARACTER_LIST                 1    1.708ms    1.708ms    1.708ms    1.708ms    1.708ms    1.708ms
07:56:15 |  Server  | Server          |   CMSG_QUEST_GIVER_STATUS_MULTIPLE_QUERY         24    0.023ms    0.128ms    0.035ms    0.103ms    1.676ms    2.145ms
07:56:15 |  Server  | Server          |   CMSG_QUERY_PLAYER_NAME                          1    1.144ms    1.144ms    1.144ms    1.144ms    1.144ms    1.144ms
07:56:15 |  Server  | Server          |   CMSG_BATTLENET_REQUEST                          1    0.992ms    0.992ms    0.992ms    0.992ms    0.992ms    0.992ms
07:56:15 |  Server  | Server          |   CMSG_ENUM_CHARACTERS                            1    0.840ms    0.840ms    0.840ms    0.840ms    0.840ms    0.840ms
07:56:15 |  Server  | Server          |   CMSG_LOOT_ITEM                                 54    0.005ms    0.067ms    0.049ms    0.072ms    0.772ms    1.526ms
07:56:15 |  Server  | Server          |   CMSG_LOOT_UNIT                                 47    0.015ms    0.066ms    0.039ms    0.083ms    0.627ms    0.890ms
07:56:15 |  Server  | Server          |   CMSG_MOVE_START_FORWARD                       112    0.015ms    0.091ms    0.070ms    0.426ms    0.461ms    0.544ms
07:56:15 |  Server  | Server          | Server -> Client (top by p99):
07:56:15 |  Server  | Server          |   Opcode                                      Count       Min       Avg       P50       P95       P99       Max
07:56:15 |  Server  | Server          |   ---------------------------------------- -------- --------- --------- --------- --------- --------- ---------
07:56:15 |  Server  | Server          |   SMSG_ENUM_CHARACTERS_RESULT                     1   29.215ms   29.215ms   29.215ms   29.215ms   29.215ms   29.215ms
07:56:15 |  Server  | Server          |   SMSG_ITEM_QUERY_SINGLE_RESPONSE                42    0.135ms    1.493ms    0.256ms    1.712ms   25.301ms   34.991ms
07:56:15 |  Server  | Server          |   SMSG_SPELL_GO                                 160    0.026ms   13.604ms   16.041ms   17.066ms   17.173ms   26.352ms
07:56:15 |  Server  | Server          |   SMSG_SPELL_START                              128    0.024ms   13.321ms   15.639ms   16.972ms   17.152ms   17.878ms
07:56:15 |  Server  | Server          |   SMSG_CAST_FAILED                              149   15.018ms   16.028ms   15.959ms   16.931ms   17.043ms   17.452ms
07:56:15 |  Server  | Server          |   SMSG_SPELL_FAILED_OTHER                         5    0.035ms    3.347ms    0.078ms   12.947ms   15.431ms   16.053ms
07:56:15 |  Server  | Server          |   SMSG_INIT_WORLD_STATES                          1    8.241ms    8.241ms    8.241ms    8.241ms    8.241ms    8.241ms
07:56:15 |  Server  | Server          |   SMSG_ACCOUNT_DATA_TIMES                         1    8.113ms    8.113ms    8.113ms    8.113ms    8.113ms    8.113ms
07:56:15 |  Server  | Server          |   SMSG_QUERY_CREATURE_RESPONSE                    2    0.029ms    3.467ms    3.467ms    6.561ms    6.837ms    6.905ms
07:56:15 |  Server  | Server          |   SMSG_SEND_KNOWN_SPELLS                          1    4.159ms    4.159ms    4.159ms    4.159ms    4.159ms    4.159ms
07:56:15 |  Server  | Server          |   SMSG_LOOT_RESPONSE                             44    0.038ms    0.217ms    0.081ms    0.139ms    3.508ms    6.026ms
07:56:15 |  Server  | Server          |   SMSG_QUERY_PLAYER_NAME_RESPONSE                 1    3.165ms    3.165ms    3.165ms    3.165ms    3.165ms    3.165ms
07:56:15 |  Server  | Server          |   SMSG_CHAT                                      10    0.024ms    0.325ms    0.113ms    1.349ms    2.145ms    2.344ms
07:56:15 |  Server  | Server          |   SMSG_COMPRESSED_UPDATE_OBJECT                 813    0.117ms    0.469ms    0.204ms    0.491ms    2.090ms  149.146ms
07:56:15 |  Server  | Server          |   MSG_QUERY_NEXT_MAIL_TIME                        1    2.006ms    2.006ms    2.006ms    2.006ms    2.006ms    2.006ms
07:56:15 |  Server  | Server          |   SMSG_LOGIN_VERIFY_WORLD                         1    1.998ms    1.998ms    1.998ms    1.998ms    1.998ms    1.998ms
07:56:15 |  Server  | Server          |   SMSG_SET_FLAT_SPELL_MODIFIER                    3    0.088ms    0.811ms    0.326ms    1.849ms    1.984ms    2.018ms
07:56:15 |  Server  | Server          |   SMSG_FRIEND_LIST                                1    1.775ms    1.775ms    1.775ms    1.775ms    1.775ms    1.775ms
07:56:15 |  Server  | Server          |   SMSG_ITEM_PUSH_RESULT                          54    0.016ms    0.085ms    0.025ms    0.034ms    1.562ms    3.270ms
07:56:15 |  Server  | Server          |   SMSG_RAID_INSTANCE_INFO                         1    1.387ms    1.387ms    1.387ms    1.387ms    1.387ms    1.387ms
```


