### PR TITLE
Feature/perf/span pooled packet handler

### DIFF
--- a/Framework/Constants/GameLimits.cs
+++ b/Framework/Constants/GameLimits.cs
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2012-2020 CypherCore <http://github.com/CypherCore>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Framework.Constants
+{
+    /// <summary>
+    /// Game-defined limits for names and other strings.
+    /// These limits have been consistent since vanilla WoW.
+    /// </summary>
+    /// <remarks>
+    /// WoW names allow certain accented Latin characters (é, è, ñ, ö, ß, etc.)
+    /// which are 2 bytes in UTF-8. The byte limits assume worst-case where
+    /// all characters are 2-byte UTF-8 encoded.
+    /// </remarks>
+    public static class GameLimits
+    {
+        /// <summary>
+        /// Maximum character count for player names (2-12 characters).
+        /// </summary>
+        public const int MaxPlayerNameChars = 12;
+
+        /// <summary>
+        /// Maximum byte size for player names in UTF-8 (12 chars * 2 bytes).
+        /// </summary>
+        public const int MaxPlayerNameBytes = MaxPlayerNameChars * 2;
+
+        /// <summary>
+        /// Maximum character count for pet names (2-12 characters).
+        /// </summary>
+        public const int MaxPetNameChars = 12;
+
+        /// <summary>
+        /// Maximum byte size for pet names in UTF-8 (12 chars * 2 bytes).
+        /// </summary>
+        public const int MaxPetNameBytes = MaxPetNameChars * 2;
+
+        /// <summary>
+        /// Maximum character count for guild names (2-24 characters).
+        /// </summary>
+        public const int MaxGuildNameChars = 24;
+
+        /// <summary>
+        /// Maximum byte size for guild names in UTF-8 (24 chars * 2 bytes).
+        /// </summary>
+        public const int MaxGuildNameBytes = MaxGuildNameChars * 2;
+
+        /// <summary>
+        /// Maximum character count for arena team names (2-24 characters).
+        /// </summary>
+        public const int MaxArenaTeamNameChars = 24;
+
+        /// <summary>
+        /// Maximum byte size for arena team names in UTF-8 (24 chars * 2 bytes).
+        /// </summary>
+        public const int MaxArenaTeamNameBytes = MaxArenaTeamNameChars * 2;
+    }
+}

--- a/Framework/IO/ByteBuffer.cs
+++ b/Framework/IO/ByteBuffer.cs
@@ -1,6 +1,6 @@
-﻿/*
+/*
  * Copyright (C) 2012-2020 CypherCore <http://github.com/CypherCore>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -17,131 +17,206 @@
 
 using Framework.GameMath;
 using System;
+using System.Buffers;
+using System.Buffers.Binary;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Framework.IO
 {
     public class ByteBuffer : IDisposable
     {
+        private const int DefaultWriteCapacity = 256;
+
+        private byte[] _buffer;
+        private int _position;
+        private int _length;
+        private bool _isPooledBuffer;
+        private readonly bool _isWriteMode;
+        private bool _disposed;
+        private byte _bitPosition = 8;
+        private byte _bitValue;
+
+        private MemoryStream? _compatStream;
+
         public ByteBuffer()
         {
-            writeStream = new BinaryWriter(new MemoryStream());
+            _buffer = ArrayPool<byte>.Shared.Rent(DefaultWriteCapacity);
+            _position = 0;
+            _length = 0;
+            _isPooledBuffer = true;
+            _isWriteMode = true;
         }
 
         public ByteBuffer(byte[] data)
         {
-            readStream = new BinaryReader(new MemoryStream(data));
+            _buffer = data;
+            _position = 0;
+            _length = data.Length;
+            _isPooledBuffer = false;
+            _isWriteMode = false;
+        }
+
+        ~ByteBuffer()
+        {
+            Dispose(false);
         }
 
         public void Dispose()
         {
-            if (writeStream != null)
-                writeStream.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
 
-            if (readStream != null)
-                readStream.Dispose();
+        private void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            if (_isPooledBuffer && _buffer != null)
+            {
+                ArrayPool<byte>.Shared.Return(_buffer);
+                _buffer = null!;
+            }
+
+            if (disposing)
+                _compatStream?.Dispose();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void EnsureCapacity(int additionalBytes)
+        {
+            int required = _position + additionalBytes;
+            if (required <= _buffer.Length) return;
+
+            int newSize = Math.Max(_buffer.Length * 2, required);
+            byte[] newBuffer = ArrayPool<byte>.Shared.Rent(newSize);
+            _buffer.AsSpan(0, _length).CopyTo(newBuffer);
+
+            if (_isPooledBuffer)
+                ArrayPool<byte>.Shared.Return(_buffer);
+
+            _buffer = newBuffer;
+            _isPooledBuffer = true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void AdvanceWrite(int bytes)
+        {
+            _position += bytes;
+            if (_position > _length)
+                _length = _position;
         }
 
         #region Read Methods
         public sbyte ReadInt8()
         {
             ResetBitPos();
-            return readStream.ReadSByte();
+            sbyte value = (sbyte)_buffer[_position];
+            _position++;
+            return value;
         }
 
         public short ReadInt16()
         {
             ResetBitPos();
-            return readStream.ReadInt16();
+            short value = BinaryPrimitives.ReadInt16LittleEndian(_buffer.AsSpan(_position));
+            _position += 2;
+            return value;
         }
 
         public int ReadInt32()
         {
             ResetBitPos();
-            return readStream.ReadInt32();
+            int value = BinaryPrimitives.ReadInt32LittleEndian(_buffer.AsSpan(_position));
+            _position += 4;
+            return value;
         }
 
         public long ReadInt64()
         {
             ResetBitPos();
-            return readStream.ReadInt64();
+            long value = BinaryPrimitives.ReadInt64LittleEndian(_buffer.AsSpan(_position));
+            _position += 8;
+            return value;
         }
 
         public byte ReadUInt8()
         {
             ResetBitPos();
-            return readStream.ReadByte();
+            byte value = _buffer[_position];
+            _position++;
+            return value;
         }
 
         public ushort ReadUInt16()
         {
             ResetBitPos();
-            return readStream.ReadUInt16();
+            ushort value = BinaryPrimitives.ReadUInt16LittleEndian(_buffer.AsSpan(_position));
+            _position += 2;
+            return value;
         }
 
         public uint ReadUInt32()
         {
             ResetBitPos();
-            return readStream.ReadUInt32();
+            uint value = BinaryPrimitives.ReadUInt32LittleEndian(_buffer.AsSpan(_position));
+            _position += 4;
+            return value;
         }
 
         public ulong ReadUInt64()
         {
             ResetBitPos();
-            return readStream.ReadUInt64();
+            ulong value = BinaryPrimitives.ReadUInt64LittleEndian(_buffer.AsSpan(_position));
+            _position += 8;
+            return value;
         }
 
         public float ReadFloat()
         {
             ResetBitPos();
-            return readStream.ReadSingle();
+            float value = BinaryPrimitives.ReadSingleLittleEndian(_buffer.AsSpan(_position));
+            _position += 4;
+            return value;
         }
 
         public double ReadDouble()
         {
             ResetBitPos();
-            return readStream.ReadDouble();
+            double value = BinaryPrimitives.ReadDoubleLittleEndian(_buffer.AsSpan(_position));
+            _position += 8;
+            return value;
         }
 
-        public T ReadByteEnum<T>() where T: Enum
+        public T ReadByteEnum<T>() where T : Enum
         {
-            return (T)(object) ReadUInt8();
+            return (T)(object)ReadUInt8();
         }
 
         public string ReadCString()
         {
             ResetBitPos();
 
-            var stream = readStream.BaseStream;
-            long startPos = stream.Position;
+            int startPos = _position;
 
             // Scan for null terminator
-            int b;
-            while ((b = stream.ReadByte()) > 0) { }
+            while (_position < _length && _buffer[_position] != 0)
+            {
+                _position++;
+            }
 
-            int length = (int)(stream.Position - startPos - 1);
+            int strLength = _position - startPos;
 
-            if (length <= 0)
+            // Skip null terminator
+            if (_position < _length)
+                _position++;
+
+            if (strLength <= 0)
                 return string.Empty;
 
-            // Seek back and read the string bytes
-            stream.Position = startPos;
-
-            // Use stackalloc for small strings to avoid heap allocation
-            if (length <= 256)
-            {
-                Span<byte> buffer = stackalloc byte[length];
-                stream.ReadExactly(buffer);
-                stream.ReadByte(); // consume null terminator
-                return Encoding.UTF8.GetString(buffer);
-            }
-            else
-            {
-                var buffer = readStream.ReadBytes(length);
-                stream.ReadByte(); // consume null terminator
-                return Encoding.UTF8.GetString(buffer);
-            }
+            return Encoding.UTF8.GetString(_buffer, startPos, strLength);
         }
 
         /// <summary>
@@ -151,13 +226,13 @@ namespace Framework.IO
         {
             ResetBitPos();
             StringBuilder tmpString = new StringBuilder();
-            char tmpChar = readStream.ReadChar();
-            char tmpEndChar = Convert.ToChar(Encoding.UTF8.GetString(new byte[] { 0 }));
 
-            while (tmpChar != tmpEndChar)
+            while (_position < _length)
             {
-                tmpString.Append(tmpChar);
-                tmpChar = readStream.ReadChar();
+                byte b = _buffer[_position++];
+                if (b == 0)
+                    break;
+                tmpString.Append((char)b);
             }
 
             return tmpString.ToString();
@@ -175,24 +250,35 @@ namespace Framework.IO
         public bool ReadBool()
         {
             ResetBitPos();
-            return readStream.ReadBoolean();
+            byte value = _buffer[_position];
+            _position++;
+            return value != 0;
         }
 
         public byte[] ReadBytes(uint count)
         {
             ResetBitPos();
-            return readStream.ReadBytes((int)count);
+            int available = _length - _position;
+            int toRead = Math.Min((int)count, available);
+
+            if (toRead <= 0)
+                return [];
+
+            byte[] result = new byte[toRead];
+            _buffer.AsSpan(_position, toRead).CopyTo(result);
+            _position += toRead;
+            return result;
         }
 
         public void Skip(int count)
         {
             ResetBitPos();
-            readStream.BaseStream.Position += count;
+            _position += count;
         }
 
         public bool CanRead()
         {
-            return GetCurrentStream().Position != GetCurrentStream().Length;
+            return _position < _length;
         }
 
         public uint ReadPackedTime()
@@ -245,17 +331,17 @@ namespace Framework.IO
             return new Quaternion(ReadFloat(), ReadFloat(), ReadFloat(), ReadFloat());
         }
 
-        //BitPacking
+        // BitPacking
         public bool ReadBit()
         {
             if (_bitPosition == 8)
             {
-                BitValue = ReadUInt8();
+                _bitValue = ReadUInt8();
                 _bitPosition = 0;
             }
 
-            int returnValue = BitValue;
-            BitValue = (byte)(2 * returnValue); // BitValue <<= 1;
+            int returnValue = _bitValue;
+            _bitValue = (byte)(2 * returnValue); // BitValue <<= 1;
             ++_bitPosition;
 
             return (returnValue >> 7) != 0;
@@ -265,12 +351,12 @@ namespace Framework.IO
         {
             if (_bitPosition == 8)
             {
-                BitValue = ReadUInt8();
+                _bitValue = ReadUInt8();
                 _bitPosition = 0;
             }
 
-            int returnValue = BitValue;
-            BitValue = (byte)(2 * returnValue);
+            int returnValue = _bitValue;
+            _bitValue = (byte)(2 * returnValue);
             ++_bitPosition;
 
             return Convert.ToBoolean(returnValue >> 7);
@@ -292,67 +378,89 @@ namespace Framework.IO
         public void WriteInt8(sbyte data)
         {
             FlushBits();
-            writeStream.Write(data);
+            EnsureCapacity(1);
+            _buffer[_position] = (byte)data;
+            AdvanceWrite(1);
         }
 
         public void WriteInt16(short data)
         {
             FlushBits();
-            writeStream.Write(data);
+            EnsureCapacity(2);
+            BinaryPrimitives.WriteInt16LittleEndian(_buffer.AsSpan(_position), data);
+            AdvanceWrite(2);
         }
 
         public void WriteInt32(int data)
         {
             FlushBits();
-            writeStream.Write(data);
+            EnsureCapacity(4);
+            BinaryPrimitives.WriteInt32LittleEndian(_buffer.AsSpan(_position), data);
+            AdvanceWrite(4);
         }
 
         public void WriteInt64(long data)
         {
             FlushBits();
-            writeStream.Write(data);
+            EnsureCapacity(8);
+            BinaryPrimitives.WriteInt64LittleEndian(_buffer.AsSpan(_position), data);
+            AdvanceWrite(8);
         }
 
         public void WriteBool(bool data)
         {
             FlushBits();
-            writeStream.Write(data);
+            EnsureCapacity(1);
+            _buffer[_position] = data ? (byte)1 : (byte)0;
+            AdvanceWrite(1);
         }
 
         public void WriteUInt8(byte data)
         {
             FlushBits();
-            writeStream.Write(data);
+            EnsureCapacity(1);
+            _buffer[_position] = data;
+            AdvanceWrite(1);
         }
 
         public void WriteUInt16(ushort data)
         {
             FlushBits();
-            writeStream.Write(data);
+            EnsureCapacity(2);
+            BinaryPrimitives.WriteUInt16LittleEndian(_buffer.AsSpan(_position), data);
+            AdvanceWrite(2);
         }
 
         public void WriteUInt32(uint data)
         {
             FlushBits();
-            writeStream.Write(data);
+            EnsureCapacity(4);
+            BinaryPrimitives.WriteUInt32LittleEndian(_buffer.AsSpan(_position), data);
+            AdvanceWrite(4);
         }
 
         public void WriteUInt64(ulong data)
         {
             FlushBits();
-            writeStream.Write(data);
+            EnsureCapacity(8);
+            BinaryPrimitives.WriteUInt64LittleEndian(_buffer.AsSpan(_position), data);
+            AdvanceWrite(8);
         }
 
         public void WriteFloat(float data)
         {
             FlushBits();
-            writeStream.Write(data);
+            EnsureCapacity(4);
+            BinaryPrimitives.WriteSingleLittleEndian(_buffer.AsSpan(_position), data);
+            AdvanceWrite(4);
         }
 
         public void WriteDouble(double data)
         {
             FlushBits();
-            writeStream.Write(data);
+            EnsureCapacity(8);
+            BinaryPrimitives.WriteDoubleLittleEndian(_buffer.AsSpan(_position), data);
+            AdvanceWrite(8);
         }
 
         /// <summary>
@@ -383,19 +491,25 @@ namespace Framework.IO
         public void WriteBytes(byte[] data)
         {
             FlushBits();
-            writeStream.Write(data, 0, data.Length);
+            EnsureCapacity(data.Length);
+            data.CopyTo(_buffer.AsSpan(_position));
+            AdvanceWrite(data.Length);
         }
 
         public void WriteBytes(Span<byte> data)
         {
             FlushBits();
-            writeStream.Write(data);
+            EnsureCapacity(data.Length);
+            data.CopyTo(_buffer.AsSpan(_position));
+            AdvanceWrite(data.Length);
         }
 
         public void WriteBytes(byte[] data, uint count)
         {
             FlushBits();
-            writeStream.Write(data, 0, (int)count);
+            EnsureCapacity((int)count);
+            data.AsSpan(0, (int)count).CopyTo(_buffer.AsSpan(_position));
+            AdvanceWrite((int)count);
         }
 
         public void WriteBytes(ByteBuffer buffer)
@@ -440,14 +554,16 @@ namespace Framework.IO
             --_bitPosition;
 
             if (bit)
-                BitValue |= (byte)(1 << _bitPosition);
+                _bitValue |= (byte)(1 << _bitPosition);
 
             if (_bitPosition == 0)
             {
-                writeStream.Write(BitValue);
+                EnsureCapacity(1);
+                _buffer[_position] = _bitValue;
+                AdvanceWrite(1);
 
                 _bitPosition = 8;
-                BitValue = 0;
+                _bitValue = 0;
             }
             return bit;
         }
@@ -468,14 +584,14 @@ namespace Framework.IO
             WriteUInt32(Time.GetPackedTimeFromDateTime(DateTime.Now));
         }
 
-        public void WriteByteEnum<T>(T x) where T: Enum
+        public void WriteByteEnum<T>(T x) where T : Enum
         {
-            WriteUInt8((byte)(object) x);
+            WriteUInt8((byte)(object)x);
         }
 
-        public void WriteUint32Enum<T>(T x) where T: Enum
+        public void WriteUint32Enum<T>(T x) where T : Enum
         {
-            WriteUInt32((uint)(object) x);
+            WriteUInt32((uint)(object)x);
         }
 
         #endregion
@@ -490,8 +606,10 @@ namespace Framework.IO
             if (_bitPosition == 8)
                 return;
 
-            writeStream.Write(BitValue);
-            BitValue = 0;
+            EnsureCapacity(1);
+            _buffer[_position] = _bitValue;
+            AdvanceWrite(1);
+            _bitValue = 0;
             _bitPosition = 8;
         }
 
@@ -501,40 +619,36 @@ namespace Framework.IO
                 return;
 
             _bitPosition = 8;
-            BitValue = 0;
+            _bitValue = 0;
         }
 
         public void ResetReadPos()
         {
-            readStream.BaseStream.Position = 0;
-            readStream.BaseStream.Seek(0, SeekOrigin.Begin);
+            _position = 0;
             ResetBitPos();
         }
 
         public byte[] ReadToEnd()
         {
-            Stream stream = GetCurrentStream();
-            var length = (uint)(stream.Length - stream.Position);
-            return ReadBytes(length);
+            var remaining = (uint)(_length - _position);
+            return ReadBytes(remaining);
         }
 
         public byte[] GetData()
         {
-            Stream stream = GetCurrentStream();
-
-            // MemoryStream provides efficient ToArray() and GetBuffer()
-            if (stream is MemoryStream ms)
+            if (_isWriteMode)
             {
-                return ms.ToArray();
+                FlushBits();
+                // Return only actual data, not the potentially larger pooled buffer
+                byte[] result = new byte[_length];
+                _buffer.AsSpan(0, _length).CopyTo(result);
+                return result;
             }
-
-            // Fallback for other stream types - use bulk read
-            var data = new byte[stream.Length];
-            long pos = stream.Position;
-            stream.Position = 0;
-            stream.ReadExactly(data);
-            stream.Position = pos;
-            return data;
+            else
+            {
+                // For read mode, return the original buffer (which IS the right size)
+                return _buffer;
+            }
         }
 
         /// <summary>
@@ -542,43 +656,56 @@ namespace Framework.IO
         /// </summary>
         internal byte[] GetDataOriginal()
         {
-            Stream stream = GetCurrentStream();
-
-            var data = new byte[stream.Length];
-
-            long pos = stream.Position;
-            stream.Seek(0, SeekOrigin.Begin);
-            for (int i = 0; i < data.Length; i++)
-                data[i] = (byte)stream.ReadByte();
-
-            stream.Seek(pos, SeekOrigin.Begin);
-            return data;
+            if (_isWriteMode)
+            {
+                FlushBits();
+                var data = new byte[_length];
+                for (int i = 0; i < _length; i++)
+                    data[i] = _buffer[i];
+                return data;
+            }
+            else
+            {
+                var data = new byte[_length];
+                for (int i = 0; i < _length; i++)
+                    data[i] = _buffer[i];
+                return data;
+            }
         }
 
         public uint GetSize()
         {
-            return (uint)GetCurrentStream().Length;
+            return (uint)_length;
         }
 
+        [Obsolete("Use GetData() instead. This creates a MemoryStream copy for compatibility.")]
         public Stream GetCurrentStream()
         {
-            if (writeStream != null)
-                return writeStream.BaseStream;
-            else
-                return readStream.BaseStream;
+            if (_compatStream == null)
+            {
+                if (_isWriteMode)
+                {
+                    FlushBits();
+                    _compatStream = new MemoryStream(_buffer, 0, _length);
+                }
+                else
+                {
+                    _compatStream = new MemoryStream(_buffer, 0, _length);
+                }
+            }
+            return _compatStream;
         }
 
         public void Clear()
         {
             _bitPosition = 8;
-            BitValue = 0;
-            writeStream = new BinaryWriter(new MemoryStream());
+            _bitValue = 0;
+            _position = 0;
+            _length = 0;
+            _compatStream?.Dispose();
+            _compatStream = null;
+            // Keep the existing buffer for reuse
         }
-
-        byte _bitPosition = 8;
-        byte BitValue;
-        BinaryWriter writeStream;
-        BinaryReader readStream;
 
         // Hex Printer from WPP
         // https://github.com/TrinityCore/WowPacketParser/blob/7edfda7e4daf9a5b9069083806a9a3c261dea8a7/WowPacketParser/Misc/Utilities.cs#L48
@@ -589,7 +716,7 @@ namespace Framework.IO
             const bool noOffsetFirstLine = false;
 
             var data = GetData();
-            
+
             var n = Environment.NewLine;
 
             var prefix = new string(' ', offset);

--- a/Framework/IO/ISpanWritable.cs
+++ b/Framework/IO/ISpanWritable.cs
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2012-2020 CypherCore <http://github.com/CypherCore>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+
+namespace Framework.IO
+{
+    /// <summary>
+    /// Interface for packets that support zero-allocation Span-based writing.
+    /// Packets implementing this interface can be written using SpanPacketWriter
+    /// for improved performance in hot paths.
+    /// </summary>
+    public interface ISpanWritable
+    {
+        /// <summary>
+        /// Writes the packet data to the provided buffer using SpanPacketWriter.
+        /// </summary>
+        /// <param name="buffer">The buffer to write to. Must be at least MaxSize bytes.</param>
+        /// <returns>
+        /// The number of bytes written, or a negative value to indicate that the packet
+        /// exceeds MaxSize and the caller should fall back to the standard Write() method.
+        /// This allows packets with variable-length data to use a capped MaxSize for common
+        /// cases while gracefully handling rare oversized packets.
+        /// </returns>
+        int WriteToSpan(Span<byte> buffer);
+
+        /// <summary>
+        /// Returns the maximum size in bytes this packet could be.
+        /// Used for buffer allocation. Should be a constant or cheap to compute.
+        /// For packets with variable-length data, this may be a practical cap rather than
+        /// a theoretical maximum. If actual data exceeds this, WriteToSpan should return
+        /// a negative value to trigger fallback.
+        /// </summary>
+        int MaxSize { get; }
+    }
+}

--- a/Framework/IO/PackedGuidHelper.cs
+++ b/Framework/IO/PackedGuidHelper.cs
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2012-2020 CypherCore <http://github.com/CypherCore>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Framework.IO
+{
+    /// <summary>
+    /// Helper methods for encoding/decoding packed GUIDs in Span-based packet I/O.
+    /// </summary>
+    public static class PackedGuidHelper
+    {
+        /// <summary>
+        /// Maximum size of a packed GUID128 (2 mask bytes + 16 value bytes).
+        /// </summary>
+        public const int MaxPackedGuid128Size = 18;
+
+        /// <summary>
+        /// Writes a packed GUID128 to the buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write to.</param>
+        /// <param name="low">The low 64 bits of the GUID.</param>
+        /// <param name="high">The high 64 bits of the GUID.</param>
+        /// <returns>The number of bytes written (2-18).</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int WritePackedGuid128(Span<byte> buffer, ulong low, ulong high)
+        {
+            // Empty GUID
+            if (low == 0 && high == 0)
+            {
+                buffer[0] = 0;
+                buffer[1] = 0;
+                return 2;
+            }
+
+            Span<byte> lowPacked = stackalloc byte[8];
+            Span<byte> highPacked = stackalloc byte[8];
+
+            int loSize = PackUInt64(low, out byte lowMask, lowPacked);
+            int hiSize = PackUInt64(high, out byte highMask, highPacked);
+
+            buffer[0] = lowMask;
+            buffer[1] = highMask;
+
+            lowPacked.Slice(0, loSize).CopyTo(buffer.Slice(2));
+            highPacked.Slice(0, hiSize).CopyTo(buffer.Slice(2 + loSize));
+
+            return 2 + loSize + hiSize;
+        }
+
+        /// <summary>
+        /// Writes a packed UInt64 to the buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to write to.</param>
+        /// <param name="value">The value to pack.</param>
+        /// <returns>The number of bytes written (1-9).</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int WritePackedUInt64(Span<byte> buffer, ulong value)
+        {
+            Span<byte> packed = stackalloc byte[8];
+            int size = PackUInt64(value, out byte mask, packed);
+
+            buffer[0] = mask;
+            packed.Slice(0, size).CopyTo(buffer.Slice(1));
+
+            return 1 + size;
+        }
+
+        /// <summary>
+        /// Reads a packed GUID128 from the buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read from.</param>
+        /// <param name="low">The low 64 bits of the GUID.</param>
+        /// <param name="high">The high 64 bits of the GUID.</param>
+        /// <returns>The number of bytes read.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ReadPackedGuid128(ReadOnlySpan<byte> buffer, out ulong low, out ulong high)
+        {
+            byte lowMask = buffer[0];
+            byte highMask = buffer[1];
+            int pos = 2;
+
+            low = UnpackUInt64(buffer.Slice(pos), lowMask, out int lowSize);
+            pos += lowSize;
+
+            high = UnpackUInt64(buffer.Slice(pos), highMask, out int highSize);
+            pos += highSize;
+
+            return pos;
+        }
+
+        /// <summary>
+        /// Reads a packed UInt64 from the buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to read from.</param>
+        /// <param name="value">The unpacked value.</param>
+        /// <returns>The number of bytes read.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ReadPackedUInt64(ReadOnlySpan<byte> buffer, out ulong value)
+        {
+            byte mask = buffer[0];
+            value = UnpackUInt64(buffer.Slice(1), mask, out int size);
+            return 1 + size;
+        }
+
+        /// <summary>
+        /// Packs a ulong into non-zero bytes with a bitmask indicating which byte positions are present.
+        /// Uses unrolled mask computation and TrailingZeroCount for optimal performance.
+        /// </summary>
+        /// <param name="value">The value to pack.</param>
+        /// <param name="mask">Output: bitmask where bit i is set if byte i of value is non-zero.</param>
+        /// <param name="result">Output buffer for packed bytes (must be at least 8 bytes).</param>
+        /// <returns>Number of bytes written to result.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int PackUInt64(ulong value, out byte mask, Span<byte> result)
+        {
+            // Compute 8-bit mask: bit i set iff byte i of value != 0
+            // Unrolled for instruction-level parallelism (no loop-carried dependency)
+            mask = 0;
+            mask |= (byte)(((value) & 0xFFUL) != 0 ? 1 << 0 : 0);
+            mask |= (byte)(((value >> 8) & 0xFFUL) != 0 ? 1 << 1 : 0);
+            mask |= (byte)(((value >> 16) & 0xFFUL) != 0 ? 1 << 2 : 0);
+            mask |= (byte)(((value >> 24) & 0xFFUL) != 0 ? 1 << 3 : 0);
+            mask |= (byte)(((value >> 32) & 0xFFUL) != 0 ? 1 << 4 : 0);
+            mask |= (byte)(((value >> 40) & 0xFFUL) != 0 ? 1 << 5 : 0);
+            mask |= (byte)(((value >> 48) & 0xFFUL) != 0 ? 1 << 6 : 0);
+            mask |= (byte)(((value >> 56) & 0xFFUL) != 0 ? 1 << 7 : 0);
+
+            if (mask == 0)
+                return 0;
+
+            // Write bytes in order using TrailingZeroCount to find set bits efficiently.
+            // Iterates exactly PopCount(mask) times.
+            ref byte dst = ref MemoryMarshal.GetReference(result);
+            int size = 0;
+            uint m = mask;
+
+            while (m != 0)
+            {
+                int bit = BitOperations.TrailingZeroCount(m);
+                Unsafe.Add(ref dst, size) = (byte)(value >> (bit * 8));
+                size++;
+                m &= (m - 1); // Clear lowest set bit
+            }
+
+            return size;
+        }
+
+        /// <summary>
+        /// Unpacks bytes into a ulong based on a bitmask indicating which byte positions are present.
+        /// Uses TrailingZeroCount for optimal bit scanning.
+        /// </summary>
+        /// <param name="buffer">Input buffer containing packed bytes.</param>
+        /// <param name="mask">Bitmask where bit i indicates byte i is present in buffer.</param>
+        /// <param name="bytesRead">Output: number of bytes consumed from buffer.</param>
+        /// <returns>The unpacked ulong value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong UnpackUInt64(ReadOnlySpan<byte> buffer, byte mask, out int bytesRead)
+        {
+            if (mask == 0)
+            {
+                bytesRead = 0;
+                return 0;
+            }
+
+            ref byte src = ref MemoryMarshal.GetReference(buffer);
+            ulong value = 0;
+            int idx = 0;
+            uint m = mask;
+
+            // Reads exactly PopCount(mask) bytes
+            while (m != 0)
+            {
+                int bit = BitOperations.TrailingZeroCount(m);
+                value |= (ulong)Unsafe.Add(ref src, idx) << (bit * 8);
+                idx++;
+                m &= (m - 1); // Clear lowest set bit
+            }
+
+            bytesRead = idx;
+            return value;
+        }
+    }
+}

--- a/Framework/IO/SpanPacketReader.cs
+++ b/Framework/IO/SpanPacketReader.cs
@@ -1,0 +1,312 @@
+/*
+ * Copyright (C) 2012-2020 CypherCore <http://github.com/CypherCore>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Framework.GameMath;
+
+namespace Framework.IO
+{
+    /// <summary>
+    /// High-performance packet reader using ReadOnlySpan&lt;byte&gt; for zero-allocation reads.
+    /// This is a ref struct that lives on the stack.
+    /// </summary>
+    public ref struct SpanPacketReader
+    {
+        private readonly ReadOnlySpan<byte> _buffer;
+        private int _position;
+        private byte _bitValue;
+        private byte _bitPosition;
+
+        public SpanPacketReader(ReadOnlySpan<byte> buffer)
+        {
+            _buffer = buffer;
+            _position = 0;
+            _bitValue = 0;
+            _bitPosition = 8;
+        }
+
+        public readonly int Position => _position;
+        public readonly int Length => _buffer.Length;
+        public readonly int Remaining => _buffer.Length - _position;
+        public readonly bool CanRead => _position < _buffer.Length;
+
+        #region Integer Read Methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public byte ReadUInt8()
+        {
+            ResetBitPos();
+            return _buffer[_position++];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public sbyte ReadInt8()
+        {
+            ResetBitPos();
+            return (sbyte)_buffer[_position++];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ushort ReadUInt16()
+        {
+            ResetBitPos();
+            var value = BinaryPrimitives.ReadUInt16LittleEndian(_buffer.Slice(_position));
+            _position += 2;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public short ReadInt16()
+        {
+            ResetBitPos();
+            var value = BinaryPrimitives.ReadInt16LittleEndian(_buffer.Slice(_position));
+            _position += 2;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint ReadUInt32()
+        {
+            ResetBitPos();
+            var value = BinaryPrimitives.ReadUInt32LittleEndian(_buffer.Slice(_position));
+            _position += 4;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ReadInt32()
+        {
+            ResetBitPos();
+            var value = BinaryPrimitives.ReadInt32LittleEndian(_buffer.Slice(_position));
+            _position += 4;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong ReadUInt64()
+        {
+            ResetBitPos();
+            var value = BinaryPrimitives.ReadUInt64LittleEndian(_buffer.Slice(_position));
+            _position += 8;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public long ReadInt64()
+        {
+            ResetBitPos();
+            var value = BinaryPrimitives.ReadInt64LittleEndian(_buffer.Slice(_position));
+            _position += 8;
+            return value;
+        }
+
+        #endregion
+
+        #region Float Read Methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float ReadFloat()
+        {
+            ResetBitPos();
+            var value = BinaryPrimitives.ReadSingleLittleEndian(_buffer.Slice(_position));
+            _position += 4;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public double ReadDouble()
+        {
+            ResetBitPos();
+            var value = BinaryPrimitives.ReadDoubleLittleEndian(_buffer.Slice(_position));
+            _position += 8;
+            return value;
+        }
+
+        #endregion
+
+        #region Vector Read Methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Vector2 ReadVector2()
+        {
+            return new Vector2(ReadFloat(), ReadFloat());
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Vector3 ReadVector3()
+        {
+            return new Vector3(ReadFloat(), ReadFloat(), ReadFloat());
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Vector4 ReadVector4()
+        {
+            return new Vector4(ReadFloat(), ReadFloat(), ReadFloat(), ReadFloat());
+        }
+
+        #endregion
+
+        #region Byte/String Read Methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool ReadBool()
+        {
+            ResetBitPos();
+            return _buffer[_position++] != 0;
+        }
+
+        public ReadOnlySpan<byte> ReadBytes(int count)
+        {
+            ResetBitPos();
+            int available = Math.Min(count, Remaining);
+            if (available <= 0)
+                return ReadOnlySpan<byte>.Empty;
+
+            var slice = _buffer.Slice(_position, available);
+            _position += available;
+            return slice;
+        }
+
+        public void Skip(int count)
+        {
+            ResetBitPos();
+            _position += count;
+        }
+
+        /// <summary>
+        /// Reads a null-terminated string. Only allocates for the final string.
+        /// </summary>
+        public string ReadCString()
+        {
+            ResetBitPos();
+            int start = _position;
+
+            while (_position < _buffer.Length && _buffer[_position] != 0)
+                _position++;
+
+            var slice = _buffer.Slice(start, _position - start);
+
+            // Skip null terminator
+            if (_position < _buffer.Length)
+                _position++;
+
+            if (slice.Length == 0)
+                return string.Empty;
+
+            return Encoding.UTF8.GetString(slice);
+        }
+
+        public string ReadString(int length)
+        {
+            if (length == 0)
+                return string.Empty;
+
+            ResetBitPos();
+            var slice = _buffer.Slice(_position, length);
+            _position += length;
+            return Encoding.UTF8.GetString(slice);
+        }
+
+        #endregion
+
+        #region Bit Read Methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool ReadBit()
+        {
+            if (_bitPosition == 8)
+            {
+                _bitValue = _buffer[_position++];
+                _bitPosition = 0;
+            }
+
+            int returnValue = _bitValue;
+            _bitValue = (byte)(_bitValue << 1);
+            ++_bitPosition;
+
+            return (returnValue >> 7) != 0;
+        }
+
+        public T ReadBits<T>(int bitCount) where T : unmanaged
+        {
+            int value = 0;
+
+            for (int i = bitCount - 1; i >= 0; --i)
+                if (ReadBit())
+                    value |= (1 << i);
+
+            return (T)Convert.ChangeType(value, typeof(T));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ResetBitPos()
+        {
+            if (_bitPosition > 7)
+                return;
+
+            _bitPosition = 8;
+            _bitValue = 0;
+        }
+
+        #endregion
+
+        #region Packed GUID Methods
+
+        /// <summary>
+        /// Reads a packed GUID128 (low and high parts).
+        /// </summary>
+        public void ReadPackedGuid128(out ulong low, out ulong high)
+        {
+            ResetBitPos();
+            int bytesRead = PackedGuidHelper.ReadPackedGuid128(_buffer.Slice(_position), out low, out high);
+            _position += bytesRead;
+        }
+
+        /// <summary>
+        /// Reads a packed UInt64.
+        /// </summary>
+        public ulong ReadPackedUInt64()
+        {
+            ResetBitPos();
+            int bytesRead = PackedGuidHelper.ReadPackedUInt64(_buffer.Slice(_position), out ulong value);
+            _position += bytesRead;
+            return value;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Reads remaining bytes to end of buffer.
+        /// </summary>
+        public ReadOnlySpan<byte> ReadToEnd()
+        {
+            return ReadBytes(Remaining);
+        }
+
+        /// <summary>
+        /// Resets position to beginning of buffer.
+        /// </summary>
+        public void ResetReadPos()
+        {
+            _position = 0;
+            ResetBitPos();
+        }
+    }
+}

--- a/Framework/IO/SpanPacketWriter.cs
+++ b/Framework/IO/SpanPacketWriter.cs
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2012-2020 CypherCore <http://github.com/CypherCore>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using System;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Framework.GameMath;
+
+namespace Framework.IO
+{
+    /// <summary>
+    /// High-performance packet writer using Span&lt;byte&gt; for zero-allocation writes.
+    /// This is a ref struct that lives on the stack.
+    /// </summary>
+    public ref struct SpanPacketWriter
+    {
+        private readonly Span<byte> _buffer;
+        private int _position;
+        private byte _bitValue;
+        private byte _bitPosition;
+
+        public SpanPacketWriter(Span<byte> buffer)
+        {
+            _buffer = buffer;
+            _position = 0;
+            _bitValue = 0;
+            _bitPosition = 8;
+        }
+
+        public readonly int Position => _position;
+        public readonly int Remaining => _buffer.Length - _position;
+
+        #region Integer Write Methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteUInt8(byte value)
+        {
+            FlushBits();
+            _buffer[_position++] = value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteInt8(sbyte value)
+        {
+            FlushBits();
+            _buffer[_position++] = (byte)value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteUInt16(ushort value)
+        {
+            FlushBits();
+            BinaryPrimitives.WriteUInt16LittleEndian(_buffer.Slice(_position), value);
+            _position += 2;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteInt16(short value)
+        {
+            FlushBits();
+            BinaryPrimitives.WriteInt16LittleEndian(_buffer.Slice(_position), value);
+            _position += 2;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteUInt32(uint value)
+        {
+            FlushBits();
+            BinaryPrimitives.WriteUInt32LittleEndian(_buffer.Slice(_position), value);
+            _position += 4;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteInt32(int value)
+        {
+            FlushBits();
+            BinaryPrimitives.WriteInt32LittleEndian(_buffer.Slice(_position), value);
+            _position += 4;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteUInt64(ulong value)
+        {
+            FlushBits();
+            BinaryPrimitives.WriteUInt64LittleEndian(_buffer.Slice(_position), value);
+            _position += 8;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteInt64(long value)
+        {
+            FlushBits();
+            BinaryPrimitives.WriteInt64LittleEndian(_buffer.Slice(_position), value);
+            _position += 8;
+        }
+
+        #endregion
+
+        #region Float Write Methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteFloat(float value)
+        {
+            FlushBits();
+            BinaryPrimitives.WriteSingleLittleEndian(_buffer.Slice(_position), value);
+            _position += 4;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteDouble(double value)
+        {
+            FlushBits();
+            BinaryPrimitives.WriteDoubleLittleEndian(_buffer.Slice(_position), value);
+            _position += 8;
+        }
+
+        #endregion
+
+        #region Vector Write Methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteVector2(Vector2 value)
+        {
+            WriteFloat(value.X);
+            WriteFloat(value.Y);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteVector3(Vector3 value)
+        {
+            WriteFloat(value.X);
+            WriteFloat(value.Y);
+            WriteFloat(value.Z);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteVector4(Vector4 value)
+        {
+            WriteFloat(value.X);
+            WriteFloat(value.Y);
+            WriteFloat(value.Z);
+            WriteFloat(value.W);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WritePackXYZ(Vector3 pos)
+        {
+            // Pack X (11 bits), Y (11 bits), Z (10 bits) into a single uint32
+            uint packed = 0;
+            packed |= (uint)((int)(pos.X / 0.25f)) & 0x7FF;
+            packed |= ((uint)((int)(pos.Y / 0.25f)) & 0x7FF) << 11;
+            packed |= ((uint)((int)(pos.Z / 0.25f)) & 0x3FF) << 22;
+            WriteUInt32(packed);
+        }
+
+        #endregion
+
+        #region Byte/String Write Methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteBytes(ReadOnlySpan<byte> data)
+        {
+            FlushBits();
+            data.CopyTo(_buffer.Slice(_position));
+            _position += data.Length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void WriteBool(bool value)
+        {
+            FlushBits();
+            _buffer[_position++] = value ? (byte)1 : (byte)0;
+        }
+
+        public void WriteCString(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                WriteUInt8(0);
+                return;
+            }
+
+            WriteString(value);
+            WriteUInt8(0);
+        }
+
+        public void WriteString(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            FlushBits();
+            int bytesWritten = Encoding.UTF8.GetBytes(value, _buffer.Slice(_position));
+            _position += bytesWritten;
+        }
+
+        #endregion
+
+        #region Bit Write Methods
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool WriteBit(bool value)
+        {
+            --_bitPosition;
+
+            if (value)
+                _bitValue |= (byte)(1 << _bitPosition);
+
+            if (_bitPosition == 0)
+            {
+                _buffer[_position++] = _bitValue;
+                _bitPosition = 8;
+                _bitValue = 0;
+            }
+
+            return value;
+        }
+
+        public void WriteBits(uint value, int bitCount)
+        {
+            for (int i = bitCount - 1; i >= 0; --i)
+                WriteBit(((value >> i) & 1) != 0);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void FlushBits()
+        {
+            if (_bitPosition == 8)
+                return;
+
+            _buffer[_position++] = _bitValue;
+            _bitValue = 0;
+            _bitPosition = 8;
+        }
+
+        public readonly bool HasUnfinishedBitPack => _bitPosition != 8;
+
+        #endregion
+
+        #region Packed GUID Methods
+
+        /// <summary>
+        /// Writes a packed GUID128 (low and high parts).
+        /// </summary>
+        public void WritePackedGuid128(ulong low, ulong high)
+        {
+            FlushBits();
+            int written = PackedGuidHelper.WritePackedGuid128(_buffer.Slice(_position), low, high);
+            _position += written;
+        }
+
+        /// <summary>
+        /// Writes a packed UInt64.
+        /// </summary>
+        public void WritePackedUInt64(ulong value)
+        {
+            FlushBits();
+            int written = PackedGuidHelper.WritePackedUInt64(_buffer.Slice(_position), value);
+            _position += written;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Returns the written portion of the buffer as a ReadOnlySpan.
+        /// </summary>
+        public ReadOnlySpan<byte> GetWrittenSpan()
+        {
+            FlushBits();
+            return _buffer.Slice(0, _position);
+        }
+
+        /// <summary>
+        /// Copies the written data to a new byte array.
+        /// </summary>
+        public byte[] ToArray()
+        {
+            return GetWrittenSpan().ToArray();
+        }
+    }
+}

--- a/Framework/IO/Zlib/compress.cs
+++ b/Framework/IO/Zlib/compress.cs
@@ -26,7 +26,7 @@ namespace Framework.IO
     {
         public static byte[] Compress(byte[] data)
         {
-            ByteBuffer buffer = new ByteBuffer();
+            using ByteBuffer buffer = new ByteBuffer();
             buffer.WriteUInt8(0x78);
             buffer.WriteUInt8(0x9c);
 

--- a/Framework/Logging/Log.cs
+++ b/Framework/Logging/Log.cs
@@ -17,7 +17,9 @@ namespace Framework.Logging
         Debug,
         Error,
         Warn,
-        Storage
+        Storage,
+        SpanMiss,
+        SpanStats
     }
 
     public enum LogNetDir // Network direction
@@ -32,12 +34,14 @@ namespace Framework.Logging
     {
         static Dictionary<LogType, (ConsoleColor Color, string Type)> LogToColorType = new()
         {
-            { LogType.Debug,    (ConsoleColor.DarkBlue, " Debug   ") },
-            { LogType.Server,   (ConsoleColor.Blue,     " Server  ") },
-            { LogType.Network,  (ConsoleColor.Green,    " Network ") },
-            { LogType.Error,    (ConsoleColor.Red,      " Error   ") },
-            { LogType.Warn,     (ConsoleColor.Yellow,   " Warning ") },
-            { LogType.Storage,  (ConsoleColor.Cyan,     " Storage ") },
+            { LogType.Debug,     (ConsoleColor.DarkBlue,  " Debug   ") },
+            { LogType.Server,    (ConsoleColor.Blue,      " Server  ") },
+            { LogType.Network,   (ConsoleColor.Green,     " Network ") },
+            { LogType.Error,     (ConsoleColor.Red,       " Error   ") },
+            { LogType.Warn,      (ConsoleColor.Yellow,    " Warning ") },
+            { LogType.Storage,   (ConsoleColor.Cyan,      " Storage ") },
+            { LogType.SpanMiss,  (ConsoleColor.Magenta,   " SpanMiss") },
+            { LogType.SpanStats, (ConsoleColor.DarkGreen, "SpanStats") },
         }; 
 
         static BlockingCollection<(LogType Type, string Message)> logQueue = new();
@@ -45,6 +49,7 @@ namespace Framework.Logging
         public static bool IsLogging => _logOutputThread != null && !logQueue.IsCompleted;
 
         public static bool DebugLogEnabled { get; set; }
+        public static bool SpanStatsEnabled { get; set; }
         
         /// <summary>
         /// Start the logging Thread and take logs out of the <see cref="BlockingCollection{T}"/>
@@ -69,6 +74,8 @@ namespace Framework.Logging
         private static void PrintInternalDirectly(LogType type, string text)
         {
             if (type == LogType.Debug && !DebugLogEnabled)
+                return;
+            if (type == LogType.SpanStats && !SpanStatsEnabled)
                 return;
 #if DEBUG
             Console.Write($"{DateTime.Now:HH:mm:ss.ff} | "); // This function is directly called in DEBUG, so our timesstamps can also be a more precise

--- a/HermesProxy.Benchmarks/SpanPacketBenchmarks.cs
+++ b/HermesProxy.Benchmarks/SpanPacketBenchmarks.cs
@@ -1,0 +1,210 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using Framework.IO;
+using Framework.GameMath;
+
+namespace HermesProxy.Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class SpanPacketWriterBenchmarks
+{
+    private byte[] _buffer = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _buffer = new byte[256];
+    }
+
+    // ========== Simple Write: Int64 ==========
+
+    [Benchmark(Baseline = true)]
+    public byte[] WriteInt64_ByteBuffer()
+    {
+        using var buffer = new ByteBuffer();
+        buffer.WriteInt64(0x123456789ABCDEF0);
+        return buffer.GetData();
+    }
+
+    [Benchmark]
+    public int WriteInt64_SpanWriter()
+    {
+        var writer = new SpanPacketWriter(_buffer);
+        writer.WriteInt64(0x123456789ABCDEF0);
+        return writer.Position;
+    }
+
+    // ========== Vector3 Write ==========
+
+    [Benchmark]
+    public byte[] WriteVector3_ByteBuffer()
+    {
+        using var buffer = new ByteBuffer();
+        buffer.WriteVector3(new Vector3(100.5f, 200.5f, 300.5f));
+        return buffer.GetData();
+    }
+
+    [Benchmark]
+    public int WriteVector3_SpanWriter()
+    {
+        var writer = new SpanPacketWriter(_buffer);
+        writer.WriteVector3(new Vector3(100.5f, 200.5f, 300.5f));
+        return writer.Position;
+    }
+
+    // ========== Mixed Write (simulates small packet) ==========
+
+    [Benchmark]
+    public byte[] WriteMixed_ByteBuffer()
+    {
+        using var buffer = new ByteBuffer();
+        buffer.WriteUInt32(0xDEADBEEF);
+        buffer.WriteVector3(new Vector3(1.0f, 2.0f, 3.0f));
+        buffer.WriteBit(true);
+        buffer.WriteBits(0b101, 3);
+        buffer.FlushBits();
+        buffer.WriteUInt8(0xFF);
+        return buffer.GetData();
+    }
+
+    [Benchmark]
+    public int WriteMixed_SpanWriter()
+    {
+        var writer = new SpanPacketWriter(_buffer);
+        writer.WriteUInt32(0xDEADBEEF);
+        writer.WriteVector3(new Vector3(1.0f, 2.0f, 3.0f));
+        writer.WriteBit(true);
+        writer.WriteBits(0b101, 3);
+        writer.FlushBits();
+        writer.WriteUInt8(0xFF);
+        return writer.Position;
+    }
+}
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class SpanPacketReaderBenchmarks
+{
+    private byte[] _int64Data = null!;
+    private byte[] _vector3Data = null!;
+    private byte[] _cstringData = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Prepare test data using ByteBuffer
+        using var intBuffer = new ByteBuffer();
+        intBuffer.WriteInt64(0x123456789ABCDEF0);
+        _int64Data = intBuffer.GetData();
+
+        using var vecBuffer = new ByteBuffer();
+        vecBuffer.WriteVector3(new Vector3(100.5f, 200.5f, 300.5f));
+        _vector3Data = vecBuffer.GetData();
+
+        using var strBuffer = new ByteBuffer();
+        strBuffer.WriteCString("TestPlayerName");
+        _cstringData = strBuffer.GetData();
+    }
+
+    // ========== Read Int64 ==========
+
+    [Benchmark(Baseline = true)]
+    public long ReadInt64_ByteBuffer()
+    {
+        var buffer = new ByteBuffer(_int64Data);
+        return buffer.ReadInt64();
+    }
+
+    [Benchmark]
+    public long ReadInt64_SpanReader()
+    {
+        var reader = new SpanPacketReader(_int64Data);
+        return reader.ReadInt64();
+    }
+
+    // ========== Read Vector3 ==========
+
+    [Benchmark]
+    public Vector3 ReadVector3_ByteBuffer()
+    {
+        var buffer = new ByteBuffer(_vector3Data);
+        return buffer.ReadVector3();
+    }
+
+    [Benchmark]
+    public Vector3 ReadVector3_SpanReader()
+    {
+        var reader = new SpanPacketReader(_vector3Data);
+        return reader.ReadVector3();
+    }
+
+    // ========== Read CString ==========
+
+    [Benchmark]
+    public string ReadCString_ByteBuffer()
+    {
+        var buffer = new ByteBuffer(_cstringData);
+        return buffer.ReadCString();
+    }
+
+    [Benchmark]
+    public string ReadCString_SpanReader()
+    {
+        var reader = new SpanPacketReader(_cstringData);
+        return reader.ReadCString();
+    }
+}
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class PilotPacketBenchmarks
+{
+    private byte[] _buffer = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _buffer = new byte[64];
+    }
+
+    // ========== ServerTimeOffset (8 bytes) ==========
+
+    [Benchmark(Baseline = true)]
+    public byte[] ServerTimeOffset_ByteBuffer()
+    {
+        using var buffer = new ByteBuffer();
+        buffer.WriteInt64(1234567890123456789L);
+        return buffer.GetData();
+    }
+
+    [Benchmark]
+    public int ServerTimeOffset_SpanWriter()
+    {
+        var writer = new SpanPacketWriter(_buffer);
+        writer.WriteInt64(1234567890123456789L);
+        return writer.Position;
+    }
+
+    // ========== BindPointUpdate (20 bytes) ==========
+
+    [Benchmark]
+    public byte[] BindPointUpdate_ByteBuffer()
+    {
+        using var buffer = new ByteBuffer();
+        buffer.WriteVector3(new Vector3(100.5f, 200.5f, 300.5f));
+        buffer.WriteUInt32(0); // MapID
+        buffer.WriteUInt32(1); // AreaID
+        return buffer.GetData();
+    }
+
+    [Benchmark]
+    public int BindPointUpdate_SpanWriter()
+    {
+        var writer = new SpanPacketWriter(_buffer);
+        writer.WriteVector3(new Vector3(100.5f, 200.5f, 300.5f));
+        writer.WriteUInt32(0); // MapID
+        writer.WriteUInt32(1); // AreaID
+        return writer.Position;
+    }
+}

--- a/HermesProxy.Tests/Framework/SpanPacketTests.cs
+++ b/HermesProxy.Tests/Framework/SpanPacketTests.cs
@@ -1,0 +1,747 @@
+using Framework.IO;
+using Framework.GameMath;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using Xunit;
+using System;
+using HermesProxy.World.Server.Packets;
+
+namespace HermesProxy.Tests.Framework
+{
+    public class SpanPacketWriterTests
+    {
+        [Fact]
+        public void WriteInt8_MatchesByteBuffer()
+        {
+            sbyte testValue = -42;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteInt8(testValue);
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[1];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteInt8(testValue);
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteUInt8_MatchesByteBuffer()
+        {
+            byte testValue = 0xAB;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteUInt8(testValue);
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[1];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteUInt8(testValue);
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteInt16_MatchesByteBuffer()
+        {
+            short testValue = -12345;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteInt16(testValue);
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[2];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteInt16(testValue);
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteUInt16_MatchesByteBuffer()
+        {
+            ushort testValue = 0xABCD;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteUInt16(testValue);
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[2];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteUInt16(testValue);
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteInt32_MatchesByteBuffer()
+        {
+            int testValue = -123456789;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteInt32(testValue);
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[4];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteInt32(testValue);
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteUInt32_MatchesByteBuffer()
+        {
+            uint testValue = 0xDEADBEEF;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteUInt32(testValue);
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[4];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteUInt32(testValue);
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteInt64_MatchesByteBuffer()
+        {
+            long testValue = -0x123456789ABCDEF0;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteInt64(testValue);
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[8];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteInt64(testValue);
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteUInt64_MatchesByteBuffer()
+        {
+            ulong testValue = 0xDEADBEEFCAFEBABE;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteUInt64(testValue);
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[8];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteUInt64(testValue);
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteFloat_MatchesByteBuffer()
+        {
+            float testValue = 3.14159f;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteFloat(testValue);
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[4];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteFloat(testValue);
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteDouble_MatchesByteBuffer()
+        {
+            double testValue = 3.141592653589793;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteDouble(testValue);
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[8];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteDouble(testValue);
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteVector3_MatchesByteBuffer()
+        {
+            var testValue = new Vector3(1.5f, 2.5f, 3.5f);
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteVector3(testValue);
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[12];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteVector3(testValue);
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteBit_MatchesByteBuffer()
+        {
+            using var buffer = new ByteBuffer();
+            buffer.WriteBit(true);
+            buffer.WriteBit(false);
+            buffer.WriteBit(true);
+            buffer.WriteBit(true);
+            buffer.WriteBit(false);
+            buffer.WriteBit(false);
+            buffer.WriteBit(true);
+            buffer.WriteBit(false);
+            buffer.FlushBits();
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[1];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteBit(true);
+            writer.WriteBit(false);
+            writer.WriteBit(true);
+            writer.WriteBit(true);
+            writer.WriteBit(false);
+            writer.WriteBit(false);
+            writer.WriteBit(true);
+            writer.WriteBit(false);
+            writer.FlushBits();
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteBits_MatchesByteBuffer()
+        {
+            uint testValue = 0b101101;
+            int bitCount = 6;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteBits(testValue, bitCount);
+            buffer.FlushBits();
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[1];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteBits(testValue, bitCount);
+            writer.FlushBits();
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void WriteMixed_MatchesByteBuffer()
+        {
+            // Test a realistic packet: int32, float, bits, uint8
+            int intVal = 42;
+            float floatVal = 1.5f;
+            uint bits = 0b110;
+            byte byteVal = 0xFF;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteInt32(intVal);
+            buffer.WriteFloat(floatVal);
+            buffer.WriteBits(bits, 3);
+            buffer.FlushBits();
+            buffer.WriteUInt8(byteVal);
+            byte[] expected = buffer.GetData();
+
+            Span<byte> span = stackalloc byte[10];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteInt32(intVal);
+            writer.WriteFloat(floatVal);
+            writer.WriteBits(bits, 3);
+            writer.FlushBits();
+            writer.WriteUInt8(byteVal);
+
+            Assert.Equal(expected, writer.ToArray());
+        }
+
+        [Fact]
+        public void Position_TracksCorrectly()
+        {
+            Span<byte> span = stackalloc byte[32];
+            var writer = new SpanPacketWriter(span);
+
+            Assert.Equal(0, writer.Position);
+
+            writer.WriteUInt32(1);
+            Assert.Equal(4, writer.Position);
+
+            writer.WriteUInt64(2);
+            Assert.Equal(12, writer.Position);
+
+            writer.WriteUInt8(3);
+            Assert.Equal(13, writer.Position);
+        }
+    }
+
+    public class SpanPacketReaderTests
+    {
+        [Fact]
+        public void ReadInt8_MatchesByteBuffer()
+        {
+            sbyte testValue = -42;
+
+            using var writeBuffer = new ByteBuffer();
+            writeBuffer.WriteInt8(testValue);
+            byte[] data = writeBuffer.GetData();
+
+            var byteBufferReader = new ByteBuffer(data);
+            sbyte expected = byteBufferReader.ReadInt8();
+
+            var spanReader = new SpanPacketReader(data);
+            sbyte actual = spanReader.ReadInt8();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReadUInt32_MatchesByteBuffer()
+        {
+            uint testValue = 0xDEADBEEF;
+
+            using var writeBuffer = new ByteBuffer();
+            writeBuffer.WriteUInt32(testValue);
+            byte[] data = writeBuffer.GetData();
+
+            var byteBufferReader = new ByteBuffer(data);
+            uint expected = byteBufferReader.ReadUInt32();
+
+            var spanReader = new SpanPacketReader(data);
+            uint actual = spanReader.ReadUInt32();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReadInt64_MatchesByteBuffer()
+        {
+            long testValue = -0x123456789ABCDEF0;
+
+            using var writeBuffer = new ByteBuffer();
+            writeBuffer.WriteInt64(testValue);
+            byte[] data = writeBuffer.GetData();
+
+            var byteBufferReader = new ByteBuffer(data);
+            long expected = byteBufferReader.ReadInt64();
+
+            var spanReader = new SpanPacketReader(data);
+            long actual = spanReader.ReadInt64();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReadFloat_MatchesByteBuffer()
+        {
+            float testValue = 3.14159f;
+
+            using var writeBuffer = new ByteBuffer();
+            writeBuffer.WriteFloat(testValue);
+            byte[] data = writeBuffer.GetData();
+
+            var byteBufferReader = new ByteBuffer(data);
+            float expected = byteBufferReader.ReadFloat();
+
+            var spanReader = new SpanPacketReader(data);
+            float actual = spanReader.ReadFloat();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReadVector3_MatchesByteBuffer()
+        {
+            var testValue = new Vector3(1.5f, 2.5f, 3.5f);
+
+            using var writeBuffer = new ByteBuffer();
+            writeBuffer.WriteVector3(testValue);
+            byte[] data = writeBuffer.GetData();
+
+            var byteBufferReader = new ByteBuffer(data);
+            var expected = byteBufferReader.ReadVector3();
+
+            var spanReader = new SpanPacketReader(data);
+            var actual = spanReader.ReadVector3();
+
+            Assert.Equal(expected.X, actual.X);
+            Assert.Equal(expected.Y, actual.Y);
+            Assert.Equal(expected.Z, actual.Z);
+        }
+
+        [Fact]
+        public void ReadBit_MatchesByteBuffer()
+        {
+            using var writeBuffer = new ByteBuffer();
+            writeBuffer.WriteBit(true);
+            writeBuffer.WriteBit(false);
+            writeBuffer.WriteBit(true);
+            writeBuffer.WriteBit(true);
+            writeBuffer.WriteBit(false);
+            writeBuffer.WriteBit(false);
+            writeBuffer.WriteBit(true);
+            writeBuffer.WriteBit(false);
+            writeBuffer.FlushBits();
+            byte[] data = writeBuffer.GetData();
+
+            var byteBufferReader = new ByteBuffer(data);
+            var spanReader = new SpanPacketReader(data);
+
+            for (int i = 0; i < 8; i++)
+            {
+                Assert.Equal(byteBufferReader.ReadBit(), spanReader.ReadBit());
+            }
+        }
+
+        [Fact]
+        public void ReadBits_MatchesByteBuffer()
+        {
+            uint testValue = 0b101101;
+            int bitCount = 6;
+
+            using var writeBuffer = new ByteBuffer();
+            writeBuffer.WriteBits(testValue, bitCount);
+            writeBuffer.FlushBits();
+            byte[] data = writeBuffer.GetData();
+
+            var byteBufferReader = new ByteBuffer(data);
+            uint expected = byteBufferReader.ReadBits<uint>(bitCount);
+
+            var spanReader = new SpanPacketReader(data);
+            uint actual = spanReader.ReadBits<uint>(bitCount);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReadCString_MatchesByteBuffer()
+        {
+            string testValue = "Hello, World!";
+
+            using var writeBuffer = new ByteBuffer();
+            writeBuffer.WriteCString(testValue);
+            byte[] data = writeBuffer.GetData();
+
+            var byteBufferReader = new ByteBuffer(data);
+            string expected = byteBufferReader.ReadCString();
+
+            var spanReader = new SpanPacketReader(data);
+            string actual = spanReader.ReadCString();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReadMixed_MatchesByteBuffer()
+        {
+            int intVal = 42;
+            float floatVal = 1.5f;
+            uint bits = 0b110;
+            byte byteVal = 0xFF;
+
+            using var writeBuffer = new ByteBuffer();
+            writeBuffer.WriteInt32(intVal);
+            writeBuffer.WriteFloat(floatVal);
+            writeBuffer.WriteBits(bits, 3);
+            writeBuffer.FlushBits();
+            writeBuffer.WriteUInt8(byteVal);
+            byte[] data = writeBuffer.GetData();
+
+            var byteBufferReader = new ByteBuffer(data);
+            var spanReader = new SpanPacketReader(data);
+
+            Assert.Equal(byteBufferReader.ReadInt32(), spanReader.ReadInt32());
+            Assert.Equal(byteBufferReader.ReadFloat(), spanReader.ReadFloat());
+            Assert.Equal(byteBufferReader.ReadBits<uint>(3), spanReader.ReadBits<uint>(3));
+            Assert.Equal(byteBufferReader.ReadUInt8(), spanReader.ReadUInt8());
+        }
+
+        [Fact]
+        public void Position_TracksCorrectly()
+        {
+            byte[] data = new byte[32];
+            var reader = new SpanPacketReader(data);
+
+            Assert.Equal(0, reader.Position);
+
+            reader.ReadUInt32();
+            Assert.Equal(4, reader.Position);
+
+            reader.ReadUInt64();
+            Assert.Equal(12, reader.Position);
+
+            reader.ReadUInt8();
+            Assert.Equal(13, reader.Position);
+        }
+
+        [Fact]
+        public void CanRead_ReturnsCorrectly()
+        {
+            byte[] data = new byte[4];
+            var reader = new SpanPacketReader(data);
+
+            Assert.True(reader.CanRead);
+            reader.ReadUInt32();
+            Assert.False(reader.CanRead);
+        }
+    }
+
+    public class SpanPacketRoundTripTests
+    {
+        [Fact]
+        public void RoundTrip_SpanWriter_ByteBufferReader()
+        {
+            // Write with SpanPacketWriter, read with ByteBuffer
+            long testValue = 0x123456789ABCDEF0;
+
+            Span<byte> span = stackalloc byte[8];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteInt64(testValue);
+
+            var reader = new ByteBuffer(writer.ToArray());
+            long result = reader.ReadInt64();
+
+            Assert.Equal(testValue, result);
+        }
+
+        [Fact]
+        public void RoundTrip_ByteBufferWriter_SpanReader()
+        {
+            // Write with ByteBuffer, read with SpanPacketReader
+            long testValue = 0x123456789ABCDEF0;
+
+            using var buffer = new ByteBuffer();
+            buffer.WriteInt64(testValue);
+            byte[] data = buffer.GetData();
+
+            var reader = new SpanPacketReader(data);
+            long result = reader.ReadInt64();
+
+            Assert.Equal(testValue, result);
+        }
+
+        [Fact]
+        public void RoundTrip_ComplexPacket()
+        {
+            // Simulate a realistic packet structure
+            uint packetId = 0x1234;
+            var position = new Vector3(100.5f, 200.5f, 300.5f);
+            bool hasExtra = true;
+            string name = "TestPlayer";
+
+            // Write with SpanPacketWriter
+            Span<byte> span = stackalloc byte[64];
+            var writer = new SpanPacketWriter(span);
+            writer.WriteUInt32(packetId);
+            writer.WriteVector3(position);
+            writer.WriteBit(hasExtra);
+            writer.FlushBits();
+            writer.WriteCString(name);
+
+            // Read back with SpanPacketReader
+            var reader = new SpanPacketReader(writer.GetWrittenSpan());
+            Assert.Equal(packetId, reader.ReadUInt32());
+
+            var readPos = reader.ReadVector3();
+            Assert.Equal(position.X, readPos.X);
+            Assert.Equal(position.Y, readPos.Y);
+            Assert.Equal(position.Z, readPos.Z);
+
+            Assert.Equal(hasExtra, reader.ReadBit());
+            reader.ResetBitPos();
+            Assert.Equal(name, reader.ReadCString());
+        }
+    }
+
+    /// <summary>
+    /// Note: Full MovementInfo comparison tests cannot run in unit tests because
+    /// WriteMovementInfoModern depends on ModernVersion which requires application-level
+    /// configuration. The Span-based implementation should be verified through integration
+    /// testing with the actual proxy.
+    ///
+    /// These tests verify that the Span-based writer produces reasonable output and
+    /// doesn't crash for various MovementInfo configurations.
+    /// </summary>
+    public class MovementInfoSpanTests
+    {
+        static MovementInfoSpanTests()
+        {
+            // Initialize required settings for ModernVersion static constructor
+            // This must run before any test that uses ModernVersion.AddedInVersion()
+            if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            {
+                global::Framework.Settings.ClientBuild = ClientVersionBuild.V9_0_1_36216;
+            }
+        }
+
+        [Fact]
+        public void WriteMovementInfoModernToSpan_Simple_ProducesOutput()
+        {
+            var moveInfo = new MovementInfo
+            {
+                Flags = 0,
+                FlagsExtra = 0,
+                FlagsExtra2 = 0,
+                MoveTime = 12345,
+                Position = new Vector3(100.5f, 200.5f, 300.5f),
+                Orientation = 1.5f,
+                SwimPitch = 0.0f,
+                SplineElevation = 0.0f,
+                HasSplineData = false
+            };
+
+            var guid = new WowGuid128(0x123456789ABCDEF0, 0xFEDCBA9876543210);
+
+            Span<byte> span = stackalloc byte[MovementInfo.MaxMovementInfoSize];
+            int bytesWritten = moveInfo.WriteMovementInfoModernToSpan(span, guid.Low, guid.High);
+
+            // Should write at least GUID + basic movement data
+            Assert.True(bytesWritten > 0);
+            Assert.True(bytesWritten <= MovementInfo.MaxMovementInfoSize);
+        }
+
+        [Fact]
+        public void WriteMovementInfoModernToSpan_WithTransport_ProducesLargerOutput()
+        {
+            var moveInfoWithoutTransport = new MovementInfo
+            {
+                Flags = 0,
+                MoveTime = 12345,
+                Position = new Vector3(100.5f, 200.5f, 300.5f),
+                Orientation = 1.5f
+            };
+
+            var moveInfoWithTransport = new MovementInfo
+            {
+                Flags = 0,
+                MoveTime = 12345,
+                Position = new Vector3(100.5f, 200.5f, 300.5f),
+                Orientation = 1.5f,
+                TransportGuid = new WowGuid128(0x1111111111111111, 0x2222222222222222),
+                TransportOffset = new Vector3(1.0f, 2.0f, 3.0f),
+                TransportOrientation = 0.5f,
+                TransportSeat = 0,
+                TransportTime = 1000
+            };
+
+            var guid = new WowGuid128(0xAAAABBBBCCCCDDDD, 0xEEEEFFFF00001111);
+
+            Span<byte> span1 = stackalloc byte[MovementInfo.MaxMovementInfoSize];
+            int bytesWithoutTransport = moveInfoWithoutTransport.WriteMovementInfoModernToSpan(span1, guid.Low, guid.High);
+
+            Span<byte> span2 = stackalloc byte[MovementInfo.MaxMovementInfoSize];
+            int bytesWithTransport = moveInfoWithTransport.WriteMovementInfoModernToSpan(span2, guid.Low, guid.High);
+
+            // Transport data should make the packet larger
+            Assert.True(bytesWithTransport > bytesWithoutTransport);
+        }
+
+        [Fact]
+        public void WriteMovementInfoModernToSpan_WithFall_ProducesLargerOutput()
+        {
+            var moveInfoWithoutFall = new MovementInfo
+            {
+                Flags = 0,
+                MoveTime = 99999,
+                Position = new Vector3(10.0f, 20.0f, 30.0f),
+                Orientation = 0.0f
+            };
+
+            var moveInfoWithFall = new MovementInfo
+            {
+                Flags = (uint)MovementFlagModern.Falling,
+                MoveTime = 99999,
+                Position = new Vector3(10.0f, 20.0f, 30.0f),
+                Orientation = 0.0f,
+                FallTime = 500,
+                JumpVerticalSpeed = 5.0f,
+                JumpSinAngle = 0.707f,
+                JumpCosAngle = 0.707f,
+                JumpHorizontalSpeed = 10.0f
+            };
+
+            var guid = new WowGuid128(0x0000000000000001, 0x0000000000000000);
+
+            Span<byte> span1 = stackalloc byte[MovementInfo.MaxMovementInfoSize];
+            int bytesWithoutFall = moveInfoWithoutFall.WriteMovementInfoModernToSpan(span1, guid.Low, guid.High);
+
+            Span<byte> span2 = stackalloc byte[MovementInfo.MaxMovementInfoSize];
+            int bytesWithFall = moveInfoWithFall.WriteMovementInfoModernToSpan(span2, guid.Low, guid.High);
+
+            // Fall data should make the packet larger
+            Assert.True(bytesWithFall > bytesWithoutFall);
+        }
+
+        [Fact]
+        public void WriteMovementInfoModernToSpan_MaxSize_IsAdequate()
+        {
+            // Create a maximally complex movement info
+            var moveInfo = new MovementInfo
+            {
+                Flags = (uint)MovementFlagModern.Falling,
+                FlagsExtra = 0xFFFFFFFF,
+                FlagsExtra2 = 0xFFFFFFFF,
+                MoveTime = 0xFFFFFFFF,
+                Position = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue),
+                Orientation = float.MaxValue,
+                SwimPitch = float.MaxValue,
+                SplineElevation = float.MaxValue,
+                HasSplineData = true,
+                TransportGuid = new WowGuid128(ulong.MaxValue, ulong.MaxValue),
+                TransportOffset = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue),
+                TransportOrientation = float.MaxValue,
+                TransportSeat = sbyte.MaxValue,
+                TransportTime = uint.MaxValue,
+                VehicleId = uint.MaxValue,
+                FallTime = uint.MaxValue,
+                JumpVerticalSpeed = float.MaxValue,
+                JumpSinAngle = float.MaxValue,
+                JumpCosAngle = float.MaxValue,
+                JumpHorizontalSpeed = float.MaxValue
+            };
+
+            var guid = new WowGuid128(ulong.MaxValue, ulong.MaxValue);
+
+            // Should not throw due to buffer overflow
+            Span<byte> span = stackalloc byte[MovementInfo.MaxMovementInfoSize];
+            int bytesWritten = moveInfo.WriteMovementInfoModernToSpan(span, guid.Low, guid.High);
+
+            Assert.True(bytesWritten > 0);
+            Assert.True(bytesWritten <= MovementInfo.MaxMovementInfoSize);
+        }
+
+        [Fact]
+        public void WriteMovementInfoModernToSpan_DifferentGuids_ProduceDifferentOutput()
+        {
+            var moveInfo = new MovementInfo
+            {
+                Flags = 0,
+                MoveTime = 12345,
+                Position = new Vector3(100.5f, 200.5f, 300.5f),
+                Orientation = 1.5f
+            };
+
+            var guid1 = new WowGuid128(0x0000000000000001, 0x0000000000000000);
+            var guid2 = new WowGuid128(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF);
+
+            Span<byte> span1 = stackalloc byte[MovementInfo.MaxMovementInfoSize];
+            int bytes1 = moveInfo.WriteMovementInfoModernToSpan(span1, guid1.Low, guid1.High);
+
+            Span<byte> span2 = stackalloc byte[MovementInfo.MaxMovementInfoSize];
+            int bytes2 = moveInfo.WriteMovementInfoModernToSpan(span2, guid2.Low, guid2.High);
+
+            // Different GUIDs should produce different output
+            // (at minimum the packed GUID bytes will differ)
+            Assert.NotEqual(span1.Slice(0, bytes1).ToArray(), span2.Slice(0, bytes2).ToArray());
+        }
+    }
+}

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -27,6 +27,7 @@ namespace Framework
         public static int InstancePort;
         public static bool DebugOutput;
         public static bool PacketsLog;
+        public static bool SpanStatsLog;
 
         public static bool LoadAndVerifyFrom(ConfigurationParser config)
         {
@@ -48,6 +49,7 @@ namespace Framework
             InstancePort = config.GetInt("InstancePort", 8086);
             DebugOutput = config.GetBoolean("DebugOutput", false);
             PacketsLog = config.GetBoolean("PacketsLog", true);
+            SpanStatsLog = config.GetBoolean("SpanStatsLog", false);
 
             return VerifyConfig();
         }

--- a/HermesProxy/Server.cs
+++ b/HermesProxy/Server.cs
@@ -81,6 +81,7 @@ namespace HermesProxy
             }
             Log.DebugLogEnabled = Settings.DebugOutput;
             Log.Print(LogType.Debug, "Debug logging enabled");
+            Log.SpanStatsEnabled = Settings.SpanStatsLog;
 
             if (!AesGcm.IsSupported)
             {

--- a/HermesProxy/World/Objects/MovementInfo.cs
+++ b/HermesProxy/World/Objects/MovementInfo.cs
@@ -468,9 +468,10 @@ namespace HermesProxy.World.Objects
 
         /// <summary>
         /// Maximum size for movement info when written with Span writer.
-        /// Includes: GUID(18) + flags(12) + times/positions(40) + bits(6) + transport(48) + inertia(34) + fall(21) + padding
+        /// Includes: GUID(18) + flags(12) + times/positions(40) + bits(6) + transport(48) + inertia(34) + fall(21) = ~179
+        /// Reduced from 256 to 192 based on actual usage data (54-75 bytes typical, theoretical max ~179)
         /// </summary>
-        public const int MaxMovementInfoSize = 256;
+        public const int MaxMovementInfoSize = 192;
 
         /// <summary>
         /// Writes movement info using SpanPacketWriter for zero-allocation hot path.

--- a/HermesProxy/World/Objects/MovementInfo.cs
+++ b/HermesProxy/World/Objects/MovementInfo.cs
@@ -1,4 +1,5 @@
 ﻿using Framework.GameMath;
+using Framework.IO;
 using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
@@ -463,6 +464,110 @@ namespace HermesProxy.World.Objects
 
             if (hasVehicleId)
                 data.WriteUInt32(moveInfo.VehicleId);
+        }
+
+        /// <summary>
+        /// Maximum size for movement info when written with Span writer.
+        /// Includes: GUID(18) + flags(12) + times/positions(40) + bits(6) + transport(48) + inertia(34) + fall(21) + padding
+        /// </summary>
+        public const int MaxMovementInfoSize = 256;
+
+        /// <summary>
+        /// Writes movement info using SpanPacketWriter for zero-allocation hot path.
+        /// </summary>
+        public int WriteMovementInfoModernToSpan(Span<byte> buffer, ulong guidLow, ulong guidHigh)
+        {
+            MovementInfo moveInfo = this;
+            bool hasFallDirection = moveInfo.Flags.HasAnyFlag(MovementFlagModern.Falling | MovementFlagModern.FallingFar);
+            bool hasFall = hasFallDirection || moveInfo.FallTime != 0;
+
+            var writer = new SpanPacketWriter(buffer);
+
+            writer.WritePackedGuid128(guidLow, guidHigh);                    // MoverGUID
+
+            if (ModernVersion.AddedInVersion(9, 2, 0, 1, 14, 1, 2, 5, 3))
+            {
+                writer.WriteUInt32(Flags);
+                writer.WriteUInt32(FlagsExtra);
+                writer.WriteUInt32(FlagsExtra2);
+            }
+
+            writer.WriteUInt32(moveInfo.MoveTime);                           // MoveTime
+            writer.WriteFloat(moveInfo.Position.X);
+            writer.WriteFloat(moveInfo.Position.Y);
+            writer.WriteFloat(moveInfo.Position.Z);
+            writer.WriteFloat(moveInfo.Orientation);
+
+            writer.WriteFloat(moveInfo.SwimPitch);                           // Pitch
+            writer.WriteFloat(moveInfo.SplineElevation);                     // StepUpStartElevation
+
+            writer.WriteUInt32(0);                                           // RemoveForcesIDs.size()
+            writer.WriteUInt32(0);                                           // MoveIndex
+
+            if (!ModernVersion.AddedInVersion(9, 2, 0, 1, 14, 1, 2, 5, 3))
+            {
+                writer.WriteBits(moveInfo.Flags, 30);
+                writer.WriteBits(moveInfo.FlagsExtra, 18);
+            }
+
+            writer.WriteBit(moveInfo.TransportGuid != default);              // HasTransport
+            writer.WriteBit(hasFall);                                        // HasFall
+            writer.WriteBit(HasSplineData);                                  // HasSpline
+            writer.WriteBit(false);                                          // HeightChangeFailed
+            writer.WriteBit(false);                                          // RemoteTimeValid
+            if (ModernVersion.AddedInVersion(9, 2, 0, 1, 14, 1, 2, 5, 3))
+                writer.WriteBit(false);                                      // HasInertia
+            writer.FlushBits();
+
+            if (moveInfo.TransportGuid != default)
+                WriteTransportInfoModernToSpan(ref writer);
+
+            // Inertia would go here if needed (9.2.0+)
+
+            if (hasFall)
+            {
+                writer.WriteUInt32(moveInfo.FallTime);                       // Time
+                writer.WriteFloat(moveInfo.JumpVerticalSpeed);               // JumpVelocity
+                writer.WriteBit(hasFallDirection);
+                writer.FlushBits();
+
+                if (hasFallDirection)
+                {
+                    writer.WriteFloat(moveInfo.JumpSinAngle);                // Direction
+                    writer.WriteFloat(moveInfo.JumpCosAngle);
+                    writer.WriteFloat(moveInfo.JumpHorizontalSpeed);         // Speed
+                }
+            }
+
+            return writer.Position;
+        }
+
+        /// <summary>
+        /// Writes transport info using SpanPacketWriter.
+        /// </summary>
+        private void WriteTransportInfoModernToSpan(ref SpanPacketWriter writer)
+        {
+            MovementInfo moveInfo = this;
+            bool hasPrevTime = false;
+            bool hasVehicleId = moveInfo.VehicleId != 0;
+
+            writer.WritePackedGuid128(moveInfo.TransportGuid.Low, moveInfo.TransportGuid.High);
+            writer.WriteFloat(moveInfo.TransportOffset.X);
+            writer.WriteFloat(moveInfo.TransportOffset.Y);
+            writer.WriteFloat(moveInfo.TransportOffset.Z);
+            writer.WriteFloat(moveInfo.TransportOrientation);
+            writer.WriteInt8(moveInfo.TransportSeat);
+            writer.WriteUInt32(moveInfo.TransportTime);
+
+            writer.WriteBit(hasPrevTime);
+            writer.WriteBit(hasVehicleId);
+            writer.FlushBits();
+
+            if (hasPrevTime)
+                writer.WriteUInt32(0); // PrevMoveTime
+
+            if (hasVehicleId)
+                writer.WriteUInt32(moveInfo.VehicleId);
         }
 
         public static void ClampOrientation(ref float orientation)

--- a/HermesProxy/World/Packet.cs
+++ b/HermesProxy/World/Packet.cs
@@ -17,7 +17,9 @@
 
 using Framework.IO;
 using Framework.Constants;
+using Framework.Logging;
 using System;
+using System.Buffers;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Client;
 using Ionic.Zlib;
@@ -121,10 +123,41 @@ namespace HermesProxy.World
             if (buffer != null)
                 return;
 
-            Write();
+            // Fast path: Use Span-based writing for packets that support it
+            if (this is ISpanWritable spanWritable)
+            {
+                byte[] pooledBuffer = ArrayPool<byte>.Shared.Rent(spanWritable.MaxSize);
+                try
+                {
+                    int bytesWritten = spanWritable.WriteToSpan(pooledBuffer);
 
-            buffer = _worldPacket.GetData();
-            _worldPacket.Dispose();
+                    // Negative return means packet exceeded MaxSize cap, fall back to standard Write()
+                    if (bytesWritten < 0)
+                    {
+                        Log.Print(LogType.SpanMiss, $"{GetType().Name} exceeded MaxSize ({spanWritable.MaxSize}), using fallback");
+                        Write();
+                        buffer = _worldPacket.GetData();
+                    }
+                    else
+                    {
+                        Log.Print(LogType.SpanStats, $"{GetType().Name}: {bytesWritten}/{spanWritable.MaxSize} bytes");
+                        buffer = new byte[bytesWritten];
+                        pooledBuffer.AsSpan(0, bytesWritten).CopyTo(buffer);
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(pooledBuffer);
+                }
+                _worldPacket.Dispose();
+            }
+            else
+            {
+                // Standard path: Use ByteBuffer-based writing
+                Write();
+                buffer = _worldPacket.GetData();
+                _worldPacket.Dispose();
+            }
         }
 
         public ConnectionType GetConnection() { return connectionType; }

--- a/HermesProxy/World/Server/Packets/ArenaPackets.cs
+++ b/HermesProxy/World/Server/Packets/ArenaPackets.cs
@@ -18,10 +18,12 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace HermesProxy.World.Server.Packets
 {
@@ -49,7 +51,7 @@ namespace HermesProxy.World.Server.Packets
         public uint TeamId;
     }
 
-    class ArenaTeamRosterResponse : ServerPacket
+    class ArenaTeamRosterResponse : ServerPacket, ISpanWritable
     {
         public ArenaTeamRosterResponse() : base(Opcode.SMSG_ARENA_TEAM_ROSTER) { }
 
@@ -71,6 +73,67 @@ namespace HermesProxy.World.Server.Packets
             }
             foreach (var member in Members)
                 member.Write(_worldPacket);
+        }
+
+        // Cap for arena team members (max 5 for 5v5, but allow some buffer)
+        private const int MaxMembers = 10;
+        // Per member: GUID(18) + bool(1) + int(4) + 2 bytes(2) + 5 uints(20) + bits(1) + name(48) + 2 floats(8) = 102 bytes max
+        private const int MaxMemberSize = 102;
+        // 8 uints(32) + count(4) + bit(1) + members
+        public int MaxSize => 32 + 4 + 1 + MaxMembers * MaxMemberSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Members.Count > MaxMembers)
+                return -1;
+
+            // Pre-validate name lengths
+            foreach (var member in Members)
+            {
+                if (Encoding.UTF8.GetByteCount(member.Name) > GameLimits.MaxPlayerNameBytes)
+                    return -1;
+            }
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(TeamId);
+            writer.WriteUInt32(TeamSize);
+            writer.WriteUInt32(TeamPlayed);
+            writer.WriteUInt32(TeamWins);
+            writer.WriteUInt32(SeasonPlayed);
+            writer.WriteUInt32(SeasonWins);
+            writer.WriteUInt32(TeamRating);
+            writer.WriteUInt32(PlayerRating);
+            writer.WriteInt32(Members.Count);
+            if (ModernVersion.AddedInClassicVersion(1, 14, 2, 2, 5, 3))
+            {
+                writer.WriteBit(UnkBit);
+                writer.FlushBits();
+            }
+            foreach (var member in Members)
+            {
+                writer.WritePackedGuid128(member.MemberGUID.Low, member.MemberGUID.High);
+                writer.WriteBool(member.Online);
+                writer.WriteInt32(member.Captain);
+                writer.WriteUInt8(member.Level);
+                writer.WriteUInt8((byte)member.ClassId);
+                writer.WriteUInt32(member.WeekGamesPlayed);
+                writer.WriteUInt32(member.WeekGamesWon);
+                writer.WriteUInt32(member.SeasonGamesPlayed);
+                writer.WriteUInt32(member.SeasonGamesWon);
+                writer.WriteUInt32(member.PersonalRating);
+
+                writer.WriteBits((uint)Encoding.UTF8.GetByteCount(member.Name), 6);
+                writer.WriteBit(member.dword60 != null);
+                writer.WriteBit(member.dword68 != null);
+                writer.FlushBits();
+
+                writer.WriteString(member.Name);
+                if (member.dword60 != null)
+                    writer.WriteFloat((float)member.dword60);
+                if (member.dword68 != null)
+                    writer.WriteFloat((float)member.dword68);
+            }
+            return writer.Position;
         }
 
         public uint TeamId;
@@ -127,7 +190,7 @@ namespace HermesProxy.World.Server.Packets
         public float? dword68;
     }
 
-    class ArenaTeamQueryResponse : ServerPacket
+    class ArenaTeamQueryResponse : ServerPacket, ISpanWritable
     {
         public ArenaTeamQueryResponse() : base(Opcode.SMSG_QUERY_ARENA_TEAM_RESPONSE) { }
 
@@ -139,6 +202,35 @@ namespace HermesProxy.World.Server.Packets
 
             if (Emblem != null)
                 Emblem.Write(_worldPacket);
+        }
+
+        // uint(4) + bit(1) + optional ArenaTeamEmblem: 7 uints(28) + bits(1) + team name(48) = 82 bytes max
+        public int MaxSize => 4 + 1 + 28 + 1 + GameLimits.MaxArenaTeamNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Emblem != null && Encoding.UTF8.GetByteCount(Emblem.TeamName) > GameLimits.MaxArenaTeamNameBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(TeamId);
+            writer.WriteBit(Emblem != null);
+            writer.FlushBits();
+
+            if (Emblem != null)
+            {
+                writer.WriteUInt32(Emblem.TeamId);
+                writer.WriteUInt32(Emblem.TeamSize);
+                writer.WriteUInt32(Emblem.BackgroundColor);
+                writer.WriteUInt32(Emblem.EmblemStyle);
+                writer.WriteUInt32(Emblem.EmblemColor);
+                writer.WriteUInt32(Emblem.BorderStyle);
+                writer.WriteUInt32(Emblem.BorderColor);
+                writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Emblem.TeamName), 7);
+                writer.FlushBits();
+                writer.WriteString(Emblem.TeamName);
+            }
+            return writer.Position;
         }
 
         public uint TeamId;
@@ -233,7 +325,7 @@ namespace HermesProxy.World.Server.Packets
         public uint TeamId;
     }
 
-    class ArenaTeamEvent : ServerPacket
+    class ArenaTeamEvent : ServerPacket, ISpanWritable
     {
         public ArenaTeamEvent() : base(Opcode.SMSG_ARENA_TEAM_EVENT) { }
 
@@ -249,13 +341,38 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(Param3);
         }
 
+        // Cap for param strings - usually player/team names
+        private const int MaxParamBytes = 64;
+        // byte(1) + 27 bits(4) + 3 strings
+        public int MaxSize => 1 + 4 + MaxParamBytes * 3;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int param1Bytes = Encoding.UTF8.GetByteCount(Param1);
+            int param2Bytes = Encoding.UTF8.GetByteCount(Param2);
+            int param3Bytes = Encoding.UTF8.GetByteCount(Param3);
+            if (param1Bytes > MaxParamBytes || param2Bytes > MaxParamBytes || param3Bytes > MaxParamBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt8((byte)Event);
+            writer.WriteBits((uint)param1Bytes, 9);
+            writer.WriteBits((uint)param2Bytes, 9);
+            writer.WriteBits((uint)param3Bytes, 9);
+            writer.FlushBits();
+            writer.WriteString(Param1);
+            writer.WriteString(Param2);
+            writer.WriteString(Param3);
+            return writer.Position;
+        }
+
         public ArenaTeamEventModern Event;
         public string Param1 = "";
         public string Param2 = "";
         public string Param3 = "";
     }
 
-    class ArenaTeamCommandResult : ServerPacket
+    class ArenaTeamCommandResult : ServerPacket, ISpanWritable
     {
         public ArenaTeamCommandResult() : base(Opcode.SMSG_ARENA_TEAM_COMMAND_RESULT) { }
 
@@ -270,13 +387,29 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(PlayerName);
         }
 
+        // MaxSize: 2 bytes + bits (7+6=13 -> 2) + team name (48) + player name (24) = 76
+        public int MaxSize => 2 + 2 + GameLimits.MaxArenaTeamNameBytes + GameLimits.MaxPlayerNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt8((byte)Action);
+            writer.WriteUInt8((byte)Error);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(TeamName), 7);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(PlayerName), 6);
+            writer.FlushBits();
+            writer.WriteString(TeamName);
+            writer.WriteString(PlayerName);
+            return writer.Position;
+        }
+
         public ArenaTeamCommandType Action;
         public ArenaTeamCommandErrorModern Error;
         public string TeamName;
         public string PlayerName;
     }
 
-    class ArenaTeamInvite : ServerPacket
+    class ArenaTeamInvite : ServerPacket, ISpanWritable
     {
         public ArenaTeamInvite() : base(Opcode.SMSG_ARENA_TEAM_INVITE) { }
 
@@ -290,6 +423,23 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
             _worldPacket.WriteString(PlayerName);
             _worldPacket.WriteString(TeamName);
+        }
+
+        // MaxSize: 2 GUIDs (36) + uint (4) + bits (6+7=13 -> 2) + player name (24) + team name (48) = 114
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 4 + 2 + GameLimits.MaxPlayerNameBytes + GameLimits.MaxArenaTeamNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(PlayerGuid.Low, PlayerGuid.High);
+            writer.WriteUInt32(PlayerVirtualAddress);
+            writer.WritePackedGuid128(TeamGuid.Low, TeamGuid.High);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(PlayerName), 6);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(TeamName), 7);
+            writer.FlushBits();
+            writer.WriteString(PlayerName);
+            writer.WriteString(TeamName);
+            return writer.Position;
         }
 
         public WowGuid128 PlayerGuid;

--- a/HermesProxy/World/Server/Packets/AuctionPackets.cs
+++ b/HermesProxy/World/Server/Packets/AuctionPackets.cs
@@ -552,7 +552,31 @@ namespace HermesProxy.World.Server.Packets
         public ItemInstance Item = new ItemInstance();
     }
 
-    class AuctionClosedNotification : ServerPacket
+    internal static class AuctionPacketHelpers
+    {
+        // AuctionOwnerNotification: uint(4) + ulong(8) + ItemInstance
+        public const int AuctionOwnerNotificationMaxSize = 12 + ItemPacketHelpers.ItemInstanceMaxSize;
+
+        // AuctionBidderNotification: 2 uints(8) + PackedGuid128(18) + ItemInstance
+        public const int AuctionBidderNotificationMaxSize = 8 + PackedGuidHelper.MaxPackedGuid128Size + ItemPacketHelpers.ItemInstanceMaxSize;
+
+        public static bool WriteAuctionOwnerNotification(ref SpanPacketWriter writer, AuctionOwnerNotification info)
+        {
+            writer.WriteUInt32(info.AuctionID);
+            writer.WriteUInt64(info.BidAmount);
+            return ItemPacketHelpers.WriteItemInstance(ref writer, info.Item);
+        }
+
+        public static bool WriteAuctionBidderNotification(ref SpanPacketWriter writer, AuctionBidderNotification info)
+        {
+            writer.WriteUInt32(info.Command);
+            writer.WriteUInt32(info.AuctionID);
+            writer.WritePackedGuid128(info.Bidder.Low, info.Bidder.High);
+            return ItemPacketHelpers.WriteItemInstance(ref writer, info.Item);
+        }
+    }
+
+    class AuctionClosedNotification : ServerPacket, ISpanWritable
     {
         public AuctionClosedNotification() : base(Opcode.SMSG_AUCTION_CLOSED_NOTIFICATION) { }
 
@@ -564,12 +588,26 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        // AuctionOwnerNotification + float(4) + bit(1)
+        public int MaxSize => AuctionPacketHelpers.AuctionOwnerNotificationMaxSize + 5;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            if (!AuctionPacketHelpers.WriteAuctionOwnerNotification(ref writer, Info))
+                return -1;
+            writer.WriteFloat(ProceedsMailDelay);
+            writer.WriteBit(Sold);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public AuctionOwnerNotification Info;
         public float ProceedsMailDelay = 3600;
         public bool Sold = true;
     }
 
-    class AuctionOwnerBidNotification : ServerPacket
+    class AuctionOwnerBidNotification : ServerPacket, ISpanWritable
     {
         public AuctionOwnerBidNotification() : base(Opcode.SMSG_AUCTION_OWNER_BID_NOTIFICATION) { }
 
@@ -578,6 +616,19 @@ namespace HermesProxy.World.Server.Packets
             Info.Write(_worldPacket);
             _worldPacket.WriteUInt64(MinIncrement);
             _worldPacket.WritePackedGuid128(Bidder);
+        }
+
+        // AuctionOwnerNotification + ulong(8) + PackedGuid128(18)
+        public int MaxSize => AuctionPacketHelpers.AuctionOwnerNotificationMaxSize + 8 + PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            if (!AuctionPacketHelpers.WriteAuctionOwnerNotification(ref writer, Info))
+                return -1;
+            writer.WriteUInt64(MinIncrement);
+            writer.WritePackedGuid128(Bidder.Low, Bidder.High);
+            return writer.Position;
         }
 
         public AuctionOwnerNotification Info;
@@ -601,7 +652,7 @@ namespace HermesProxy.World.Server.Packets
         public ItemInstance Item = new ItemInstance();
     }
 
-    class AuctionWonNotification : ServerPacket
+    class AuctionWonNotification : ServerPacket, ISpanWritable
     {
         public AuctionWonNotification() : base(Opcode.SMSG_AUCTION_WON_NOTIFICATION) { }
 
@@ -610,10 +661,20 @@ namespace HermesProxy.World.Server.Packets
             Info.Write(_worldPacket);
         }
 
+        public int MaxSize => AuctionPacketHelpers.AuctionBidderNotificationMaxSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            if (!AuctionPacketHelpers.WriteAuctionBidderNotification(ref writer, Info))
+                return -1;
+            return writer.Position;
+        }
+
         public AuctionBidderNotification Info;
     }
 
-    class AuctionOutbidNotification : ServerPacket
+    class AuctionOutbidNotification : ServerPacket, ISpanWritable
     {
         public AuctionOutbidNotification() : base(Opcode.SMSG_AUCTION_OUTBID_NOTIFICATION) { }
 
@@ -622,6 +683,19 @@ namespace HermesProxy.World.Server.Packets
             Info.Write(_worldPacket);
             _worldPacket.WriteUInt64(BidAmount);
             _worldPacket.WriteUInt64(MinIncrement);
+        }
+
+        // AuctionBidderNotification + 2 ulongs(16)
+        public int MaxSize => AuctionPacketHelpers.AuctionBidderNotificationMaxSize + 16;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            if (!AuctionPacketHelpers.WriteAuctionBidderNotification(ref writer, Info))
+                return -1;
+            writer.WriteUInt64(BidAmount);
+            writer.WriteUInt64(MinIncrement);
+            return writer.Position;
         }
 
         public AuctionBidderNotification Info;

--- a/HermesProxy/World/Server/Packets/AuctionPackets.cs
+++ b/HermesProxy/World/Server/Packets/AuctionPackets.cs
@@ -16,16 +16,17 @@
  */
 
 
+using System;
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
-using System;
 using System.Collections.Generic;
 
 namespace HermesProxy.World.Server.Packets
 {
-    class AuctionHelloResponse : ServerPacket
+    class AuctionHelloResponse : ServerPacket, ISpanWritable
     {
         public AuctionHelloResponse() : base(Opcode.SMSG_AUCTION_HELLO_RESPONSE) { }
 
@@ -36,6 +37,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteBit(OpenForBusiness);
             _worldPacket.FlushBits();
         }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 5; // GUID + uint + bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            writer.WriteUInt32(AuctionHouseID);
+            writer.WriteBit(OpenForBusiness);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public WowGuid128 Guid;
         public uint AuctionHouseID;
         public bool OpenForBusiness = true;
@@ -481,7 +495,7 @@ namespace HermesProxy.World.Server.Packets
         }
     }
 
-    class AuctionCommandResult : ServerPacket
+    class AuctionCommandResult : ServerPacket, ISpanWritable
     {
         public AuctionCommandResult() : base(Opcode.SMSG_AUCTION_COMMAND_RESULT) { }
 
@@ -495,6 +509,23 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt64(MinIncrement);
             _worldPacket.WriteUInt64(Money);
             _worldPacket.WriteUInt32(DesiredDelay);
+        }
+
+        // 4 ints(16) + GUID(18) + 2 ulongs(16) + uint(4) = 54
+        public int MaxSize => 16 + PackedGuidHelper.MaxPackedGuid128Size + 16 + 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(AuctionID);
+            writer.WriteInt32((int)Command);
+            writer.WriteInt32((int)ErrorCode);
+            writer.WriteInt32((int)BagResult);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            writer.WriteUInt64(MinIncrement);
+            writer.WriteUInt64(Money);
+            writer.WriteUInt32(DesiredDelay);
+            return writer.Position;
         }
 
         public uint AuctionID;                              //< the id of the auction that triggered this notification

--- a/HermesProxy/World/Server/Packets/AuthenticationPackets.cs
+++ b/HermesProxy/World/Server/Packets/AuthenticationPackets.cs
@@ -40,7 +40,7 @@ namespace HermesProxy.World.Server.Packets
         public uint Latency;
     }
 
-    class Pong : ServerPacket
+    class Pong : ServerPacket, ISpanWritable
     {
         public Pong(uint serial) : base(Opcode.SMSG_PONG)
         {
@@ -52,10 +52,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(Serial);
         }
 
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(Serial);
+            return writer.Position;
+        }
+
         uint Serial;
     }
 
-    class AuthChallenge : ServerPacket
+    class AuthChallenge : ServerPacket, ISpanWritable
     {
         public AuthChallenge() : base(Opcode.SMSG_AUTH_CHALLENGE) { }
 
@@ -64,6 +73,18 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteBytes(DosChallenge);
             _worldPacket.WriteBytes(Challenge);
             _worldPacket.WriteUInt8(DosZeroBits);
+        }
+
+        // Fixed size: DosChallenge(32) + Challenge(16) + byte(1) = 49
+        public int MaxSize => 32 + 16 + 1;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBytes(DosChallenge);
+            writer.WriteBytes(Challenge);
+            writer.WriteUInt8(DosZeroBits);
+            return writer.Position;
         }
 
         public byte[] Challenge = new byte[16];
@@ -282,7 +303,7 @@ namespace HermesProxy.World.Server.Packets
         }
     }
 
-    class WaitQueueUpdate : ServerPacket
+    class WaitQueueUpdate : ServerPacket, ISpanWritable
     {
         public WaitQueueUpdate() : base(Opcode.SMSG_WAIT_QUEUE_UPDATE) { }
 
@@ -291,14 +312,31 @@ namespace HermesProxy.World.Server.Packets
             WaitInfo.Write(_worldPacket);
         }
 
+        // AuthWaitInfo: 2 uints(8) + 1 bit(1) = 9 bytes
+        public int MaxSize => 9;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(WaitInfo.WaitCount);
+            writer.WriteUInt32(WaitInfo.WaitTime);
+            writer.WriteBit(WaitInfo.HasFCM);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public AuthWaitInfo WaitInfo = new AuthWaitInfo();
     }
 
-    class WaitQueueFinish : ServerPacket
+    class WaitQueueFinish : ServerPacket, ISpanWritable
     {
         public WaitQueueFinish() : base(Opcode.SMSG_WAIT_QUEUE_FINISH) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
     class ConnectTo : ServerPacket
@@ -390,11 +428,15 @@ namespace HermesProxy.World.Server.Packets
         public byte[] Digest = new byte[24];
     }
 
-    class ResumeComms : ServerPacket
+    class ResumeComms : ServerPacket, ISpanWritable
     {
         public ResumeComms(ConnectionType connection) : base(Opcode.SMSG_RESUME_COMMS, connection) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
     class ConnectToFailed : ClientPacket

--- a/HermesProxy/World/Server/Packets/BattleGroundPackets.cs
+++ b/HermesProxy/World/Server/Packets/BattleGroundPackets.cs
@@ -18,6 +18,7 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
@@ -25,7 +26,7 @@ using System.Collections.Generic;
 
 namespace HermesProxy.World.Server.Packets
 {
-    class BattlefieldList : ServerPacket
+    class BattlefieldList : ServerPacket, ISpanWritable
     {
         public BattlefieldList() : base(Opcode.SMSG_BATTLEFIELD_LIST) { }
 
@@ -44,6 +45,33 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteBit(PvpAnywhere);
             _worldPacket.WriteBit(HasRandomWinToday);
             _worldPacket.FlushBits();
+        }
+
+        // Cap for battlefield instances - rarely more than a few
+        private const int MaxInstances = 10;
+        // GUID(18) + int + uint + 2 bytes + count(4) + instances(4 each) + 1 byte bits
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4 + 4 + 2 + 4 + MaxInstances * 4 + 1;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (BattlefieldInstances.Count > MaxInstances)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(BattlemasterGuid.Low, BattlemasterGuid.High);
+            writer.WriteInt32(Verification);
+            writer.WriteUInt32(BattlemasterListID);
+            writer.WriteUInt8(MinLevel);
+            writer.WriteUInt8(MaxLevel);
+            writer.WriteInt32(BattlefieldInstances.Count);
+
+            foreach (var field in BattlefieldInstances)
+                writer.WriteInt32(field);
+
+            writer.WriteBit(PvpAnywhere);
+            writer.WriteBit(HasRandomWinToday);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public WowGuid128 BattlemasterGuid;
@@ -83,7 +111,7 @@ namespace HermesProxy.World.Server.Packets
         public bool JoinAsGroup;
     }
 
-    public class BattlefieldStatusNeedConfirmation : ServerPacket
+    public class BattlefieldStatusNeedConfirmation : ServerPacket, ISpanWritable
     {
         public BattlefieldStatusNeedConfirmation() : base(Opcode.SMSG_BATTLEFIELD_STATUS_NEED_CONFIRMATION) { }
 
@@ -95,13 +123,56 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt8(Role);
         }
 
+        // MaxSize: BattlefieldStatusHeader + 2 uints(8) + byte(1)
+        // BattlefieldStatusHeader: RideTicket(34) + opt byte(1) + int(4) + 3 bytes(3) + uint(4) + max 4 bgIds(32) + bits(2 -> 1) = 79
+        private const int MaxBattlefieldIds = 4;
+        private const int HeaderSize = 34 + 1 + 4 + 3 + 4 + MaxBattlefieldIds * 8 + 1;
+        public int MaxSize => HeaderSize + 9;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Hdr.BattlefieldListIDs.Count > MaxBattlefieldIds)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            // Inline BattlefieldStatusHeader write
+            writer.WritePackedGuid128(Hdr.Ticket.RequesterGuid.Low, Hdr.Ticket.RequesterGuid.High);
+            writer.WriteUInt32(Hdr.Ticket.Id);
+            writer.WriteUInt32((uint)Hdr.Ticket.Type);
+            writer.WriteInt64(Hdr.Ticket.Time);
+
+            if (ModernVersion.AddedInClassicVersion(1, 14, 3, 2, 5, 4))
+                writer.WriteUInt8(Hdr.Unk254);
+
+            writer.WriteInt32(Hdr.BattlefieldListIDs.Count);
+            writer.WriteUInt8(Hdr.RangeMin);
+            writer.WriteUInt8(Hdr.RangeMax);
+            writer.WriteUInt8(Hdr.ArenaTeamSize);
+            writer.WriteUInt32(Hdr.InstanceID);
+
+            foreach (ulong bgId in Hdr.BattlefieldListIDs)
+            {
+                ulong queueID = bgId | 0x1F10000000000000;
+                writer.WriteUInt64(queueID);
+            }
+
+            writer.WriteBit(Hdr.IsArena);
+            writer.WriteBit(Hdr.TournamentRules);
+            writer.FlushBits();
+
+            writer.WriteUInt32(Mapid);
+            writer.WriteUInt32(Timeout);
+            writer.WriteUInt8(Role);
+            return writer.Position;
+        }
+
         public BattlefieldStatusHeader Hdr = new();
         public uint Mapid;
         public uint Timeout;
         public byte Role;
     }
 
-    public class BattlefieldStatusQueued : ServerPacket
+    public class BattlefieldStatusQueued : ServerPacket, ISpanWritable
     {
         public BattlefieldStatusQueued() : base(Opcode.SMSG_BATTLEFIELD_STATUS_QUEUED) { }
 
@@ -120,6 +191,55 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        // MaxSize: BattlefieldStatusHeader(79) + 2 uints(8) + opt int(4) + 3 bits(1) = 92
+        private const int MaxBattlefieldIds = 4;
+        private const int HeaderSize = 34 + 1 + 4 + 3 + 4 + MaxBattlefieldIds * 8 + 1;
+        public int MaxSize => HeaderSize + 13;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Hdr.BattlefieldListIDs.Count > MaxBattlefieldIds)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            // Inline BattlefieldStatusHeader write
+            writer.WritePackedGuid128(Hdr.Ticket.RequesterGuid.Low, Hdr.Ticket.RequesterGuid.High);
+            writer.WriteUInt32(Hdr.Ticket.Id);
+            writer.WriteUInt32((uint)Hdr.Ticket.Type);
+            writer.WriteInt64(Hdr.Ticket.Time);
+
+            if (ModernVersion.AddedInClassicVersion(1, 14, 3, 2, 5, 4))
+                writer.WriteUInt8(Hdr.Unk254);
+
+            writer.WriteInt32(Hdr.BattlefieldListIDs.Count);
+            writer.WriteUInt8(Hdr.RangeMin);
+            writer.WriteUInt8(Hdr.RangeMax);
+            writer.WriteUInt8(Hdr.ArenaTeamSize);
+            writer.WriteUInt32(Hdr.InstanceID);
+
+            foreach (ulong bgId in Hdr.BattlefieldListIDs)
+            {
+                ulong queueID = bgId | 0x1F10000000000000;
+                writer.WriteUInt64(queueID);
+            }
+
+            writer.WriteBit(Hdr.IsArena);
+            writer.WriteBit(Hdr.TournamentRules);
+            writer.FlushBits();
+
+            writer.WriteUInt32(AverageWaitTime);
+            writer.WriteUInt32(WaitTime);
+
+            if (ModernVersion.AddedInVersion(9, 2, 0, 1, 14, 3, 2, 5, 4))
+                writer.WriteInt32(Unk254);
+
+            writer.WriteBit(AsGroup);
+            writer.WriteBit(EligibleForMatchmaking);
+            writer.WriteBit(SuspendedQueue);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public BattlefieldStatusHeader Hdr = new();
         public uint AverageWaitTime;
         public uint WaitTime;
@@ -129,7 +249,7 @@ namespace HermesProxy.World.Server.Packets
         public bool SuspendedQueue;
     }
 
-    public class BattlefieldStatusFailed : ServerPacket
+    public class BattlefieldStatusFailed : ServerPacket, ISpanWritable
     {
         public BattlefieldStatusFailed() : base(Opcode.SMSG_BATTLEFIELD_STATUS_FAILED) { }
 
@@ -141,6 +261,26 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt64(queueID);
             _worldPacket.WriteInt32(Reason);
             _worldPacket.WritePackedGuid128(ClientID);
+        }
+
+        // RideTicket: GUID(18) + uint(4) + uint(4) + long(8) = 34
+        // Rest: ulong(8) + int(4) + GUID(18) = 30
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 16 + 8 + 4 + PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            // Inline RideTicket write
+            writer.WritePackedGuid128(Ticket.RequesterGuid.Low, Ticket.RequesterGuid.High);
+            writer.WriteUInt32(Ticket.Id);
+            writer.WriteUInt32((uint)Ticket.Type);
+            writer.WriteInt64(Ticket.Time);
+
+            ulong queueID = BattlefieldListId | 0x1F10000000000000;
+            writer.WriteUInt64(queueID);
+            writer.WriteInt32(Reason);
+            writer.WritePackedGuid128(ClientID.Low, ClientID.High);
+            return writer.Position;
         }
 
         public RideTicket Ticket = new();
@@ -232,7 +372,7 @@ namespace HermesProxy.World.Server.Packets
         public bool AcceptedInvite;
     }
 
-    public class BattlefieldStatusActive : ServerPacket
+    public class BattlefieldStatusActive : ServerPacket, ISpanWritable
     {
         public BattlefieldStatusActive() : base(Opcode.SMSG_BATTLEFIELD_STATUS_ACTIVE) { }
 
@@ -247,6 +387,51 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        // MaxSize: BattlefieldStatusHeader(79) + 3 uints(12) + 2 bits(1) = 92
+        private const int MaxBattlefieldIds = 4;
+        private const int HeaderSize = 34 + 1 + 4 + 3 + 4 + MaxBattlefieldIds * 8 + 1;
+        public int MaxSize => HeaderSize + 13;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Hdr.BattlefieldListIDs.Count > MaxBattlefieldIds)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            // Inline BattlefieldStatusHeader write
+            writer.WritePackedGuid128(Hdr.Ticket.RequesterGuid.Low, Hdr.Ticket.RequesterGuid.High);
+            writer.WriteUInt32(Hdr.Ticket.Id);
+            writer.WriteUInt32((uint)Hdr.Ticket.Type);
+            writer.WriteInt64(Hdr.Ticket.Time);
+
+            if (ModernVersion.AddedInClassicVersion(1, 14, 3, 2, 5, 4))
+                writer.WriteUInt8(Hdr.Unk254);
+
+            writer.WriteInt32(Hdr.BattlefieldListIDs.Count);
+            writer.WriteUInt8(Hdr.RangeMin);
+            writer.WriteUInt8(Hdr.RangeMax);
+            writer.WriteUInt8(Hdr.ArenaTeamSize);
+            writer.WriteUInt32(Hdr.InstanceID);
+
+            foreach (ulong bgId in Hdr.BattlefieldListIDs)
+            {
+                ulong queueID = bgId | 0x1F10000000000000;
+                writer.WriteUInt64(queueID);
+            }
+
+            writer.WriteBit(Hdr.IsArena);
+            writer.WriteBit(Hdr.TournamentRules);
+            writer.FlushBits();
+
+            writer.WriteUInt32(Mapid);
+            writer.WriteUInt32(ShutdownTimer);
+            writer.WriteUInt32(StartTimer);
+            writer.WriteBit(ArenaFaction != 0);
+            writer.WriteBit(LeftEarly);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public BattlefieldStatusHeader Hdr = new();
         public uint Mapid;
         public uint ShutdownTimer;
@@ -255,7 +440,7 @@ namespace HermesProxy.World.Server.Packets
         public bool LeftEarly;
     }
 
-    public class BattlegroundInit : ServerPacket
+    public class BattlegroundInit : ServerPacket, ISpanWritable
     {
         public BattlegroundInit() : base(Opcode.SMSG_BATTLEGROUND_INIT) { }
 
@@ -263,6 +448,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WriteUInt32(Milliseconds);
             _worldPacket.WriteUInt16(BattlegroundPoints);
+        }
+
+        public int MaxSize => 6; // uint + ushort
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(Milliseconds);
+            writer.WriteUInt16(BattlegroundPoints);
+            return writer.Position;
         }
 
         public uint Milliseconds;
@@ -443,7 +638,7 @@ namespace HermesProxy.World.Server.Packets
         public override void Read() { }
     }
 
-    class BattlegroundPlayerPositions : ServerPacket
+    class BattlegroundPlayerPositions : ServerPacket, ISpanWritable
     {
         public BattlegroundPlayerPositions() : base(Opcode.SMSG_BATTLEGROUND_PLAYER_POSITIONS, ConnectionType.Instance) { }
 
@@ -452,6 +647,29 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(FlagCarriers.Count);
             foreach (var pos in FlagCarriers)
                 pos.Write(_worldPacket);
+        }
+
+        // Cap for flag carriers - typically 2 (one per team), max 4 for safety
+        private const int MaxFlagCarriers = 4;
+        // Each position: GUID(18) + Vector2(8) + 2 bytes = 28
+        private const int PositionSize = PackedGuidHelper.MaxPackedGuid128Size + 8 + 2;
+        public int MaxSize => 4 + MaxFlagCarriers * PositionSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (FlagCarriers.Count > MaxFlagCarriers)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(FlagCarriers.Count);
+            foreach (var pos in FlagCarriers)
+            {
+                writer.WritePackedGuid128(pos.Guid.Low, pos.Guid.High);
+                writer.WriteVector2(pos.Pos);
+                writer.WriteInt8(pos.IconID);
+                writer.WriteInt8(pos.ArenaSlot);
+            }
+            return writer.Position;
         }
 
         public List<BattlegroundPlayerPosition> FlagCarriers = new();
@@ -473,7 +691,7 @@ namespace HermesProxy.World.Server.Packets
         public sbyte ArenaSlot;
     }
 
-    class BattlegroundPlayerLeftOrJoined : ServerPacket
+    class BattlegroundPlayerLeftOrJoined : ServerPacket, ISpanWritable
     {
         public BattlegroundPlayerLeftOrJoined(Opcode opcode) : base(opcode, ConnectionType.Instance) { }
 
@@ -482,10 +700,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(Guid);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            return writer.Position;
+        }
+
         public WowGuid128 Guid;
     }
 
-    public class AreaSpiritHealerTime : ServerPacket
+    public class AreaSpiritHealerTime : ServerPacket, ISpanWritable
     {
         public AreaSpiritHealerTime() : base(Opcode.SMSG_AREA_SPIRIT_HEALER_TIME) { }
 
@@ -495,11 +722,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(TimeLeft);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4; // GUID + uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(HealerGuid.Low, HealerGuid.High);
+            writer.WriteUInt32(TimeLeft);
+            return writer.Position;
+        }
+
         public WowGuid128 HealerGuid;
         public uint TimeLeft;
     }
 
-    class PvPCredit : ServerPacket
+    class PvPCredit : ServerPacket, ISpanWritable
     {
         public PvPCredit() : base(Opcode.SMSG_PVP_CREDIT) { }
 
@@ -511,13 +748,25 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(Rank);
         }
 
+        public int MaxSize => 12 + PackedGuidHelper.MaxPackedGuid128Size; // 2 ints + GUID + uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(OriginalHonor);
+            writer.WriteInt32(Honor);
+            writer.WritePackedGuid128(Target.Low, Target.High);
+            writer.WriteUInt32(Rank);
+            return writer.Position;
+        }
+
         public int OriginalHonor;
         public int Honor;
         public WowGuid128 Target;
         public uint Rank;
     }
 
-    class PlayerSkinned : ServerPacket
+    class PlayerSkinned : ServerPacket, ISpanWritable
     {
         public PlayerSkinned() : base(Opcode.SMSG_PLAYER_SKINNED, ConnectionType.Instance) { }
 
@@ -525,6 +774,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WriteBit(FreeRepop);
             _worldPacket.FlushBits();
+        }
+
+        public int MaxSize => 1; // 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBit(FreeRepop);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public bool FreeRepop;

--- a/HermesProxy/World/Server/Packets/CharacterPackets.cs
+++ b/HermesProxy/World/Server/Packets/CharacterPackets.cs
@@ -15,12 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-using HermesProxy.World.Enums;
 using System;
 using System.Collections.Generic;
-using Framework.GameMath;
-using HermesProxy.World.Objects;
+using System.Text;
 using Framework.Constants;
+using Framework.GameMath;
+using Framework.IO;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
 
 namespace HermesProxy.World.Server.Packets
 {
@@ -328,7 +330,7 @@ namespace HermesProxy.World.Server.Packets
         public Gender Sex;
     }
 
-    public class GenerateRandomCharacterNameResult : ServerPacket
+    public class GenerateRandomCharacterNameResult : ServerPacket, ISpanWritable
     {
         public GenerateRandomCharacterNameResult() : base(Opcode.SMSG_GENERATE_RANDOM_CHARACTER_NAME_RESULT) { }
 
@@ -338,6 +340,18 @@ namespace HermesProxy.World.Server.Packets
 
             _worldPacket.WriteBits(Name.Length, 6);
             _worldPacket.WriteString(Name);
+        }
+
+        // MaxSize: bool (1) + 6 bits (1) + player name (24) = 26
+        public int MaxSize => 1 + 1 + GameLimits.MaxPlayerNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBool(Success);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Name), 6);
+            writer.WriteString(Name);
+            return writer.Position;
         }
 
         public bool Success;
@@ -421,7 +435,7 @@ namespace HermesProxy.World.Server.Packets
         public byte CharCount = 0;
     }
 
-    public class CreateChar : ServerPacket
+    public class CreateChar : ServerPacket, ISpanWritable
     {
         public CreateChar() : base(Opcode.SMSG_CREATE_CHAR) { }
 
@@ -429,6 +443,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WriteUInt8(Code);
             _worldPacket.WritePackedGuid128(Guid);
+        }
+
+        public int MaxSize => 1 + PackedGuidHelper.MaxPackedGuid128Size; // byte + GUID
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt8(Code);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            return writer.Position;
         }
 
         public byte Code;
@@ -447,13 +471,22 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 Guid; // Guid of the character to delete
     }
 
-    public class DeleteChar : ServerPacket
+    public class DeleteChar : ServerPacket, ISpanWritable
     {
         public DeleteChar() : base(Opcode.SMSG_DELETE_CHAR) { }
 
         public override void Write()
         {
             _worldPacket.WriteUInt8(Code);
+        }
+
+        public int MaxSize => 1; // byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt8(Code);
+            return writer.Position;
         }
 
         public byte Code;
@@ -489,7 +522,7 @@ namespace HermesProxy.World.Server.Packets
         public bool UnkBit;
     }
 
-    public class LoginVerifyWorld : ServerPacket
+    public class LoginVerifyWorld : ServerPacket, ISpanWritable
     {
         public LoginVerifyWorld() : base(Opcode.SMSG_LOGIN_VERIFY_WORLD, ConnectionType.Instance) { }
 
@@ -503,18 +536,41 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(Reason);
         }
 
+        public int MaxSize => 24; // uint + 4 floats + uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(MapID);
+            writer.WriteFloat(Pos.X);
+            writer.WriteFloat(Pos.Y);
+            writer.WriteFloat(Pos.Z);
+            writer.WriteFloat(Pos.Orientation);
+            writer.WriteUInt32(Reason);
+            return writer.Position;
+        }
+
         public uint MapID;
         public Position Pos;
         public uint Reason;
     }
 
-    public class CharacterLoginFailed : ServerPacket
+    public class CharacterLoginFailed : ServerPacket, ISpanWritable
     {
         public CharacterLoginFailed() : base(Opcode.SMSG_CHARACTER_LOGIN_FAILED) { }
 
         public override void Write()
         {
             _worldPacket.WriteUInt8((byte)Code);
+        }
+
+        public int MaxSize => 1; // byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt8((byte)Code);
+            return writer.Position;
         }
 
         public LoginFailureReason Code;
@@ -532,7 +588,7 @@ namespace HermesProxy.World.Server.Packets
         public bool IdleLogout;
     }
 
-    public class LogoutResponse : ServerPacket
+    public class LogoutResponse : ServerPacket, ISpanWritable
     {
         public LogoutResponse() : base(Opcode.SMSG_LOGOUT_RESPONSE, ConnectionType.Instance) { }
 
@@ -543,15 +599,30 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 5; // int + bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(LogoutResult);
+            writer.WriteBit(Instant);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public int LogoutResult;
         public bool Instant = false;
     }
 
-    public class LogoutComplete : ServerPacket
+    public class LogoutComplete : ServerPacket, ISpanWritable
     {
         public LogoutComplete() : base(Opcode.SMSG_LOGOUT_COMPLETE) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
     public class LogoutCancel : ClientPacket
@@ -561,14 +632,18 @@ namespace HermesProxy.World.Server.Packets
         public override void Read() { }
     }
 
-    public class LogoutCancelAck : ServerPacket
+    public class LogoutCancelAck : ServerPacket, ISpanWritable
     {
         public LogoutCancelAck() : base(Opcode.SMSG_LOGOUT_CANCEL_ACK, ConnectionType.Instance) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
-    class LogXPGain : ServerPacket
+    class LogXPGain : ServerPacket, ISpanWritable
     {
         public LogXPGain() : base(Opcode.SMSG_LOG_XP_GAIN) { }
 
@@ -580,6 +655,20 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(Amount);
             _worldPacket.WriteFloat(GroupBonus);
             _worldPacket.WriteUInt8(RAFBonus);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 14; // GUID + int + byte + int + float + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Victim.Low, Victim.High);
+            writer.WriteInt32(Original);
+            writer.WriteUInt8((byte)Reason);
+            writer.WriteInt32(Amount);
+            writer.WriteFloat(GroupBonus);
+            writer.WriteUInt8(RAFBonus);
+            return writer.Position;
         }
 
         public WowGuid128 Victim;
@@ -602,7 +691,7 @@ namespace HermesProxy.World.Server.Packets
         public bool TriggerScriptEvent;
     }
 
-    public class PlayedTime : ServerPacket
+    public class PlayedTime : ServerPacket, ISpanWritable
     {
         public PlayedTime() : base(Opcode.SMSG_PLAYED_TIME, ConnectionType.Instance) { }
 
@@ -612,6 +701,18 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(LevelTime);
             _worldPacket.WriteBit(TriggerEvent);
             _worldPacket.FlushBits();
+        }
+
+        public int MaxSize => 9; // uint + uint + bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(TotalTime);
+            writer.WriteUInt32(LevelTime);
+            writer.WriteBit(TriggerEvent);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public uint TotalTime;
@@ -678,7 +779,7 @@ namespace HermesProxy.World.Server.Packets
         public byte Mask;
     }
 
-    public class LevelUpInfo : ServerPacket
+    public class LevelUpInfo : ServerPacket, ISpanWritable
     {
         public LevelUpInfo() : base(Opcode.SMSG_LEVEL_UP_INFO) { }
 
@@ -695,6 +796,27 @@ namespace HermesProxy.World.Server.Packets
 
             _worldPacket.WriteInt32(NumNewTalents);
             _worldPacket.WriteInt32(NumNewPvpTalentSlots);
+        }
+
+        // Level(4) + Health(4) + 7 powers(28) + 5 stats(20) + 2 ints(8) = 64 bytes
+        public int MaxSize => 4 + 4 + 7 * 4 + 5 * 4 + 4 + 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Level);
+            writer.WriteInt32(HealthDelta);
+
+            int powerCount = ModernVersion.GetPowerCountForClientVersion();
+            for (int i = 0; i < powerCount; i++)
+                writer.WriteInt32(PowerDelta[i]);
+
+            foreach (int stat in StatDelta)
+                writer.WriteInt32(stat);
+
+            writer.WriteInt32(NumNewTalents);
+            writer.WriteInt32(NumNewPvpTalentSlots);
+            return writer.Position;
         }
 
         public int Level = 0;
@@ -954,7 +1076,7 @@ namespace HermesProxy.World.Server.Packets
         public bool Disqualified;
     }
 
-    public class InspectHonorStatsResultClassic : ServerPacket
+    public class InspectHonorStatsResultClassic : ServerPacket, ISpanWritable
     {
         public InspectHonorStatsResultClassic() : base(Opcode.SMSG_INSPECT_HONOR_STATS) { }
 
@@ -979,6 +1101,31 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt8(RankProgress);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 42; // GUID + byte + 8 ushorts + 6 uints + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(PlayerGUID.Low, PlayerGUID.High);
+            writer.WriteUInt8(LifetimeHighestRank);
+            writer.WriteUInt16(TodayHonorableKills);
+            writer.WriteUInt16(TodayDishonorableKills);
+            writer.WriteUInt16(YesterdayHonorableKills);
+            writer.WriteUInt16(YesterdayDishonorableKills);
+            writer.WriteUInt16(LastWeekHonorableKills);
+            writer.WriteUInt16(LastWeekDishonorableKills);
+            writer.WriteUInt16(ThisWeekHonorableKills);
+            writer.WriteUInt16(ThisWeekDishonorableKills);
+            writer.WriteUInt32(LifetimeHonorableKills);
+            writer.WriteUInt32(LifetimeDishonorableKills);
+            writer.WriteUInt32(YesterdayHonor);
+            writer.WriteUInt32(LastWeekHonor);
+            writer.WriteUInt32(ThisWeekHonor);
+            writer.WriteUInt32(Standing);
+            writer.WriteUInt8(RankProgress);
+            return writer.Position;
+        }
+
         public WowGuid128 PlayerGUID;
         public byte LifetimeHighestRank;
         public ushort TodayHonorableKills;
@@ -998,7 +1145,7 @@ namespace HermesProxy.World.Server.Packets
         public byte RankProgress;
     }
 
-    public class InspectHonorStatsResultTBC : ServerPacket
+    public class InspectHonorStatsResultTBC : ServerPacket, ISpanWritable
     {
         public InspectHonorStatsResultTBC() : base(Opcode.SMSG_INSPECT_HONOR_STATS) { }
 
@@ -1018,6 +1165,26 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt8(Unused9);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 30; // GUID + byte + 4 ushorts + 5 uints + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(PlayerGUID.Low, PlayerGUID.High);
+            writer.WriteUInt8(LifetimeHighestRank);
+            writer.WriteUInt16(Unused1);
+            writer.WriteUInt16(YesterdayHonorableKills);
+            writer.WriteUInt16(Unused3);
+            writer.WriteUInt16(LifetimeHonorableKills);
+            writer.WriteUInt32(Unused4);
+            writer.WriteUInt32(Unused5);
+            writer.WriteUInt32(Unused6);
+            writer.WriteUInt32(Unused7);
+            writer.WriteUInt32(Unused8);
+            writer.WriteUInt8(Unused9);
+            return writer.Position;
+        }
+
         public WowGuid128 PlayerGUID;
         public byte LifetimeHighestRank;
         public ushort Unused1;
@@ -1032,7 +1199,7 @@ namespace HermesProxy.World.Server.Packets
         public byte Unused9;
     }
 
-    public class InspectPvP : ServerPacket
+    public class InspectPvP : ServerPacket, ISpanWritable
     {
         public InspectPvP() : base(Opcode.SMSG_INSPECT_PVP) { }
 
@@ -1048,6 +1215,54 @@ namespace HermesProxy.World.Server.Packets
 
             foreach (var team in ArenaTeams)
                 team.Write(_worldPacket);
+        }
+
+        // MaxSize: GUID (18) + bits (5 -> 1 byte) + max 8 brackets (42 bytes each) + max 3 teams (38 bytes each)
+        // PvPBracketInspectData: byte(1) + 10 ints(40) + bool(1) = 42
+        // ArenaTeamInspectData: GUID(18) + 5 ints(20) = 38
+        private const int MaxBrackets = 8;
+        private const int MaxArenaTeams = 3;
+        private const int BracketSize = 42;
+        private const int ArenaTeamSize = PackedGuidHelper.MaxPackedGuid128Size + 20;
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 1 + MaxBrackets * BracketSize + MaxArenaTeams * ArenaTeamSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Brackets.Count > MaxBrackets || ArenaTeams.Count > MaxArenaTeams)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(PlayerGUID.Low, PlayerGUID.High);
+            writer.WriteBits((uint)Brackets.Count, 3);
+            writer.WriteBits((uint)ArenaTeams.Count, 2);
+            writer.FlushBits();
+
+            foreach (var bracket in Brackets)
+            {
+                writer.WriteUInt8(bracket.Bracket);
+                writer.WriteInt32(bracket.Rating);
+                writer.WriteInt32(bracket.Rank);
+                writer.WriteInt32(bracket.WeeklyPlayed);
+                writer.WriteInt32(bracket.WeeklyWon);
+                writer.WriteInt32(bracket.SeasonPlayed);
+                writer.WriteInt32(bracket.SeasonWon);
+                writer.WriteInt32(bracket.WeeklyBestRating);
+                writer.WriteInt32(bracket.SeasonBestRating);
+                writer.WriteInt32(bracket.PvpTierID);
+                writer.WriteInt32(bracket.WeeklyBestWinPvpTierID);
+                writer.WriteBool(bracket.Disqualified);
+            }
+
+            foreach (var team in ArenaTeams)
+            {
+                writer.WritePackedGuid128(team.TeamGuid.Low, team.TeamGuid.High);
+                writer.WriteInt32(team.TeamRating);
+                writer.WriteInt32(team.TeamGamesPlayed);
+                writer.WriteInt32(team.TeamGamesWon);
+                writer.WriteInt32(team.PersonalGamesPlayed);
+                writer.WriteInt32(team.PersonalRating);
+            }
+            return writer.Position;
         }
 
         public WowGuid128 PlayerGUID;
@@ -1121,7 +1336,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 Guid;
     }
 
-    public class CharacterRenameResult : ServerPacket
+    public class CharacterRenameResult : ServerPacket, ISpanWritable
     {
         public CharacterRenameResult() : base(Opcode.SMSG_CHARACTER_RENAME_RESULT) { }
 
@@ -1136,6 +1351,24 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WritePackedGuid128(Guid);
 
             _worldPacket.WriteString(Name);
+        }
+
+        // MaxSize: byte (1) + bits (1+6=7 -> 1) + optional GUID (18) + name (24) = 44
+        public int MaxSize => 1 + 1 + PackedGuidHelper.MaxPackedGuid128Size + GameLimits.MaxPlayerNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt8(Result);
+            writer.WriteBit(Guid != default);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Name), 6);
+            writer.FlushBits();
+
+            if (Guid != default)
+                writer.WritePackedGuid128(Guid.Low, Guid.High);
+
+            writer.WriteString(Name);
+            return writer.Position;
         }
 
         public string Name = "";

--- a/HermesProxy/World/Server/Packets/ChatPackets.cs
+++ b/HermesProxy/World/Server/Packets/ChatPackets.cs
@@ -64,8 +64,9 @@ namespace HermesProxy.World.Server.Packets
         }
 
         // Cap for channel name and welcome message
+        // Reduced MaxWelcomeMsgBytes from 256 to 64 based on typical usage (~50 bytes)
         private const int MaxChannelBytes = 64;
-        private const int MaxWelcomeMsgBytes = 256;
+        private const int MaxWelcomeMsgBytes = 64;
         // 18 bits(3) + uint(4) + int(4) + ulong(8) + GUID(18) + channel + msg
         public int MaxSize => 3 + 4 + 4 + 8 + PackedGuidHelper.MaxPackedGuid128Size + MaxChannelBytes + MaxWelcomeMsgBytes;
 
@@ -459,11 +460,13 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WritePackedGuid128(ChannelGUID);
         }
 
-        // MaxSize: byte(1) + uint(4) + 5 GUIDs(90) + 2 uints(8) + GUID(18) + uint(4) + float(4)
-        // + bits(8) + strings: sender(2048) + target(2048) + prefix(32) + channel(128) + chat(4096)
-        // + opt uint(4) + opt GUID(18) = 8511
-        private const int MaxSenderNameBytes = 2048;
-        private const int MaxChatTextBytes = 4096;
+        // MaxSize: byte(1) + uint(4) + 6 GUIDs(108) + 2 uints(8) + uint(4) + float(4)
+        // + bits(8) + strings: sender(128) + target(128) + prefix(32) + channel(128) + chat(512)
+        // + opt uint(4) + opt GUID(18) = ~430 bytes
+        // Note: Real player names are max 24 bytes, typical chat is <200 bytes.
+        // If exceeded, WriteToSpan returns -1 to trigger fallback to Write().
+        private const int MaxSenderNameBytes = 128;
+        private const int MaxChatTextBytes = 512;
         public int MaxSize => 1 + 4 + PackedGuidHelper.MaxPackedGuid128Size * 6 + 16 + 8 +
             MaxSenderNameBytes * 2 + 32 + 128 + MaxChatTextBytes + 22;
 
@@ -475,9 +478,10 @@ namespace HermesProxy.World.Server.Packets
             int channelBytes = Encoding.UTF8.GetByteCount(Channel ?? "");
             int chatTextBytes = Encoding.UTF8.GetByteCount(ChatText ?? "");
 
-            // Check bit limits
-            if (senderNameBytes > 2047 || targetNameBytes > 2047 || prefixBytes > 31 ||
-                channelBytes > 127 || chatTextBytes > 4095)
+            // Check against our reduced MaxSize limits - fallback to Write() for oversized messages
+            // Protocol limits are larger (2047/4095) but we optimize for typical usage
+            if (senderNameBytes > MaxSenderNameBytes || targetNameBytes > MaxSenderNameBytes ||
+                prefixBytes > 31 || channelBytes > 127 || chatTextBytes > MaxChatTextBytes)
                 return -1;
 
             var writer = new SpanPacketWriter(buffer);

--- a/HermesProxy/World/Server/Packets/ChatPackets.cs
+++ b/HermesProxy/World/Server/Packets/ChatPackets.cs
@@ -18,11 +18,13 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace HermesProxy.World.Server.Packets
 {
@@ -45,7 +47,7 @@ namespace HermesProxy.World.Server.Packets
         public int ChatChannelId;
     }
 
-    public class ChannelNotifyJoined : ServerPacket
+    public class ChannelNotifyJoined : ServerPacket, ISpanWritable
     {
         public ChannelNotifyJoined() : base(Opcode.SMSG_CHANNEL_NOTIFY_JOINED) { }
 
@@ -59,6 +61,31 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(ChannelGUID);
             _worldPacket.WriteString(Channel);
             _worldPacket.WriteString(ChannelWelcomeMsg);
+        }
+
+        // Cap for channel name and welcome message
+        private const int MaxChannelBytes = 64;
+        private const int MaxWelcomeMsgBytes = 256;
+        // 18 bits(3) + uint(4) + int(4) + ulong(8) + GUID(18) + channel + msg
+        public int MaxSize => 3 + 4 + 4 + 8 + PackedGuidHelper.MaxPackedGuid128Size + MaxChannelBytes + MaxWelcomeMsgBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int channelBytes = Encoding.UTF8.GetByteCount(Channel);
+            int welcomeBytes = Encoding.UTF8.GetByteCount(ChannelWelcomeMsg);
+            if (channelBytes > MaxChannelBytes || welcomeBytes > MaxWelcomeMsgBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)channelBytes, 7);
+            writer.WriteBits((uint)welcomeBytes, 11);
+            writer.WriteUInt32((uint)ChannelFlags);
+            writer.WriteInt32(ChatChannelID);
+            writer.WriteUInt64(InstanceID);
+            writer.WritePackedGuid128(ChannelGUID.Low, ChannelGUID.High);
+            writer.WriteString(Channel);
+            writer.WriteString(ChannelWelcomeMsg);
+            return writer.Position;
         }
 
         public string ChannelWelcomeMsg = "";
@@ -83,7 +110,7 @@ namespace HermesProxy.World.Server.Packets
         public string ChannelName;
     }
 
-    public class ChannelNotifyLeft : ServerPacket
+    public class ChannelNotifyLeft : ServerPacket, ISpanWritable
     {
         public ChannelNotifyLeft() : base(Opcode.SMSG_CHANNEL_NOTIFY_LEFT) { }
 
@@ -93,6 +120,25 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteBit(Suspended);
             _worldPacket.WriteInt32(ChatChannelID);
             _worldPacket.WriteString(Channel);
+        }
+
+        // Cap for channel name - 7 bits = max 128, using 64
+        private const int MaxChannelBytes = 64;
+        // 8 bits(1) + int(4) + channel name
+        public int MaxSize => 1 + 4 + MaxChannelBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int channelBytes = Encoding.UTF8.GetByteCount(Channel);
+            if (channelBytes > MaxChannelBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)channelBytes, 7);
+            writer.WriteBit(Suspended);
+            writer.WriteInt32(ChatChannelID);
+            writer.WriteString(Channel);
+            return writer.Position;
         }
 
         public string Channel;
@@ -112,7 +158,7 @@ namespace HermesProxy.World.Server.Packets
         public string ChannelName;
     }
 
-    public class ChannelListResponse : ServerPacket
+    public class ChannelListResponse : ServerPacket, ISpanWritable
     {
         public ChannelListResponse() : base(Opcode.SMSG_CHANNEL_LIST)
         {
@@ -133,6 +179,40 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteUInt32(player.VirtualRealmAddress);
                 _worldPacket.WriteUInt8(player.Flags);
             }
+        }
+
+        // Cap for channel members - typical channel size
+        private const int MaxMembers = 64;
+        // Cap for channel name
+        private const int MaxChannelBytes = 64;
+        // Per member: GUID(18) + uint(4) + byte(1) = 23 bytes
+        private const int MemberSize = PackedGuidHelper.MaxPackedGuid128Size + 4 + 1;
+        // 8 bits(1) + uint(4) + int(4) + channel name + members
+        public int MaxSize => 1 + 4 + 4 + MaxChannelBytes + MaxMembers * MemberSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Members.Count > MaxMembers)
+                return -1;
+
+            int channelBytes = Encoding.UTF8.GetByteCount(ChannelName);
+            if (channelBytes > MaxChannelBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBit(Display);
+            writer.WriteBits((uint)channelBytes, 7);
+            writer.WriteUInt32((uint)ChannelFlags);
+            writer.WriteInt32(Members.Count);
+            writer.WriteString(ChannelName);
+
+            foreach (ChannelPlayer player in Members)
+            {
+                writer.WritePackedGuid128(player.Guid.Low, player.Guid.High);
+                writer.WriteUInt32(player.VirtualRealmAddress);
+                writer.WriteUInt8(player.Flags);
+            }
+            return writer.Position;
         }
 
         public List<ChannelPlayer> Members;
@@ -288,7 +368,7 @@ namespace HermesProxy.World.Server.Packets
         public bool IsLogged;
     }
 
-    public class ChatPkt : ServerPacket
+    public class ChatPkt : ServerPacket, ISpanWritable
     {
         public ChatPkt(GlobalSessionData globalSession, ChatMessageTypeModern chatType, string message, uint language = 0, WowGuid128 sender = default, string senderName = "", WowGuid128 receiver = default, string receiverName = "", string channelName = "", ChatFlags chatFlags = ChatFlags.None, string addonPrefix = "", uint achievementId = 0) : base(Opcode.SMSG_CHAT)
         {
@@ -379,6 +459,66 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WritePackedGuid128(ChannelGUID);
         }
 
+        // MaxSize: byte(1) + uint(4) + 5 GUIDs(90) + 2 uints(8) + GUID(18) + uint(4) + float(4)
+        // + bits(8) + strings: sender(2048) + target(2048) + prefix(32) + channel(128) + chat(4096)
+        // + opt uint(4) + opt GUID(18) = 8511
+        private const int MaxSenderNameBytes = 2048;
+        private const int MaxChatTextBytes = 4096;
+        public int MaxSize => 1 + 4 + PackedGuidHelper.MaxPackedGuid128Size * 6 + 16 + 8 +
+            MaxSenderNameBytes * 2 + 32 + 128 + MaxChatTextBytes + 22;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int senderNameBytes = Encoding.UTF8.GetByteCount(SenderName ?? "");
+            int targetNameBytes = Encoding.UTF8.GetByteCount(TargetName ?? "");
+            int prefixBytes = Encoding.UTF8.GetByteCount(Prefix ?? "");
+            int channelBytes = Encoding.UTF8.GetByteCount(Channel ?? "");
+            int chatTextBytes = Encoding.UTF8.GetByteCount(ChatText ?? "");
+
+            // Check bit limits
+            if (senderNameBytes > 2047 || targetNameBytes > 2047 || prefixBytes > 31 ||
+                channelBytes > 127 || chatTextBytes > 4095)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt8((byte)SlashCmd);
+            writer.WriteUInt32(_Language);
+            writer.WritePackedGuid128(SenderGUID.Low, SenderGUID.High);
+            writer.WritePackedGuid128(SenderGuildGUID.Low, SenderGuildGUID.High);
+            writer.WritePackedGuid128(SenderAccountGUID.Low, SenderAccountGUID.High);
+            writer.WritePackedGuid128(TargetGUID.Low, TargetGUID.High);
+            writer.WriteUInt32(TargetVirtualAddress);
+            writer.WriteUInt32(SenderVirtualAddress);
+            writer.WritePackedGuid128(PartyGUID.Low, PartyGUID.High);
+            writer.WriteUInt32(AchievementID);
+            writer.WriteFloat(DisplayTime);
+            writer.WriteBits((uint)senderNameBytes, 11);
+            writer.WriteBits((uint)targetNameBytes, 11);
+            writer.WriteBits((uint)prefixBytes, 5);
+            writer.WriteBits((uint)channelBytes, 7);
+            writer.WriteBits((uint)chatTextBytes, 12);
+            writer.WriteBits((uint)_ChatFlags, 14);
+            writer.WriteBit(HideChatLog);
+            writer.WriteBit(FakeSenderName);
+            writer.WriteBit(Unused_801.HasValue);
+            writer.WriteBit(ChannelGUID != default);
+            writer.FlushBits();
+
+            writer.WriteString(SenderName ?? "");
+            writer.WriteString(TargetName ?? "");
+            writer.WriteString(Prefix ?? "");
+            writer.WriteString(Channel ?? "");
+            writer.WriteString(ChatText ?? "");
+
+            if (Unused_801.HasValue)
+                writer.WriteUInt32(Unused_801.Value);
+
+            if (ChannelGUID != default)
+                writer.WritePackedGuid128(ChannelGUID.Low, ChannelGUID.High);
+
+            return writer.Position;
+        }
+
         public ChatMessageTypeModern SlashCmd = 0;
         public uint _Language = 0;
         public WowGuid128 SenderGUID;
@@ -402,7 +542,7 @@ namespace HermesProxy.World.Server.Packets
         public bool FakeSenderName = false;
     }
 
-    public class EmoteMessage : ServerPacket
+    public class EmoteMessage : ServerPacket, ISpanWritable
     {
         public EmoteMessage() : base(Opcode.SMSG_EMOTE, ConnectionType.Instance) { }
 
@@ -418,6 +558,30 @@ namespace HermesProxy.World.Server.Packets
                 foreach (var id in SpellVisualKitIDs)
                     _worldPacket.WriteUInt32(id);
             }
+        }
+
+        // Cap for spell visual kit IDs - rarely more than 1-2
+        private const int MaxSpellVisualKitIDs = 4;
+        // GUID(18) + EmoteID(4) + count(4) + SequenceVariation(4) + IDs(4 each)
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4 + 4 + 4 + MaxSpellVisualKitIDs * 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (SpellVisualKitIDs.Count > MaxSpellVisualKitIDs)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            writer.WriteUInt32(EmoteID);
+            if (ModernVersion.AddedInVersion(9, 0, 5, 1, 14, 0, 2, 5, 1))
+            {
+                writer.WriteInt32(SpellVisualKitIDs.Count);
+                if (ModernVersion.AddedInVersion(9, 2, 0, 1, 14, 2, 2, 5, 3))
+                    writer.WriteInt32(SequenceVariation);
+                foreach (var id in SpellVisualKitIDs)
+                    writer.WriteUInt32(id);
+            }
+            return writer.Position;
         }
 
         public WowGuid128 Guid;
@@ -453,7 +617,7 @@ namespace HermesProxy.World.Server.Packets
         public uint[] SpellVisualKitIDs;
     }
 
-    public class STextEmote : ServerPacket
+    public class STextEmote : ServerPacket, ISpanWritable
     {
         public STextEmote() : base(Opcode.SMSG_TEXT_EMOTE, ConnectionType.Instance) { }
 
@@ -466,6 +630,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(TargetGUID);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 3 + 8; // 3 GUIDs + 2 ints
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(SourceGUID.Low, SourceGUID.High);
+            writer.WritePackedGuid128(SourceAccountGUID.Low, SourceAccountGUID.High);
+            writer.WriteInt32(EmoteID);
+            writer.WriteInt32(SoundIndex);
+            writer.WritePackedGuid128(TargetGUID.Low, TargetGUID.High);
+            return writer.Position;
+        }
+
         public WowGuid128 SourceGUID;
         public WowGuid128 SourceAccountGUID;
         public WowGuid128 TargetGUID;
@@ -473,7 +650,7 @@ namespace HermesProxy.World.Server.Packets
         public int EmoteID;
     }
 
-    public class PrintNotification : ServerPacket
+    public class PrintNotification : ServerPacket, ISpanWritable
     {
         public PrintNotification() : base(Opcode.SMSG_PRINT_NOTIFICATION) { }
 
@@ -483,10 +660,27 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(NotifyText);
         }
 
+        // Cap for notification text - most are short system messages
+        private const int MaxTextBytes = 256;
+        // 12 bits(2) + text
+        public int MaxSize => 2 + MaxTextBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int textBytes = Encoding.UTF8.GetByteCount(NotifyText);
+            if (textBytes > MaxTextBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)textBytes, 12);
+            writer.WriteString(NotifyText);
+            return writer.Position;
+        }
+
         public string NotifyText;
     }
 
-    class ChatPlayerNotfound : ServerPacket
+    class ChatPlayerNotfound : ServerPacket, ISpanWritable
     {
         public ChatPlayerNotfound() : base(Opcode.SMSG_CHAT_PLAYER_NOTFOUND) { }
 
@@ -496,10 +690,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(Name);
         }
 
+        // MaxSize: 9 bits (2 bytes) + max player name bytes
+        public int MaxSize => 2 + GameLimits.MaxPlayerNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Name), 9);
+            writer.WriteString(Name);
+            return writer.Position;
+        }
+
         public string Name;
     }
 
-    class DefenseMessage : ServerPacket
+    class DefenseMessage : ServerPacket, ISpanWritable
     {
         public DefenseMessage() : base(Opcode.SMSG_DEFENSE_MESSAGE) { }
 
@@ -511,11 +716,30 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(MessageText);
         }
 
+        // Cap for defense message - zone attack notifications
+        private const int MaxTextBytes = 256;
+        // uint(4) + 12 bits(2) + text
+        public int MaxSize => 4 + 2 + MaxTextBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int textBytes = Encoding.UTF8.GetByteCount(MessageText);
+            if (textBytes > MaxTextBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(ZoneID);
+            writer.WriteBits((uint)textBytes, 12);
+            writer.FlushBits();
+            writer.WriteString(MessageText);
+            return writer.Position;
+        }
+
         public uint ZoneID;
         public string MessageText = "";
     }
 
-    class ChatServerMessage : ServerPacket
+    class ChatServerMessage : ServerPacket, ISpanWritable
     {
         public ChatServerMessage() : base(Opcode.SMSG_CHAT_SERVER_MESSAGE) { }
 
@@ -525,6 +749,24 @@ namespace HermesProxy.World.Server.Packets
 
             _worldPacket.WriteBits(StringParam.GetByteCount(), 11);
             _worldPacket.WriteString(StringParam);
+        }
+
+        // Cap for server message param - usually short strings
+        private const int MaxParamBytes = 256;
+        // int(4) + 11 bits(2) + string
+        public int MaxSize => 4 + 2 + MaxParamBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int paramBytes = Encoding.UTF8.GetByteCount(StringParam);
+            if (paramBytes > MaxParamBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(MessageID);
+            writer.WriteBits((uint)paramBytes, 11);
+            writer.WriteString(StringParam);
+            return writer.Position;
         }
 
         public int MessageID;

--- a/HermesProxy/World/Server/Packets/ClientConfigPackets.cs
+++ b/HermesProxy/World/Server/Packets/ClientConfigPackets.cs
@@ -124,8 +124,9 @@ namespace HermesProxy.World.Server.Packets
             }
         }
 
-        // MaxSize: GUID(18) + long(8) + uint(4) + bits(1) + length(4) + max compressed data (16KB)
-        private const int MaxCompressedDataSize = 16384;
+        // MaxSize: GUID(18) + long(8) + uint(4) + bits(1) + length(4) + max compressed data
+        // Reduced from 16KB to 2KB based on typical usage (235 bytes observed)
+        private const int MaxCompressedDataSize = 2048;
         public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 17 + MaxCompressedDataSize;
 
         public int WriteToSpan(Span<byte> buffer)
@@ -222,8 +223,8 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteBytes(Data);
         }
 
-        // Cap for CUF profile data
-        private const int MaxDataSize = 2048;
+        // Cap for CUF profile data - reduced from 2048 to 256 based on typical usage (30 bytes observed)
+        private const int MaxDataSize = 256;
         public int MaxSize => MaxDataSize;
 
         public int WriteToSpan(Span<byte> buffer)

--- a/HermesProxy/World/Server/Packets/ClientConfigPackets.cs
+++ b/HermesProxy/World/Server/Packets/ClientConfigPackets.cs
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+using System;
 using Framework.Constants;
 using Framework.IO;
 using HermesProxy.World.Enums;
@@ -22,7 +23,7 @@ using System.Collections.Generic;
 
 namespace HermesProxy.World.Server.Packets
 {
-    public class AccountDataTimes : ServerPacket
+    public class AccountDataTimes : ServerPacket, ISpanWritable
     {
         public AccountDataTimes() : base(Opcode.SMSG_ACCOUNT_DATA_TIMES) { }
 
@@ -34,18 +35,41 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteInt64(accounttime);
         }
 
+        // GUID(18) + ServerTime(8) + max 13 account times (8 each) = 130 bytes
+        private const int MaxAccountDataCount = 13;
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 8 + MaxAccountDataCount * 8;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(PlayerGuid.Low, PlayerGuid.High);
+            writer.WriteInt64(ServerTime);
+            foreach (var accounttime in AccountTimes)
+                writer.WriteInt64(accounttime);
+            return writer.Position;
+        }
+
         public WowGuid128 PlayerGuid;
         public long ServerTime;
         public long[] AccountTimes;
     }
 
-    public class ClientCacheVersion : ServerPacket
+    public class ClientCacheVersion : ServerPacket, ISpanWritable
     {
         public ClientCacheVersion() : base(Opcode.SMSG_CACHE_VERSION) { }
 
         public override void Write()
         {
             _worldPacket.WriteUInt32(CacheVersion);
+        }
+
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(CacheVersion);
+            return writer.Position;
         }
 
         public uint CacheVersion = 0;
@@ -69,7 +93,7 @@ namespace HermesProxy.World.Server.Packets
         public uint DataType;
     }
 
-    public class UpdateAccountData : ServerPacket
+    public class UpdateAccountData : ServerPacket, ISpanWritable
     {
         public UpdateAccountData(AccountData data) : base(Opcode.SMSG_UPDATE_ACCOUNT_DATA)
         {
@@ -98,6 +122,35 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteInt32(CompressedData.Length);
                 _worldPacket.WriteBytes(CompressedData);
             }
+        }
+
+        // MaxSize: GUID(18) + long(8) + uint(4) + bits(1) + length(4) + max compressed data (16KB)
+        private const int MaxCompressedDataSize = 16384;
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 17 + MaxCompressedDataSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (CompressedData != null && CompressedData.Length > MaxCompressedDataSize)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Player.Low, Player.High);
+            writer.WriteInt64(Time);
+            writer.WriteUInt32(Size);
+
+            if (ModernVersion.GetAccountDataCount() <= 8)
+                writer.WriteBits(DataType, 3);
+            else
+                writer.WriteBits(DataType, 4);
+
+            if (CompressedData == null)
+                writer.WriteUInt32(0);
+            else
+            {
+                writer.WriteInt32(CompressedData.Length);
+                writer.WriteBytes(CompressedData);
+            }
+            return writer.Position;
         }
 
         public WowGuid128 Player;
@@ -160,13 +213,30 @@ namespace HermesProxy.World.Server.Packets
         public byte[] Data;
     }
 
-    public class LoadCUFProfiles : ServerPacket
+    public class LoadCUFProfiles : ServerPacket, ISpanWritable
     {
         public LoadCUFProfiles() : base(Opcode.SMSG_LOAD_CUF_PROFILES, ConnectionType.Instance) { }
 
         public override void Write()
         {
             _worldPacket.WriteBytes(Data);
+        }
+
+        // Cap for CUF profile data
+        private const int MaxDataSize = 2048;
+        public int MaxSize => MaxDataSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Data == null)
+                return 0;
+
+            if (Data.Length > MaxDataSize)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBytes(Data);
+            return writer.Position;
         }
 
         public byte[] Data;

--- a/HermesProxy/World/Server/Packets/CombatPackets.cs
+++ b/HermesProxy/World/Server/Packets/CombatPackets.cs
@@ -16,12 +16,13 @@
  */
 
 
-using Framework.Constants;
-using Framework.GameMath;
-using HermesProxy.World.Enums;
-using HermesProxy.World.Objects;
 using System;
 using System.Collections.Generic;
+using Framework.Constants;
+using Framework.GameMath;
+using Framework.IO;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
 
 namespace HermesProxy.World.Server.Packets
 {
@@ -37,7 +38,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 Victim;
     }
 
-    public class AttackSwingError : ServerPacket
+    public class AttackSwingError : ServerPacket, ISpanWritable
     {
         public AttackSwingError() : base(Opcode.SMSG_ATTACK_SWING_ERROR) { }
 
@@ -45,6 +46,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WriteBits((uint)Reason, 3);
             _worldPacket.FlushBits();
+        }
+
+        public int MaxSize => 1; // 3 bits packed into 1 byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)Reason, 3);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public AttackSwingErr Reason;
@@ -57,7 +68,7 @@ namespace HermesProxy.World.Server.Packets
         public override void Read() { }
     }
 
-    public class SAttackStart : ServerPacket
+    public class SAttackStart : ServerPacket, ISpanWritable
     {
         public SAttackStart() : base(Opcode.SMSG_ATTACK_START, ConnectionType.Instance) { }
 
@@ -67,11 +78,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(Victim);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2; // 2 packed GUIDs
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Attacker.Low, Attacker.High);
+            writer.WritePackedGuid128(Victim.Low, Victim.High);
+            return writer.Position;
+        }
+
         public WowGuid128 Attacker;
         public WowGuid128 Victim;
     }
 
-    public class SAttackStop : ServerPacket
+    public class SAttackStop : ServerPacket, ISpanWritable
     {
         public SAttackStop() : base(Opcode.SMSG_ATTACK_STOP, ConnectionType.Instance) { }
 
@@ -81,6 +102,18 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(Victim);
             _worldPacket.WriteBit(NowDead);
             _worldPacket.FlushBits();
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 1; // 2 packed GUIDs + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Attacker.Low, Attacker.High);
+            writer.WritePackedGuid128(Victim.Low, Victim.High);
+            writer.WriteBit(NowDead);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public WowGuid128 Attacker;
@@ -220,11 +253,11 @@ namespace HermesProxy.World.Server.Packets
             }
         }
 
-        long Health;
-        int AttackPower;
-        int SpellPower;
-        uint Armor;
-        List<SpellLogPowerData> PowerData = new();
+        public long Health;
+        public int AttackPower;
+        public int SpellPower;
+        public uint Armor;
+        public List<SpellLogPowerData> PowerData = new();
     }
 
     public struct SpellLogPowerData
@@ -234,11 +267,15 @@ namespace HermesProxy.World.Server.Packets
         public int Cost;
     }
 
-    public class CancelCombat : ServerPacket
+    public class CancelCombat : ServerPacket, ISpanWritable
     {
         public CancelCombat() : base(Opcode.SMSG_CANCEL_COMBAT) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0; // Empty packet
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
     public class SetSheathed : ClientPacket
@@ -255,7 +292,7 @@ namespace HermesProxy.World.Server.Packets
         public bool Animate = true;
     }
 
-    public class AIReaction : ServerPacket
+    public class AIReaction : ServerPacket, ISpanWritable
     {
         public AIReaction() : base(Opcode.SMSG_AI_REACTION, ConnectionType.Instance) { }
 
@@ -265,11 +302,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(Reaction);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4; // Packed GUID + uint32
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(UnitGUID.Low, UnitGUID.High);
+            writer.WriteUInt32(Reaction);
+            return writer.Position;
+        }
+
         public WowGuid128 UnitGUID;
         public uint Reaction;
     }
 
-    class PartyKillLog : ServerPacket
+    class PartyKillLog : ServerPacket, ISpanWritable
     {
         public PartyKillLog() : base(Opcode.SMSG_PARTY_KILL_LOG) { }
 
@@ -277,6 +324,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WritePackedGuid128(Player);
             _worldPacket.WritePackedGuid128(Victim);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2; // 2 packed GUIDs
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Player.Low, Player.High);
+            writer.WritePackedGuid128(Victim.Low, Victim.High);
+            return writer.Position;
         }
 
         public WowGuid128 Player;

--- a/HermesProxy/World/Server/Packets/DuelPackets.cs
+++ b/HermesProxy/World/Server/Packets/DuelPackets.cs
@@ -18,10 +18,12 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace HermesProxy.World.Server.Packets
 {
@@ -37,7 +39,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 TargetGUID;
     }
 
-    public class CanDuelResult : ServerPacket
+    public class CanDuelResult : ServerPacket, ISpanWritable
     {
         public CanDuelResult() : base(Opcode.SMSG_CAN_DUEL_RESULT) { }
 
@@ -48,11 +50,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 1; // GUID + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(TargetGUID.Low, TargetGUID.High);
+            writer.WriteBit(Result);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public WowGuid128 TargetGUID;
         public bool Result;
     }
 
-    public class DuelRequested : ServerPacket
+    public class DuelRequested : ServerPacket, ISpanWritable
     {
         public DuelRequested() : base(Opcode.SMSG_DUEL_REQUESTED, ConnectionType.Instance) { }
 
@@ -61,6 +74,17 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(ArbiterGUID);
             _worldPacket.WritePackedGuid128(RequestedByGUID);
             _worldPacket.WritePackedGuid128(RequestedByWowAccount);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 3; // 3 GUIDs
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(ArbiterGUID.Low, ArbiterGUID.High);
+            writer.WritePackedGuid128(RequestedByGUID.Low, RequestedByGUID.High);
+            writer.WritePackedGuid128(RequestedByWowAccount.Low, RequestedByWowAccount.High);
+            return writer.Position;
         }
 
         public WowGuid128 ArbiterGUID;
@@ -84,7 +108,7 @@ namespace HermesProxy.World.Server.Packets
         public bool Forfeited;
     }
 
-    public class DuelCountdown : ServerPacket
+    public class DuelCountdown : ServerPacket, ISpanWritable
     {
         public DuelCountdown() : base(Opcode.SMSG_DUEL_COUNTDOWN) { }
 
@@ -93,10 +117,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(Countdown);
         }
 
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(Countdown);
+            return writer.Position;
+        }
+
         public uint Countdown;
     }
 
-    public class DuelComplete : ServerPacket
+    public class DuelComplete : ServerPacket, ISpanWritable
     {
         public DuelComplete() : base(Opcode.SMSG_DUEL_COMPLETE, ConnectionType.Instance) { }
 
@@ -106,10 +139,20 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 1; // 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBit(Started);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public bool Started;
     }
 
-    public class DuelWinner : ServerPacket
+    public class DuelWinner : ServerPacket, ISpanWritable
     {
         public DuelWinner() : base(Opcode.SMSG_DUEL_WINNER, ConnectionType.Instance) { }
 
@@ -124,6 +167,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(WinnerName);
         }
 
+        // MaxSize: bits (6+6+1=13 -> 2 bytes) + 2 uints (8) + 2 names (48) = 58
+        public int MaxSize => 2 + 8 + GameLimits.MaxPlayerNameBytes * 2;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(BeatenName), 6);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(WinnerName), 6);
+            writer.WriteBit(Fled);
+            writer.WriteUInt32(BeatenVirtualRealmAddress);
+            writer.WriteUInt32(WinnerVirtualRealmAddress);
+            writer.WriteString(BeatenName);
+            writer.WriteString(WinnerName);
+            return writer.Position;
+        }
+
         public string BeatenName;
         public string WinnerName;
         public uint BeatenVirtualRealmAddress;
@@ -131,17 +190,25 @@ namespace HermesProxy.World.Server.Packets
         public bool Fled;
     }
 
-    public class DuelInBounds : ServerPacket
+    public class DuelInBounds : ServerPacket, ISpanWritable
     {
         public DuelInBounds() : base(Opcode.SMSG_DUEL_IN_BOUNDS, ConnectionType.Instance) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
-    public class DuelOutOfBounds : ServerPacket
+    public class DuelOutOfBounds : ServerPacket, ISpanWritable
     {
         public DuelOutOfBounds() : base(Opcode.SMSG_DUEL_OUT_OF_BOUNDS, ConnectionType.Instance) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 }

--- a/HermesProxy/World/Server/Packets/GameObjectPackets.cs
+++ b/HermesProxy/World/Server/Packets/GameObjectPackets.cs
@@ -16,8 +16,10 @@
  */
 
 
+using System;
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System.Collections.Generic;
@@ -48,7 +50,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 Guid;
     }
 
-    class GameObjectDespawn : ServerPacket
+    class GameObjectDespawn : ServerPacket, ISpanWritable
     {
         public GameObjectDespawn() : base(Opcode.SMSG_GAME_OBJECT_DESPAWN) { }
 
@@ -57,10 +59,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(ObjectGUID);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(ObjectGUID.Low, ObjectGUID.High);
+            return writer.Position;
+        }
+
         public WowGuid128 ObjectGUID;
     }
 
-    class GameObjectResetState : ServerPacket
+    class GameObjectResetState : ServerPacket, ISpanWritable
     {
         public GameObjectResetState() : base(Opcode.SMSG_GAME_OBJECT_RESET_STATE) { }
 
@@ -69,10 +80,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(ObjectGUID);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(ObjectGUID.Low, ObjectGUID.High);
+            return writer.Position;
+        }
+
         public WowGuid128 ObjectGUID;
     }
 
-    class GameObjectCustomAnim : ServerPacket
+    class GameObjectCustomAnim : ServerPacket, ISpanWritable
     {
         public GameObjectCustomAnim() : base(Opcode.SMSG_GAME_OBJECT_CUSTOM_ANIM, ConnectionType.Instance) { }
 
@@ -84,22 +104,42 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 5; // GUID + uint + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(ObjectGUID.Low, ObjectGUID.High);
+            writer.WriteUInt32(CustomAnim);
+            writer.WriteBit(PlayAsDespawn);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public WowGuid128 ObjectGUID;
         public uint CustomAnim;
         public bool PlayAsDespawn;
     }
 
-    class FishNotHooked : ServerPacket
+    class FishNotHooked : ServerPacket, ISpanWritable
     {
         public FishNotHooked() : base(Opcode.SMSG_FISH_NOT_HOOKED) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
-    class FishEscaped : ServerPacket
+    class FishEscaped : ServerPacket, ISpanWritable
     {
         public FishEscaped() : base(Opcode.SMSG_FISH_ESCAPED) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 }

--- a/HermesProxy/World/Server/Packets/GroupPackets.cs
+++ b/HermesProxy/World/Server/Packets/GroupPackets.cs
@@ -18,10 +18,12 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace HermesProxy.World.Server.Packets
 {
@@ -50,7 +52,7 @@ namespace HermesProxy.World.Server.Packets
         public string TargetRealm;
     }
 
-    class PartyCommandResult : ServerPacket
+    class PartyCommandResult : ServerPacket, ISpanWritable
     {
         public PartyCommandResult() : base(Opcode.SMSG_PARTY_COMMAND_RESULT) { }
 
@@ -65,6 +67,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(Name);
         }
 
+        // MaxSize: bits (9+4+6=19 -> 3) + uint (4) + GUID (18) + name (24) = 49
+        public int MaxSize => 3 + 4 + PackedGuidHelper.MaxPackedGuid128Size + GameLimits.MaxPlayerNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Name), 9);
+            writer.WriteBits(Command, 4);
+            writer.WriteBits(Result, 6);
+
+            writer.WriteUInt32(ResultData);
+            writer.WritePackedGuid128(ResultGUID.Low, ResultGUID.High);
+            writer.WriteString(Name);
+            return writer.Position;
+        }
+
         public string Name;
         public byte Command;
         public byte Result;
@@ -72,7 +90,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 ResultGUID = WowGuid128.Empty;
     }
 
-    class GroupDecline : ServerPacket
+    class GroupDecline : ServerPacket, ISpanWritable
     {
         public GroupDecline() : base(Opcode.SMSG_GROUP_DECLINE) { }
 
@@ -81,6 +99,18 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteBits(Name.GetByteCount(), 9);
             _worldPacket.FlushBits();
             _worldPacket.WriteString(Name);
+        }
+
+        // MaxSize: 9 bits (2 bytes) + max player name bytes
+        public int MaxSize => 2 + GameLimits.MaxPlayerNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Name), 9);
+            writer.FlushBits();
+            writer.WriteString(Name);
+            return writer.Position;
         }
 
         public string Name;
@@ -322,11 +352,15 @@ namespace HermesProxy.World.Server.Packets
         public string Reason;
     }
 
-    class GroupUninvite : ServerPacket
+    class GroupUninvite : ServerPacket, ISpanWritable
     {
         public GroupUninvite() : base(Opcode.SMSG_GROUP_UNINVITE) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
     class SetAssistantLeader : ClientPacket
@@ -373,7 +407,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 TargetGUID;
     }
 
-    class GroupNewLeader : ServerPacket
+    class GroupNewLeader : ServerPacket, ISpanWritable
     {
         public GroupNewLeader() : base(Opcode.SMSG_GROUP_NEW_LEADER) { }
 
@@ -382,6 +416,18 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt8(PartyIndex);
             _worldPacket.WriteBits(Name.GetByteCount(), 9);
             _worldPacket.WriteString(Name);
+        }
+
+        // MaxSize: int8 (1) + 9 bits (2 bytes) + max player name bytes
+        public int MaxSize => 1 + 2 + GameLimits.MaxPlayerNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt8(PartyIndex);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Name), 9);
+            writer.WriteString(Name);
+            return writer.Position;
         }
 
         public sbyte PartyIndex;
@@ -412,7 +458,7 @@ namespace HermesProxy.World.Server.Packets
         public sbyte PartyIndex;
     }
 
-    class ReadyCheckStarted : ServerPacket
+    class ReadyCheckStarted : ServerPacket, ISpanWritable
     {
         public ReadyCheckStarted() : base(Opcode.SMSG_READY_CHECK_STARTED) { }
 
@@ -422,6 +468,18 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(PartyGUID);
             _worldPacket.WritePackedGuid128(InitiatorGUID);
             _worldPacket.WriteUInt64(Duration);
+        }
+
+        public int MaxSize => 1 + PackedGuidHelper.MaxPackedGuid128Size * 2 + 8; // sbyte + 2 GUIDs + ulong
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt8((sbyte)PartyIndex);
+            writer.WritePackedGuid128(PartyGUID.Low, PartyGUID.High);
+            writer.WritePackedGuid128(InitiatorGUID.Low, InitiatorGUID.High);
+            writer.WriteUInt64(Duration);
+            return writer.Position;
         }
 
         public sbyte PartyIndex;
@@ -444,7 +502,7 @@ namespace HermesProxy.World.Server.Packets
         public bool IsReady;
     }
 
-    class ReadyCheckResponse : ServerPacket
+    class ReadyCheckResponse : ServerPacket, ISpanWritable
     {
         public ReadyCheckResponse() : base(Opcode.SMSG_READY_CHECK_RESPONSE) { }
 
@@ -457,12 +515,24 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 1; // 2 GUIDs + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(PartyGUID.Low, PartyGUID.High);
+            writer.WritePackedGuid128(Player.Low, Player.High);
+            writer.WriteBit(IsReady);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public WowGuid128 PartyGUID;
         public WowGuid128 Player;
         public bool IsReady;
     }
 
-    class ReadyCheckCompleted : ServerPacket
+    class ReadyCheckCompleted : ServerPacket, ISpanWritable
     {
         public ReadyCheckCompleted() : base(Opcode.SMSG_READY_CHECK_COMPLETED) { }
 
@@ -470,6 +540,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WriteInt8(PartyIndex);
             _worldPacket.WritePackedGuid128(PartyGUID);
+        }
+
+        public int MaxSize => 1 + PackedGuidHelper.MaxPackedGuid128Size; // sbyte + GUID
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt8((sbyte)PartyIndex);
+            writer.WritePackedGuid128(PartyGUID.Low, PartyGUID.High);
+            return writer.Position;
         }
 
         public sbyte PartyIndex;
@@ -492,7 +572,7 @@ namespace HermesProxy.World.Server.Packets
         public sbyte Symbol;
     }
 
-    class SendRaidTargetUpdateSingle : ServerPacket
+    class SendRaidTargetUpdateSingle : ServerPacket, ISpanWritable
     {
         public SendRaidTargetUpdateSingle() : base(Opcode.SMSG_SEND_RAID_TARGET_UPDATE_SINGLE) { }
 
@@ -504,14 +584,29 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(ChangedBy);
         }
 
+        public int MaxSize => 2 + PackedGuidHelper.MaxPackedGuid128Size * 2; // 2 sbytes + 2 GUIDs
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt8((sbyte)PartyIndex);
+            writer.WriteInt8((sbyte)Symbol);
+            writer.WritePackedGuid128(Target.Low, Target.High);
+            writer.WritePackedGuid128(ChangedBy.Low, ChangedBy.High);
+            return writer.Position;
+        }
+
         public sbyte PartyIndex;
         public sbyte Symbol;
         public WowGuid128 Target;
         public WowGuid128 ChangedBy;
     }
 
-    class SendRaidTargetUpdateAll : ServerPacket
+    class SendRaidTargetUpdateAll : ServerPacket, ISpanWritable
     {
+        // WoW has exactly 8 raid target markers (skull, cross, square, moon, triangle, diamond, circle, star)
+        private const int MaxRaidTargets = 8;
+
         public SendRaidTargetUpdateAll() : base(Opcode.SMSG_SEND_RAID_TARGET_UPDATE_ALL) { }
 
         public override void Write()
@@ -526,11 +621,33 @@ namespace HermesProxy.World.Server.Packets
             }
         }
 
+        // MaxSize: sbyte (1) + int (4) + 8 * (PackedGuid128 (18) + sbyte (1)) = 157
+        public int MaxSize => 1 + 4 + MaxRaidTargets * (PackedGuidHelper.MaxPackedGuid128Size + 1);
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            // Hard cap - should never exceed 8
+            if (TargetIcons.Count > MaxRaidTargets)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt8(PartyIndex);
+            writer.WriteInt32(TargetIcons.Count);
+
+            foreach (var pair in TargetIcons)
+            {
+                writer.WritePackedGuid128(pair.Item2.Low, pair.Item2.High);
+                writer.WriteInt8(pair.Item1);
+            }
+
+            return writer.Position;
+        }
+
         public sbyte PartyIndex;
         public List<Tuple<sbyte, WowGuid128>> TargetIcons = new();
     }
 
-    class SummonRequest : ServerPacket
+    class SummonRequest : ServerPacket, ISpanWritable
     {
         public SummonRequest() : base(Opcode.SMSG_SUMMON_REQUEST, ConnectionType.Instance) { }
 
@@ -542,6 +659,20 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt8((byte)Reason);
             _worldPacket.WriteBit(SkipStartingArea);
             _worldPacket.FlushBits();
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 10; // GUID + uint + int + byte + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(SummonerGUID.Low, SummonerGUID.High);
+            writer.WriteUInt32(SummonerVirtualRealmAddress);
+            writer.WriteInt32(AreaID);
+            writer.WriteUInt8((byte)Reason);
+            writer.WriteBit(SkipStartingArea);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public WowGuid128 SummonerGUID;
@@ -940,7 +1071,7 @@ namespace HermesProxy.World.Server.Packets
         public sbyte PartyIndex;
     }
 
-    class MinimapPing : ServerPacket
+    class MinimapPing : ServerPacket, ISpanWritable
     {
         public MinimapPing() : base(Opcode.SMSG_MINIMAP_PING) { }
 
@@ -948,6 +1079,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WritePackedGuid128(SenderGUID);
             _worldPacket.WriteVector2(Position);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 8; // GUID + Vector2 (2 floats)
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(SenderGUID.Low, SenderGUID.High);
+            writer.WriteVector2(Position);
+            return writer.Position;
         }
 
         public WowGuid128 SenderGUID;
@@ -970,7 +1111,7 @@ namespace HermesProxy.World.Server.Packets
         public byte PartyIndex;
     }
 
-    public class RandomRoll : ServerPacket
+    public class RandomRoll : ServerPacket, ISpanWritable
     {
         public RandomRoll() : base(Opcode.SMSG_RANDOM_ROLL) { }
 
@@ -981,6 +1122,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(Min);
             _worldPacket.WriteInt32(Max);
             _worldPacket.WriteInt32(Result);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 12; // 2 GUIDs + 3 ints
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Roller.Low, Roller.High);
+            writer.WritePackedGuid128(RollerWowAccount.Low, RollerWowAccount.High);
+            writer.WriteInt32(Min);
+            writer.WriteInt32(Max);
+            writer.WriteInt32(Result);
+            return writer.Position;
         }
 
         public WowGuid128 Roller;

--- a/HermesProxy/World/Server/Packets/GuildPackets.cs
+++ b/HermesProxy/World/Server/Packets/GuildPackets.cs
@@ -16,16 +16,18 @@
  */
 
 
+using System;
+using System.Text;
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
-using System;
 using System.Collections.Generic;
 
 namespace HermesProxy.World.Server.Packets
 {
-    public class GuildCommandResult : ServerPacket
+    public class GuildCommandResult : ServerPacket, ISpanWritable
     {
         public GuildCommandResult() : base(Opcode.SMSG_GUILD_COMMAND_RESULT) { }
 
@@ -36,6 +38,19 @@ namespace HermesProxy.World.Server.Packets
 
             _worldPacket.WriteBits(Name.GetByteCount(), 8);
             _worldPacket.WriteString(Name);
+        }
+
+        // MaxSize: 2 uints (8) + bits (8 -> 1) + guild name (48) = 57
+        public int MaxSize => 8 + 1 + GameLimits.MaxGuildNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32((uint)Result);
+            writer.WriteUInt32((uint)Command);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Name), 8);
+            writer.WriteString(Name);
+            return writer.Position;
         }
 
         public string Name;
@@ -301,7 +316,7 @@ namespace HermesProxy.World.Server.Packets
         public uint[] TabWithdrawItemLimit = new uint[GuildConst.MaxBankTabs];
     }
 
-    public class GuildSendRankChange : ServerPacket
+    public class GuildSendRankChange : ServerPacket, ISpanWritable
     {
         public GuildSendRankChange() : base(Opcode.SMSG_GUILD_SEND_RANK_CHANGE) { }
 
@@ -315,13 +330,26 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 5; // 2 GUIDs + uint + bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Officer.Low, Officer.High);
+            writer.WritePackedGuid128(Other.Low, Other.High);
+            writer.WriteUInt32(RankID);
+            writer.WriteBit(Promote);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public WowGuid128 Other;
         public WowGuid128 Officer;
         public bool Promote;
         public uint RankID;
     }
 
-    public class GuildEventMotd : ServerPacket
+    public class GuildEventMotd : ServerPacket, ISpanWritable
     {
         public GuildEventMotd() : base(Opcode.SMSG_GUILD_EVENT_MOTD) { }
 
@@ -331,10 +359,27 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(MotdText);
         }
 
+        // Cap for MOTD text - usually short messages
+        private const int MaxMotdBytes = 256;
+        // 11 bits(2) + text
+        public int MaxSize => 2 + MaxMotdBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int motdBytes = Encoding.UTF8.GetByteCount(MotdText);
+            if (motdBytes > MaxMotdBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)motdBytes, 11);
+            writer.WriteString(MotdText);
+            return writer.Position;
+        }
+
         public string MotdText;
     }
 
-    public class GuildEventPlayerJoined : ServerPacket
+    public class GuildEventPlayerJoined : ServerPacket, ISpanWritable
     {
         public GuildEventPlayerJoined() : base(Opcode.SMSG_GUILD_EVENT_PLAYER_JOINED) { }
 
@@ -347,12 +392,25 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(Name);
         }
 
+        // MaxSize: GUID (18) + uint (4) + 6 bits (1) + player name bytes (24) = 47
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4 + 1 + GameLimits.MaxPlayerNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            writer.WriteUInt32(VirtualRealmAddress);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Name), 6);
+            writer.WriteString(Name);
+            return writer.Position;
+        }
+
         public WowGuid128 Guid;
         public uint VirtualRealmAddress;
         public string Name;
     }
 
-    public class GuildEventPlayerLeft : ServerPacket
+    public class GuildEventPlayerLeft : ServerPacket, ISpanWritable
     {
         public GuildEventPlayerLeft() : base(Opcode.SMSG_GUILD_EVENT_PLAYER_LEFT) { }
 
@@ -374,6 +432,31 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(LeaverName);
         }
 
+        // MaxSize (worst case with Removed=true):
+        // bits (1+6+6=13 -> 2 bytes) + RemoverGUID (18) + uint (4) + RemoverName (24)
+        // + LeaverGUID (18) + uint (4) + LeaverName (24) = 94
+        public int MaxSize => 2 + PackedGuidHelper.MaxPackedGuid128Size * 2 + 8 + GameLimits.MaxPlayerNameBytes * 2;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBit(Removed);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(LeaverName), 6);
+
+            if (Removed)
+            {
+                writer.WriteBits((uint)Encoding.UTF8.GetByteCount(RemoverName), 6);
+                writer.WritePackedGuid128(RemoverGUID.Low, RemoverGUID.High);
+                writer.WriteUInt32(RemoverVirtualRealmAddress);
+                writer.WriteString(RemoverName);
+            }
+
+            writer.WritePackedGuid128(LeaverGUID.Low, LeaverGUID.High);
+            writer.WriteUInt32(LeaverVirtualRealmAddress);
+            writer.WriteString(LeaverName);
+            return writer.Position;
+        }
+
         public bool Removed;
         public WowGuid128 RemoverGUID;
         public uint RemoverVirtualRealmAddress;
@@ -383,7 +466,7 @@ namespace HermesProxy.World.Server.Packets
         public string LeaverName;
     }
 
-    public class GuildEventNewLeader : ServerPacket
+    public class GuildEventNewLeader : ServerPacket, ISpanWritable
     {
         public GuildEventNewLeader() : base(Opcode.SMSG_GUILD_EVENT_NEW_LEADER) { }
 
@@ -402,6 +485,26 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(NewLeaderName);
         }
 
+        // MaxSize: bits (1+6+6=13 -> 2 bytes) + 2 GUIDs (36) + 2 uints (8) + 2 names (48) = 94
+        public int MaxSize => 2 + PackedGuidHelper.MaxPackedGuid128Size * 2 + 8 + GameLimits.MaxPlayerNameBytes * 2;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBit(SelfPromoted);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(OldLeaderName), 6);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(NewLeaderName), 6);
+
+            writer.WritePackedGuid128(OldLeaderGUID.Low, OldLeaderGUID.High);
+            writer.WriteUInt32(OldLeaderVirtualRealmAddress);
+            writer.WritePackedGuid128(NewLeaderGUID.Low, NewLeaderGUID.High);
+            writer.WriteUInt32(NewLeaderVirtualRealmAddress);
+
+            writer.WriteString(OldLeaderName);
+            writer.WriteString(NewLeaderName);
+            return writer.Position;
+        }
+
         public bool SelfPromoted;
         public WowGuid128 NewLeaderGUID;
         public uint NewLeaderVirtualRealmAddress;
@@ -411,21 +514,29 @@ namespace HermesProxy.World.Server.Packets
         public string OldLeaderName;
     }
 
-    public class GuildEventDisbanded : ServerPacket
+    public class GuildEventDisbanded : ServerPacket, ISpanWritable
     {
         public GuildEventDisbanded() : base(Opcode.SMSG_GUILD_EVENT_DISBANDED) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
-    public class GuildEventRanksUpdated : ServerPacket
+    public class GuildEventRanksUpdated : ServerPacket, ISpanWritable
     {
         public GuildEventRanksUpdated() : base(Opcode.SMSG_GUILD_EVENT_RANKS_UPDATED) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
-    public class GuildEventPresenceChange : ServerPacket
+    public class GuildEventPresenceChange : ServerPacket, ISpanWritable
     {
         public GuildEventPresenceChange() : base(Opcode.SMSG_GUILD_EVENT_PRESENCE_CHANGE) { }
 
@@ -441,6 +552,23 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(Name);
         }
 
+        // MaxSize: GUID (18) + uint (4) + bits (6+1+1=8 -> 1 byte) + name (24) = 47
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4 + 1 + GameLimits.MaxPlayerNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            writer.WriteUInt32(VirtualRealmAddress);
+
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Name), 6);
+            writer.WriteBit(LoggedOn);
+            writer.WriteBit(Mobile);
+
+            writer.WriteString(Name);
+            return writer.Position;
+        }
+
         public WowGuid128 Guid;
         public uint VirtualRealmAddress;
         public bool LoggedOn;
@@ -448,14 +576,18 @@ namespace HermesProxy.World.Server.Packets
         public string Name;
     }
 
-    public class GuildEventTabAdded : ServerPacket
+    public class GuildEventTabAdded : ServerPacket, ISpanWritable
     {
         public GuildEventTabAdded() : base(Opcode.SMSG_GUILD_EVENT_TAB_ADDED) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
-    public class GuildEventTabModified : ServerPacket
+    public class GuildEventTabModified : ServerPacket, ISpanWritable
     {
         public GuildEventTabModified() : base(Opcode.SMSG_GUILD_EVENT_TAB_MODIFIED) { }
 
@@ -471,12 +603,35 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(Icon);
         }
 
+        // Cap for tab name and icon path
+        private const int MaxNameBytes = 64;
+        private const int MaxIconBytes = 256;
+        // int(4) + 16 bits(2) + name + icon
+        public int MaxSize => 4 + 2 + MaxNameBytes + MaxIconBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int nameBytes = Encoding.UTF8.GetByteCount(Name);
+            int iconBytes = Encoding.UTF8.GetByteCount(Icon);
+            if (nameBytes > MaxNameBytes || iconBytes > MaxIconBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Tab);
+            writer.WriteBits((uint)nameBytes, 7);
+            writer.WriteBits((uint)iconBytes, 9);
+            writer.FlushBits();
+            writer.WriteString(Name);
+            writer.WriteString(Icon);
+            return writer.Position;
+        }
+
         public int Tab;
         public string Name;
         public string Icon;
     }
 
-    public class GuildEventBankMoneyChanged : ServerPacket
+    public class GuildEventBankMoneyChanged : ServerPacket, ISpanWritable
     {
         public GuildEventBankMoneyChanged() : base(Opcode.SMSG_GUILD_EVENT_BANK_MONEY_CHANGED) { }
 
@@ -485,16 +640,34 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt64(Money);
         }
 
+        public int MaxSize => 8; // ulong
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt64(Money);
+            return writer.Position;
+        }
+
         public ulong Money;
     }
 
-    public class GuildEventTabTextChanged : ServerPacket
+    public class GuildEventTabTextChanged : ServerPacket, ISpanWritable
     {
         public GuildEventTabTextChanged() : base(Opcode.SMSG_GUILD_EVENT_TAB_TEXT_CHANGED) { }
 
         public override void Write()
         {
             _worldPacket.WriteInt32(Tab);
+        }
+
+        public int MaxSize => 4; // int
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Tab);
+            return writer.Position;
         }
 
         public int Tab;
@@ -600,7 +773,7 @@ namespace HermesProxy.World.Server.Packets
         public uint ArenaTeamId;
     }
 
-    public class GuildInvite : ServerPacket
+    public class GuildInvite : ServerPacket, ISpanWritable
     {
         public GuildInvite() : base(Opcode.SMSG_GUILD_INVITE) { }
 
@@ -625,6 +798,36 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(InviterName);
             _worldPacket.WriteString(GuildName);
             _worldPacket.WriteString(OldGuildName);
+        }
+
+        // MaxSize: bits (6+7+7=20 -> 3 bytes) + 3 uints (12) + 2 GUIDs (36) + 6 uints (24)
+        // + player name (24) + guild name (48) + old guild name (48) = 195
+        public int MaxSize => 3 + 12 + PackedGuidHelper.MaxPackedGuid128Size * 2 + 24 +
+            GameLimits.MaxPlayerNameBytes + GameLimits.MaxGuildNameBytes * 2;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(InviterName), 6);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(GuildName), 7);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(OldGuildName), 7);
+
+            writer.WriteUInt32(InviterVirtualRealmAddress);
+            writer.WriteUInt32(GuildVirtualRealmAddress);
+            writer.WritePackedGuid128(GuildGUID.Low, GuildGUID.High);
+            writer.WriteUInt32(OldGuildVirtualRealmAddress);
+            writer.WritePackedGuid128(OldGuildGUID.Low, OldGuildGUID.High);
+            writer.WriteUInt32(EmblemStyle);
+            writer.WriteUInt32(EmblemColor);
+            writer.WriteUInt32(BorderStyle);
+            writer.WriteUInt32(BorderColor);
+            writer.WriteUInt32(BackgroundColor);
+            writer.WriteInt32(AchievementPoints);
+
+            writer.WriteString(InviterName);
+            writer.WriteString(GuildName);
+            writer.WriteString(OldGuildName);
+            return writer.Position;
         }
 
         public WowGuid128 GuildGUID;
@@ -657,7 +860,7 @@ namespace HermesProxy.World.Server.Packets
         public override void Read() { }
     }
 
-    public class GuildInviteDeclined : ServerPacket
+    public class GuildInviteDeclined : ServerPacket, ISpanWritable
     {
         public GuildInviteDeclined() : base(Opcode.SMSG_GUILD_INVITE_DECLINED) { }
 
@@ -670,6 +873,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(InviterVirtualRealmAddress);
             _worldPacket.WriteString(InviterName);
 
+        }
+
+        // MaxSize: bits (6+1=7 -> 1 byte) + uint (4) + player name (24) = 29
+        public int MaxSize => 1 + 4 + GameLimits.MaxPlayerNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(InviterName), 6);
+            writer.WriteBit(AutoDecline);
+            writer.FlushBits();
+
+            writer.WriteUInt32(InviterVirtualRealmAddress);
+            writer.WriteString(InviterName);
+            return writer.Position;
         }
 
         public bool AutoDecline;
@@ -767,13 +985,22 @@ namespace HermesProxy.World.Server.Packets
         public override void Read() { }
     }
 
-    public class PlayerTabardVendorActivate : ServerPacket
+    public class PlayerTabardVendorActivate : ServerPacket, ISpanWritable
     {
         public PlayerTabardVendorActivate() : base(Opcode.SMSG_PLAYER_TABARD_VENDOR_ACTIVATE) { }
 
         public override void Write()
         {
             _worldPacket.WritePackedGuid128(DesignerGUID);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(DesignerGUID.Low, DesignerGUID.High);
+            return writer.Position;
         }
 
         public WowGuid128 DesignerGUID;
@@ -801,13 +1028,22 @@ namespace HermesProxy.World.Server.Packets
         public uint BackgroundColor;
     }
 
-    public class PlayerSaveGuildEmblem : ServerPacket
+    public class PlayerSaveGuildEmblem : ServerPacket, ISpanWritable
     {
         public PlayerSaveGuildEmblem() : base(Opcode.SMSG_PLAYER_SAVE_GUILD_EMBLEM) { }
 
         public override void Write()
         {
             _worldPacket.WriteUInt32((uint)Error);
+        }
+
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32((uint)Error);
+            return writer.Position;
         }
 
         public GuildEmblemError Error;
@@ -965,7 +1201,7 @@ namespace HermesProxy.World.Server.Packets
         public int Tab;
     }
 
-    public class GuildBankTextQueryResult : ServerPacket
+    public class GuildBankTextQueryResult : ServerPacket, ISpanWritable
     {
         public GuildBankTextQueryResult() : base(Opcode.SMSG_GUILD_BANK_TEXT_QUERY_RESULT) { }
 
@@ -975,6 +1211,25 @@ namespace HermesProxy.World.Server.Packets
 
             _worldPacket.WriteBits(Text.GetByteCount(), 14);
             _worldPacket.WriteString(Text);
+        }
+
+        // Cap for bank tab text - usually short descriptions
+        private const int MaxTextBytes = 512;
+        // int(4) + 14 bits(2) + text
+        public int MaxSize => 4 + 2 + MaxTextBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int textBytes = Text != null ? Encoding.UTF8.GetByteCount(Text) : 0;
+            if (textBytes > MaxTextBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Tab);
+            writer.WriteBits((uint)textBytes, 14);
+            if (Text != null)
+                writer.WriteString(Text);
+            return writer.Position;
         }
 
         public int Tab;
@@ -1103,13 +1358,22 @@ namespace HermesProxy.World.Server.Packets
         public byte BankTab;
     }
 
-    public class GuildBankRemainingWithdrawMoney : ServerPacket
+    public class GuildBankRemainingWithdrawMoney : ServerPacket, ISpanWritable
     {
         public GuildBankRemainingWithdrawMoney() : base(Opcode.SMSG_GUILD_BANK_REMAINING_WITHDRAW_MONEY) { }
 
         public override void Write()
         {
             _worldPacket.WriteInt64(RemainingWithdrawMoney);
+        }
+
+        public int MaxSize => 8; // long
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt64(RemainingWithdrawMoney);
+            return writer.Position;
         }
 
         public long RemainingWithdrawMoney;

--- a/HermesProxy/World/Server/Packets/InstancePackets.cs
+++ b/HermesProxy/World/Server/Packets/InstancePackets.cs
@@ -18,6 +18,7 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
@@ -25,7 +26,7 @@ using System.Collections.Generic;
 
 namespace HermesProxy.World.Server.Packets
 {
-    class UpdateInstanceOwnership : ServerPacket
+    class UpdateInstanceOwnership : ServerPacket, ISpanWritable
     {
         public UpdateInstanceOwnership() : base(Opcode.SMSG_UPDATE_INSTANCE_OWNERSHIP) { }
 
@@ -34,10 +35,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(IOwnInstance);
         }
 
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(IOwnInstance);
+            return writer.Position;
+        }
+
         public uint IOwnInstance;
     }
 
-    class UpdateLastInstance : ServerPacket
+    class UpdateLastInstance : ServerPacket, ISpanWritable
     {
         public UpdateLastInstance() : base(Opcode.SMSG_UPDATE_LAST_INSTANCE) { }
 
@@ -46,10 +56,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(MapID);
         }
 
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(MapID);
+            return writer.Position;
+        }
+
         public uint MapID;
     }
 
-    class InstanceReset : ServerPacket
+    class InstanceReset : ServerPacket, ISpanWritable
     {
         public InstanceReset() : base(Opcode.SMSG_INSTANCE_RESET) { }
 
@@ -58,10 +77,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(MapID);
         }
 
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(MapID);
+            return writer.Position;
+        }
+
         public uint MapID;
     }
 
-    class InstanceResetFailed : ServerPacket
+    class InstanceResetFailed : ServerPacket, ISpanWritable
     {
         public InstanceResetFailed() : base(Opcode.SMSG_INSTANCE_RESET_FAILED) { }
 
@@ -72,18 +100,33 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 5; // uint + 1 byte for 2 bits
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(MapID);
+            writer.WriteBits((uint)ResetFailedReason, 2);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public uint MapID;
         public ResetFailedReason ResetFailedReason;
     }
 
-    class ResetFailedNotify : ServerPacket
+    class ResetFailedNotify : ServerPacket, ISpanWritable
     {
         public ResetFailedNotify() : base(Opcode.SMSG_RESET_FAILED_NOTIFY) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
-    class RaidInstanceInfo : ServerPacket
+    class RaidInstanceInfo : ServerPacket, ISpanWritable
     {
         public RaidInstanceInfo() : base(Opcode.SMSG_RAID_INSTANCE_INFO) { }
 
@@ -93,6 +136,35 @@ namespace HermesProxy.World.Server.Packets
 
             foreach (InstanceLock lockInfos in LockList)
                 lockInfos.Write(_worldPacket);
+        }
+
+        // Cap for raid lockouts - players typically have few
+        private const int MaxLocks = 16;
+        // Each lock: 2 uints(8) + ulong(8) + int(4) + uint(4) + 2 bits(1) = 25 bytes
+        private const int LockSize = 25;
+        // count(4) + locks
+        public int MaxSize => 4 + MaxLocks * LockSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (LockList.Count > MaxLocks)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(LockList.Count);
+
+            foreach (InstanceLock lockInfos in LockList)
+            {
+                writer.WriteUInt32(lockInfos.MapID);
+                writer.WriteUInt32((uint)lockInfos.DifficultyID);
+                writer.WriteUInt64(lockInfos.InstanceID);
+                writer.WriteInt32(lockInfos.TimeRemaining);
+                writer.WriteUInt32(lockInfos.CompletedMask);
+                writer.WriteBit(lockInfos.Locked);
+                writer.WriteBit(lockInfos.Extended);
+                writer.FlushBits();
+            }
+            return writer.Position;
         }
 
         public List<InstanceLock> LockList = new();
@@ -123,7 +195,7 @@ namespace HermesProxy.World.Server.Packets
         public bool Extended;
     }
 
-    class InstanceSaveCreated : ServerPacket
+    class InstanceSaveCreated : ServerPacket, ISpanWritable
     {
         public InstanceSaveCreated() : base(Opcode.SMSG_INSTANCE_SAVE_CREATED) { }
 
@@ -133,10 +205,20 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 1; // 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBit(Gm);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public bool Gm;
     }
 
-    class RaidGroupOnly : ServerPacket
+    class RaidGroupOnly : ServerPacket, ISpanWritable
     {
         public RaidGroupOnly() : base(Opcode.SMSG_RAID_GROUP_ONLY) { }
 
@@ -146,11 +228,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32((uint)Reason);
         }
 
+        public int MaxSize => 8; // int + uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Delay);
+            writer.WriteUInt32((uint)Reason);
+            return writer.Position;
+        }
+
         public int Delay;
         public RaidGroupReason Reason;
     }
 
-    class RaidInstanceMessage : ServerPacket
+    class RaidInstanceMessage : ServerPacket, ISpanWritable
     {
         public RaidInstanceMessage() : base(Opcode.SMSG_RAID_INSTANCE_MESSAGE) { }
 
@@ -162,6 +254,20 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteBit(Locked);
             _worldPacket.WriteBit(Extended);
             _worldPacket.FlushBits();
+        }
+
+        public int MaxSize => 10; // byte + 2 uint + 1 byte for bits
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt8((byte)Type);
+            writer.WriteUInt32(MapID);
+            writer.WriteUInt32((uint)DifficultyID);
+            writer.WriteBit(Locked);
+            writer.WriteBit(Extended);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public InstanceResetWarningType Type;

--- a/HermesProxy/World/Server/Packets/ItemPackets.cs
+++ b/HermesProxy/World/Server/Packets/ItemPackets.cs
@@ -16,15 +16,17 @@
  */
 
 
+using System;
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System.Collections.Generic;
 
 namespace HermesProxy.World.Server.Packets
 {
-    public class SetProficiency : ServerPacket
+    public class SetProficiency : ServerPacket, ISpanWritable
     {
         public SetProficiency() : base(Opcode.SMSG_SET_PROFICIENCY, ConnectionType.Instance) { }
 
@@ -32,6 +34,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WriteUInt32(ProficiencyMask);
             _worldPacket.WriteUInt8(ProficiencyClass);
+        }
+
+        public int MaxSize => 5; // uint + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(ProficiencyMask);
+            writer.WriteUInt8(ProficiencyClass);
+            return writer.Position;
         }
 
         public uint ProficiencyMask;
@@ -79,7 +91,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 ContainerGUID;
     }
 
-    public class BuySucceeded : ServerPacket
+    public class BuySucceeded : ServerPacket, ISpanWritable
     {
         public BuySucceeded() : base(Opcode.SMSG_BUY_SUCCEEDED) { }
 
@@ -91,13 +103,25 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(QuantityBought);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 12; // GUID + uint + int + uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(VendorGUID.Low, VendorGUID.High);
+            writer.WriteUInt32(Slot);
+            writer.WriteInt32(NewQuantity);
+            writer.WriteUInt32(QuantityBought);
+            return writer.Position;
+        }
+
         public WowGuid128 VendorGUID;
         public uint Slot;
         public int NewQuantity;
         public uint QuantityBought;
     }
 
-    public class BuyFailed : ServerPacket
+    public class BuyFailed : ServerPacket, ISpanWritable
     {
         public BuyFailed() : base(Opcode.SMSG_BUY_FAILED) { }
 
@@ -108,12 +132,23 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt8((byte)Reason);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 5; // GUID + uint + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(VendorGUID.Low, VendorGUID.High);
+            writer.WriteUInt32(Slot);
+            writer.WriteUInt8((byte)Reason);
+            return writer.Position;
+        }
+
         public WowGuid128 VendorGUID;
         public uint Slot;
         public BuyResult Reason = BuyResult.CantFindItem;
     }
 
-    class ItemPushResult : ServerPacket
+    class ItemPushResult : ServerPacket, ISpanWritable
     {
         public ItemPushResult() : base(Opcode.SMSG_ITEM_PUSH_RESULT) { }
 
@@ -139,6 +174,38 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
 
             Item.Write(_worldPacket);
+        }
+
+        // 2 GUIDs (18 each) + byte + 9 ints + 1 byte bits + ItemInstance
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 1 + 9 * 4 + 1 +
+                              ItemPacketHelpers.ItemInstanceMaxSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(PlayerGUID.Low, PlayerGUID.High);
+            writer.WriteUInt8(Slot);
+            writer.WriteInt32(SlotInBag);
+            writer.WriteInt32(QuestLogItemID);
+            writer.WriteUInt32(Quantity);
+            writer.WriteUInt32(QuantityInInventory);
+            writer.WriteInt32(DungeonEncounterID);
+            writer.WriteInt32(BattlePetSpeciesID);
+            writer.WriteInt32(BattlePetBreedID);
+            writer.WriteUInt32(BattlePetBreedQuality);
+            writer.WriteInt32(BattlePetLevel);
+            writer.WritePackedGuid128(ItemGUID.Low, ItemGUID.High);
+            writer.WriteBit(Pushed);
+            writer.WriteBit(Created);
+            writer.WriteBits((uint)DisplayText, 3);
+            writer.WriteBit(IsBonusRoll);
+            writer.WriteBit(IsEncounterLoot);
+            writer.FlushBits();
+
+            if (!ItemPacketHelpers.WriteItemInstance(ref writer, Item))
+                return -1;
+
+            return writer.Position;
         }
 
         public WowGuid128 PlayerGUID;
@@ -186,7 +253,7 @@ namespace HermesProxy.World.Server.Packets
         public uint Amount;
     }
 
-    public class SellResponse : ServerPacket
+    public class SellResponse : ServerPacket, ISpanWritable
     {
         public SellResponse() : base(Opcode.SMSG_SELL_RESPONSE) { }
 
@@ -195,6 +262,17 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(VendorGUID);
             _worldPacket.WritePackedGuid128(ItemGUID);
             _worldPacket.WriteUInt8(Reason);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 1; // 2 GUIDs + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(VendorGUID.Low, VendorGUID.High);
+            writer.WritePackedGuid128(ItemGUID.Low, ItemGUID.High);
+            writer.WriteUInt8(Reason);
+            return writer.Position;
         }
 
         public WowGuid128 VendorGUID;
@@ -471,7 +549,7 @@ namespace HermesProxy.World.Server.Packets
         public byte Slot;
     }
 
-    class ReadItemResultFailed : ServerPacket
+    class ReadItemResultFailed : ServerPacket, ISpanWritable
     {
         public ReadItemResultFailed() : base(Opcode.SMSG_READ_ITEM_RESULT_FAILED) { }
 
@@ -483,12 +561,24 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 5; // GUID + uint + 1 byte for bits
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(ItemGUID.Low, ItemGUID.High);
+            writer.WriteUInt32(Delay);
+            writer.WriteBits(Subcode, 2);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public WowGuid128 ItemGUID;
         public uint Delay;
         public byte Subcode;
     }
 
-    class ReadItemResultOK : ServerPacket
+    class ReadItemResultOK : ServerPacket, ISpanWritable
     {
         public ReadItemResultOK() : base(Opcode.SMSG_READ_ITEM_RESULT_OK) { }
 
@@ -497,10 +587,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(ItemGUID);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(ItemGUID.Low, ItemGUID.High);
+            return writer.Position;
+        }
+
         public WowGuid128 ItemGUID;
     }
 
-    public class InventoryChangeFailure : ServerPacket
+    public class InventoryChangeFailure : ServerPacket, ISpanWritable
     {
         public InventoryChangeFailure() : base(Opcode.SMSG_INVENTORY_CHANGE_FAILURE) { }
 
@@ -528,6 +627,40 @@ namespace HermesProxy.World.Server.Packets
                     _worldPacket.WriteInt32(LimitCategory);
                     break;
             }
+        }
+
+        // Fixed: sbyte + 2 GUIDs + byte = 2 + 36 = 38
+        // Max additional (EventAutoEquipBindConfirm): 2 GUIDs + int = 40
+        public int MaxSize => 2 + PackedGuidHelper.MaxPackedGuid128Size * 2 +
+                              PackedGuidHelper.MaxPackedGuid128Size * 2 + 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt8((sbyte)BagResult);
+            writer.WritePackedGuid128(Item[0].Low, Item[0].High);
+            writer.WritePackedGuid128(Item[1].Low, Item[1].High);
+            writer.WriteUInt8(ContainerBSlot);
+
+            switch (BagResult)
+            {
+                case InventoryResult.CantEquipLevel:
+                case InventoryResult.PurchaseLevelTooLow:
+                    writer.WriteInt32(Level);
+                    break;
+                case InventoryResult.EventAutoEquipBindConfirm:
+                    writer.WritePackedGuid128(SrcContainer.Low, SrcContainer.High);
+                    writer.WriteInt32(SrcSlot);
+                    writer.WritePackedGuid128(DstContainer.Low, DstContainer.High);
+                    break;
+                case InventoryResult.ItemMaxLimitCategoryCountExceeded:
+                case InventoryResult.ItemMaxLimitCategorySocketedExceeded:
+                case InventoryResult.ItemMaxLimitCategoryEquippedExceeded:
+                    writer.WriteInt32(LimitCategory);
+                    break;
+            }
+
+            return writer.Position;
         }
 
         public InventoryResult BagResult;
@@ -571,7 +704,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128[] Gems = new WowGuid128[ItemConst.MaxGemSockets];
     }
 
-    class SocketGemsSuccess : ServerPacket
+    class SocketGemsSuccess : ServerPacket, ISpanWritable
     {
         public SocketGemsSuccess() : base(Opcode.SMSG_SOCKET_GEMS_SUCCESS, ConnectionType.Instance) { }
 
@@ -580,10 +713,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(ItemGuid);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(ItemGuid.Low, ItemGuid.High);
+            return writer.Position;
+        }
+
         public WowGuid128 ItemGuid;
     }
 
-    class DurabilityDamageDeath : ServerPacket
+    class DurabilityDamageDeath : ServerPacket, ISpanWritable
     {
         public DurabilityDamageDeath() : base(Opcode.SMSG_DURABILITY_DAMAGE_DEATH) { }
 
@@ -592,10 +734,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(Percent);
         }
 
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(Percent);
+            return writer.Position;
+        }
+
         public uint Percent;
     }
 
-    class ItemCooldown : ServerPacket
+    class ItemCooldown : ServerPacket, ISpanWritable
     {
         public ItemCooldown() : base(Opcode.SMSG_ITEM_COOLDOWN) { }
 
@@ -604,6 +755,17 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(ItemGuid);
             _worldPacket.WriteUInt32(SpellID);
             _worldPacket.WriteUInt32(Cooldown);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 8; // GUID + 2 uints
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(ItemGuid.Low, ItemGuid.High);
+            writer.WriteUInt32(SpellID);
+            writer.WriteUInt32(Cooldown);
+            return writer.Position;
         }
 
         public WowGuid128 ItemGuid;
@@ -637,7 +799,7 @@ namespace HermesProxy.World.Server.Packets
         public uint ItemId;
     }
 
-    class ItemEnchantTimeUpdate : ServerPacket
+    class ItemEnchantTimeUpdate : ServerPacket, ISpanWritable
     {
         public ItemEnchantTimeUpdate() : base(Opcode.SMSG_ITEM_ENCHANT_TIME_UPDATE, ConnectionType.Instance) { }
 
@@ -649,13 +811,25 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(OwnerGuid);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 8; // 2 GUIDs + 2 uints
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(ItemGuid.Low, ItemGuid.High);
+            writer.WriteUInt32(DurationLeft);
+            writer.WriteUInt32(Slot);
+            writer.WritePackedGuid128(OwnerGuid.Low, OwnerGuid.High);
+            return writer.Position;
+        }
+
         public WowGuid128 ItemGuid;
         public uint DurationLeft;
         public uint Slot;
         public WowGuid128 OwnerGuid;
     }
 
-    class EnchantmentLog : ServerPacket
+    class EnchantmentLog : ServerPacket, ISpanWritable
     {
         public EnchantmentLog() : base(Opcode.SMSG_ENCHANTMENT_LOG) { }
 
@@ -668,6 +842,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(Enchantment);
             _worldPacket.WriteInt32(EnchantSlot);
         }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 3 + 12; // 3 GUIDs + 3 ints
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Owner.Low, Owner.High);
+            writer.WritePackedGuid128(Caster.Low, Caster.High);
+            writer.WritePackedGuid128(ItemGUID.Low, ItemGUID.High);
+            writer.WriteInt32(ItemID);
+            writer.WriteInt32(Enchantment);
+            writer.WriteInt32(EnchantSlot);
+            return writer.Position;
+        }
+
         public WowGuid128 Owner;
         public WowGuid128 Caster;
         public WowGuid128 ItemGUID;
@@ -705,5 +894,52 @@ namespace HermesProxy.World.Server.Packets
         public byte GiftSlot;
         public byte ItemBag;
         public byte ItemSlot;
+    }
+
+    internal static class ItemPacketHelpers
+    {
+        public const int MaxItemMods = 8;
+        public const int MaxBonusListIDs = 8;
+
+        // ItemInstance: 4+4+4 fixed + 1 bit flush + ItemModList + optional ItemBonuses
+        // ItemModList: 1 byte (6 bits count) + mods * 5
+        // ItemBonuses: 1 + 4 + bonuses * 4
+        public const int ItemInstanceMaxSize = 12 + 1 + 1 + MaxItemMods * 5 + 1 + 4 + MaxBonusListIDs * 4;
+
+        public static bool WriteItemInstance(ref SpanPacketWriter writer, ItemInstance item)
+        {
+            writer.WriteUInt32(item.ItemID);
+            writer.WriteUInt32(item.RandomPropertiesSeed);
+            writer.WriteUInt32(item.RandomPropertiesID);
+
+            writer.WriteBit(item.ItemBonus != null);
+            writer.FlushBits();
+
+            // ItemModList
+            if (item.Modifications.Values.Count > MaxItemMods)
+                return false;
+
+            writer.WriteBits((uint)item.Modifications.Values.Count, 6);
+            writer.FlushBits();
+            foreach (ItemMod itemMod in item.Modifications.Values)
+            {
+                writer.WriteUInt32(itemMod.Value);
+                writer.WriteUInt8((byte)itemMod.Type);
+            }
+
+            // ItemBonuses (optional)
+            if (item.ItemBonus != null)
+            {
+                if (item.ItemBonus.BonusListIDs.Count > MaxBonusListIDs)
+                    return false;
+
+                writer.WriteUInt8((byte)item.ItemBonus.Context);
+                writer.WriteInt32(item.ItemBonus.BonusListIDs.Count);
+                foreach (uint bonusID in item.ItemBonus.BonusListIDs)
+                    writer.WriteUInt32(bonusID);
+            }
+
+            return true;
+        }
     }
 }

--- a/HermesProxy/World/Server/Packets/LootPackets.cs
+++ b/HermesProxy/World/Server/Packets/LootPackets.cs
@@ -16,8 +16,10 @@
  */
 
 
+using System;
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System.Collections.Generic;
@@ -36,7 +38,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 Unit;
     }
 
-    public class LootResponse : ServerPacket
+    public class LootResponse : ServerPacket, ISpanWritable
     {
         public LootResponse() : base(Opcode.SMSG_LOOT_RESPONSE, ConnectionType.Instance) { }
 
@@ -66,6 +68,63 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteBits(currency.UIType, 3);
                 _worldPacket.FlushBits();
             }
+        }
+
+        private const int MaxItems = 16;
+        private const int MaxCurrencies = 4;
+        // LootItemData: 1 (bits) + ItemInstance + 4 + 1 + 1 = 7 + ItemInstanceMaxSize
+        private const int LootItemDataSize = 7 + ItemPacketHelpers.ItemInstanceMaxSize;
+        // LootCurrency: 4 + 4 + 1 + 1 = 10
+        private const int LootCurrencySize = 10;
+
+        // 2 GUIDs + 4 bytes + uint + 2 ints + 1 byte bits + items + currencies
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 4 + 4 + 8 + 1 +
+                              MaxItems * LootItemDataSize + MaxCurrencies * LootCurrencySize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Items.Count > MaxItems || Currencies.Count > MaxCurrencies)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Owner.Low, Owner.High);
+            writer.WritePackedGuid128(LootObj.Low, LootObj.High);
+            writer.WriteUInt8((byte)FailureReason);
+            writer.WriteUInt8((byte)AcquireReason);
+            writer.WriteUInt8((byte)LootMethod);
+            writer.WriteUInt8(Threshold);
+            writer.WriteUInt32(Coins);
+            writer.WriteInt32(Items.Count);
+            writer.WriteInt32(Currencies.Count);
+            writer.WriteBit(Acquired);
+            writer.WriteBit(AELooting);
+            writer.FlushBits();
+
+            foreach (LootItemData item in Items)
+            {
+                writer.WriteBits(item.Type, 2);
+                writer.WriteBits((byte)item.UIType, 3);
+                writer.WriteBit(item.CanTradeToTapList);
+                writer.FlushBits();
+
+                if (!ItemPacketHelpers.WriteItemInstance(ref writer, item.Loot))
+                    return -1;
+
+                writer.WriteUInt32(item.Quantity);
+                writer.WriteUInt8(item.LootItemType);
+                writer.WriteUInt8(item.LootListID);
+            }
+
+            foreach (LootCurrency currency in Currencies)
+            {
+                writer.WriteUInt32(currency.CurrencyID);
+                writer.WriteUInt32(currency.Quantity);
+                writer.WriteUInt8(currency.LootListID);
+                writer.WriteBits(currency.UIType, 3);
+                writer.FlushBits();
+            }
+
+            return writer.Position;
         }
 
         public WowGuid128 Owner;
@@ -124,7 +183,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 Owner;
     }
 
-    class LootReleaseResponse : ServerPacket
+    class LootReleaseResponse : ServerPacket, ISpanWritable
     {
         public LootReleaseResponse() : base(Opcode.SMSG_LOOT_RELEASE) { }
 
@@ -132,6 +191,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WritePackedGuid128(LootObj);
             _worldPacket.WritePackedGuid128(Owner);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2; // 2 GUIDs
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(LootObj.Low, LootObj.High);
+            writer.WritePackedGuid128(Owner.Low, Owner.High);
+            return writer.Position;
         }
 
         public WowGuid128 LootObj;
@@ -145,7 +214,7 @@ namespace HermesProxy.World.Server.Packets
         public override void Read() { }
     }
 
-    class LootMoneyNotify : ServerPacket
+    class LootMoneyNotify : ServerPacket, ISpanWritable
     {
         public LootMoneyNotify() : base(Opcode.SMSG_LOOT_MONEY_NOTIFY) { }
 
@@ -157,18 +226,39 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 17; // 2 uint64 + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt64(Money);
+            writer.WriteUInt64(MoneyMod);
+            writer.WriteBit(SoleLooter);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public ulong Money;
         public ulong MoneyMod;
         public bool SoleLooter;
     }
 
-    class CoinRemoved : ServerPacket
+    class CoinRemoved : ServerPacket, ISpanWritable
     {
         public CoinRemoved() : base(Opcode.SMSG_COIN_REMOVED) { }
 
         public override void Write()
         {
             _worldPacket.WritePackedGuid128(LootObj);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(LootObj.Low, LootObj.High);
+            return writer.Position;
         }
 
         public WowGuid128 LootObj;
@@ -202,7 +292,7 @@ namespace HermesProxy.World.Server.Packets
         public byte LootListID;
     }
 
-    class LootRemoved : ServerPacket
+    class LootRemoved : ServerPacket, ISpanWritable
     {
         public LootRemoved() : base(Opcode.SMSG_LOOT_REMOVED, ConnectionType.Instance) { }
 
@@ -211,6 +301,17 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(Owner);
             _worldPacket.WritePackedGuid128(LootObj);
             _worldPacket.WriteUInt8(LootListID);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 1; // 2 GUIDs + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Owner.Low, Owner.High);
+            writer.WritePackedGuid128(LootObj.Low, LootObj.High);
+            writer.WriteUInt8(LootListID);
+            return writer.Position;
         }
 
         public WowGuid128 Owner;
@@ -248,7 +349,7 @@ namespace HermesProxy.World.Server.Packets
         public bool PassOnLoot;
     }
 
-    class StartLootRoll : ServerPacket
+    class StartLootRoll : ServerPacket, ISpanWritable
     {
         public StartLootRoll() : base(Opcode.SMSG_LOOT_START_ROLL) { }
 
@@ -260,6 +361,36 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt8((byte)ValidRolls);
             _worldPacket.WriteUInt8((byte)Method);
             Item.Write(_worldPacket);
+        }
+
+        // LootItemData: 1 (bits) + ItemInstance + 4 + 1 + 1 = 7 + ItemInstanceMaxSize
+        private const int LootItemDataSize = 7 + ItemPacketHelpers.ItemInstanceMaxSize;
+        // GUID(18) + 2 uints(8) + 2 bytes(2) + LootItemData
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 8 + 2 + LootItemDataSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(LootObj.Low, LootObj.High);
+            writer.WriteUInt32(MapID);
+            writer.WriteUInt32(RollTime);
+            writer.WriteUInt8((byte)ValidRolls);
+            writer.WriteUInt8((byte)Method);
+
+            // Write LootItemData inline
+            writer.WriteBits(Item.Type, 2);
+            writer.WriteBits((byte)Item.UIType, 3);
+            writer.WriteBit(Item.CanTradeToTapList);
+            writer.FlushBits();
+
+            if (!ItemPacketHelpers.WriteItemInstance(ref writer, Item.Loot))
+                return -1;
+
+            writer.WriteUInt32(Item.Quantity);
+            writer.WriteUInt8(Item.LootItemType);
+            writer.WriteUInt8(Item.LootListID);
+
+            return writer.Position;
         }
 
         public WowGuid128 LootObj;
@@ -286,7 +417,7 @@ namespace HermesProxy.World.Server.Packets
         public RollType RollType;
     }
 
-    class LootRollBroadcast : ServerPacket
+    class LootRollBroadcast : ServerPacket, ISpanWritable
     {
         public LootRollBroadcast() : base(Opcode.SMSG_LOOT_ROLL) { }
 
@@ -301,6 +432,38 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        // LootItemData: 1 (bits) + ItemInstance + 6 = 7 + ItemInstanceMaxSize
+        private const int LootItemDataSize = 7 + ItemPacketHelpers.ItemInstanceMaxSize;
+        // 2 GUIDs + int + byte + LootItemData + 1 bit
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 4 + 1 + LootItemDataSize + 1;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(LootObj.Low, LootObj.High);
+            writer.WritePackedGuid128(Player.Low, Player.High);
+            writer.WriteInt32(Roll);
+            writer.WriteUInt8((byte)RollType);
+
+            // Write LootItemData inline
+            writer.WriteBits(Item.Type, 2);
+            writer.WriteBits((byte)Item.UIType, 3);
+            writer.WriteBit(Item.CanTradeToTapList);
+            writer.FlushBits();
+
+            if (!ItemPacketHelpers.WriteItemInstance(ref writer, Item.Loot))
+                return -1;
+
+            writer.WriteUInt32(Item.Quantity);
+            writer.WriteUInt8(Item.LootItemType);
+            writer.WriteUInt8(Item.LootListID);
+
+            writer.WriteBit(Autopassed);
+            writer.FlushBits();
+
+            return writer.Position;
+        }
+
         public WowGuid128 LootObj;
         public WowGuid128 Player;
         public int Roll;
@@ -309,7 +472,7 @@ namespace HermesProxy.World.Server.Packets
         public bool Autopassed = false;    // Triggers message |HlootHistory:%d|h[Loot]|h: You automatically passed on: %s because you cannot loot that item.
     }
 
-    class LootRollWon : ServerPacket
+    class LootRollWon : ServerPacket, ISpanWritable
     {
         public LootRollWon() : base(Opcode.SMSG_LOOT_ROLL_WON) { }
 
@@ -323,6 +486,37 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt8(MainSpec);
         }
 
+        // LootItemData: 1 (bits) + ItemInstance + 6 = 7 + ItemInstanceMaxSize
+        private const int LootItemDataSize = 7 + ItemPacketHelpers.ItemInstanceMaxSize;
+        // 2 GUIDs + int + byte + LootItemData + byte
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 4 + 1 + LootItemDataSize + 1;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(LootObj.Low, LootObj.High);
+            writer.WritePackedGuid128(Winner.Low, Winner.High);
+            writer.WriteInt32(Roll);
+            writer.WriteUInt8((byte)RollType);
+
+            // Write LootItemData inline
+            writer.WriteBits(Item.Type, 2);
+            writer.WriteBits((byte)Item.UIType, 3);
+            writer.WriteBit(Item.CanTradeToTapList);
+            writer.FlushBits();
+
+            if (!ItemPacketHelpers.WriteItemInstance(ref writer, Item.Loot))
+                return -1;
+
+            writer.WriteUInt32(Item.Quantity);
+            writer.WriteUInt8(Item.LootItemType);
+            writer.WriteUInt8(Item.LootListID);
+
+            writer.WriteUInt8(MainSpec);
+
+            return writer.Position;
+        }
+
         public WowGuid128 LootObj;
         public WowGuid128 Winner;
         public int Roll;
@@ -331,7 +525,7 @@ namespace HermesProxy.World.Server.Packets
         public byte MainSpec;
     }
 
-    class LootAllPassed : ServerPacket
+    class LootAllPassed : ServerPacket, ISpanWritable
     {
         public LootAllPassed() : base(Opcode.SMSG_LOOT_ALL_PASSED) { }
 
@@ -341,11 +535,37 @@ namespace HermesProxy.World.Server.Packets
             Item.Write(_worldPacket);
         }
 
+        // LootItemData: 1 (bits) + ItemInstance + 6 = 7 + ItemInstanceMaxSize
+        private const int LootItemDataSize = 7 + ItemPacketHelpers.ItemInstanceMaxSize;
+        // GUID + LootItemData
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + LootItemDataSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(LootObj.Low, LootObj.High);
+
+            // Write LootItemData inline
+            writer.WriteBits(Item.Type, 2);
+            writer.WriteBits((byte)Item.UIType, 3);
+            writer.WriteBit(Item.CanTradeToTapList);
+            writer.FlushBits();
+
+            if (!ItemPacketHelpers.WriteItemInstance(ref writer, Item.Loot))
+                return -1;
+
+            writer.WriteUInt32(Item.Quantity);
+            writer.WriteUInt8(Item.LootItemType);
+            writer.WriteUInt8(Item.LootListID);
+
+            return writer.Position;
+        }
+
         public WowGuid128 LootObj;
         public LootItemData Item = new();
     }
 
-    class LootRollsComplete : ServerPacket
+    class LootRollsComplete : ServerPacket, ISpanWritable
     {
         public LootRollsComplete() : base(Opcode.SMSG_LOOT_ROLLS_COMPLETE) { }
 
@@ -353,6 +573,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WritePackedGuid128(LootObj);
             _worldPacket.WriteUInt8(LootListID);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 1; // GUID + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(LootObj.Low, LootObj.High);
+            writer.WriteUInt8(LootListID);
+            return writer.Position;
         }
 
         public WowGuid128 LootObj;
@@ -381,8 +611,11 @@ namespace HermesProxy.World.Server.Packets
         public List<LootRequest> Loot = new();
     }
 
-    class MasterLootCandidateList : ServerPacket
+    class MasterLootCandidateList : ServerPacket, ISpanWritable
     {
+        // Max raid size is 40 players
+        private const int MaxPlayers = 40;
+
         public MasterLootCandidateList() : base(Opcode.SMSG_LOOT_MASTER_LIST, ConnectionType.Instance) { }
 
         public override void Write()
@@ -393,11 +626,27 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WritePackedGuid128(guid);
         }
 
+        // MaxSize: GUID (18) + count (4) + 40 GUIDs (720) = 742
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4 + MaxPlayers * PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Players.Count > MaxPlayers)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(LootObj.Low, LootObj.High);
+            writer.WriteInt32(Players.Count);
+            foreach (var guid in Players)
+                writer.WritePackedGuid128(guid.Low, guid.High);
+            return writer.Position;
+        }
+
         public WowGuid128 LootObj;
         public List<WowGuid128> Players = new();
     }
 
-    class LootList : ServerPacket
+    class LootList : ServerPacket, ISpanWritable
     {
         public LootList() : base(Opcode.SMSG_LOOT_LIST, ConnectionType.Instance) { }
 
@@ -415,6 +664,28 @@ namespace HermesProxy.World.Server.Packets
 
             if (RoundRobinWinner != default)
                 _worldPacket.WritePackedGuid128(RoundRobinWinner);
+        }
+
+        // MaxSize: 2 GUIDs (36) + 2 bits (1) + 2 optional GUIDs (36) = 73
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 4 + 1;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Owner.Low, Owner.High);
+            writer.WritePackedGuid128(LootObj.Low, LootObj.High);
+
+            writer.WriteBit(Master != default);
+            writer.WriteBit(RoundRobinWinner != default);
+            writer.FlushBits();
+
+            if (Master != default)
+                writer.WritePackedGuid128(Master.Low, Master.High);
+
+            if (RoundRobinWinner != default)
+                writer.WritePackedGuid128(RoundRobinWinner.Low, RoundRobinWinner.High);
+
+            return writer.Position;
         }
 
         public WowGuid128 Owner;

--- a/HermesProxy/World/Server/Packets/MailPackets.cs
+++ b/HermesProxy/World/Server/Packets/MailPackets.cs
@@ -18,6 +18,7 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
@@ -25,7 +26,7 @@ using System.Collections.Generic;
 
 namespace HermesProxy.World.Server.Packets
 {
-    public class NotifyReceivedMail : ServerPacket
+    public class NotifyReceivedMail : ServerPacket, ISpanWritable
     {
         public NotifyReceivedMail() : base(Opcode.SMSG_NOTIFY_RECEIVED_MAIL) { }
 
@@ -34,10 +35,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteFloat(Delay);
         }
 
+        public int MaxSize => 4; // float
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteFloat(Delay);
+            return writer.Position;
+        }
+
         public float Delay;
     }
 
-    public class MailQueryNextTimeResult : ServerPacket
+    public class MailQueryNextTimeResult : ServerPacket, ISpanWritable
     {
         public MailQueryNextTimeResult() : base(Opcode.SMSG_MAIL_QUERY_NEXT_TIME_RESULT) { }
 
@@ -54,6 +64,33 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteInt8(entry.AltSenderType);
                 _worldPacket.WriteInt32(entry.StationeryID);
             }
+        }
+
+        // Cap for mail entries - typically just shows a few pending mails
+        private const int MaxMails = 10;
+        // Each entry: GUID(18) + float(4) + int(4) + sbyte(1) + int(4) = 31 bytes
+        private const int MailEntrySize = PackedGuidHelper.MaxPackedGuid128Size + 4 + 4 + 1 + 4;
+        // float(4) + count(4) + entries
+        public int MaxSize => 4 + 4 + MaxMails * MailEntrySize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Mails.Count > MaxMails)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteFloat(NextMailTime);
+            writer.WriteInt32(Mails.Count);
+
+            foreach (var entry in Mails)
+            {
+                writer.WritePackedGuid128(entry.SenderGuid.Low, entry.SenderGuid.High);
+                writer.WriteFloat(entry.TimeLeft);
+                writer.WriteInt32(entry.AltSenderID);
+                writer.WriteInt8(entry.AltSenderType);
+                writer.WriteInt32(entry.StationeryID);
+            }
+            return writer.Position;
         }
 
         public float NextMailTime;
@@ -317,7 +354,7 @@ namespace HermesProxy.World.Server.Packets
         }
     }
 
-    public class MailCommandResult : ServerPacket
+    public class MailCommandResult : ServerPacket, ISpanWritable
     {
         public MailCommandResult() : base(Opcode.SMSG_MAIL_COMMAND_RESULT) { }
 
@@ -329,6 +366,20 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32((uint)BagResult);
             _worldPacket.WriteUInt32(AttachID);
             _worldPacket.WriteUInt32(QtyInInventory);
+        }
+
+        public int MaxSize => 24; // 6 uints
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(MailID);
+            writer.WriteUInt32((uint)Command);
+            writer.WriteUInt32((uint)ErrorCode);
+            writer.WriteUInt32((uint)BagResult);
+            writer.WriteUInt32(AttachID);
+            writer.WriteUInt32(QtyInInventory);
+            return writer.Position;
         }
 
         public uint MailID;

--- a/HermesProxy/World/Server/Packets/MiscPackets.cs
+++ b/HermesProxy/World/Server/Packets/MiscPackets.cs
@@ -201,8 +201,8 @@ namespace HermesProxy.World.Server.Packets
             }
         }
 
-        // Cap for currencies - players typically have ~50-100 currencies
-        private const int MaxCurrencies = 128;
+        // Cap for currencies - reduced from 128 to 16 based on typical usage (0 observed at login)
+        private const int MaxCurrencies = 16;
         // Per currency max: 2 uints(8) + bits(2) + 5 optional uints(20) = 30 bytes
         private const int MaxRecordSize = 30;
         // count(4) + currencies
@@ -269,8 +269,8 @@ namespace HermesProxy.World.Server.Packets
                 progress.Write(_worldPacket);
         }
 
-        // Cap for account criteria - reasonable limit
-        private const int MaxCriteria = 256;
+        // Cap for account criteria - reduced from 256 to 32 based on typical usage (0 observed)
+        private const int MaxCriteria = 32;
         // Per criteria: uint(4) + ulong(8) + GUID(18) + PackedTime(4) + 2 uints(8) + bits(1) + optional ulong(8) = 51 bytes max
         private const int MaxCriteriaSize = 51;
         // count(4) + criteria
@@ -602,8 +602,8 @@ namespace HermesProxy.World.Server.Packets
                 task.Write(_worldPacket);
         }
 
-        // Cap for tasks
-        private const int MaxTasks = 64;
+        // Cap for tasks - reduced from 64 to 8 based on typical usage (0 observed)
+        private const int MaxTasks = 8;
         // Cap for progress items per task
         private const int MaxProgressPerTask = 16;
         // Per task: 4 uints(16) + count(4) + progress items(2 each) = 52 bytes max
@@ -1128,8 +1128,8 @@ namespace HermesProxy.World.Server.Packets
                 entry.Write(_worldPacket);
         }
 
-        // Cap for blacklist entries
-        private const int MaxBlacklistEntries = 128;
+        // Cap for blacklist entries - reduced from 128 to 16 based on typical usage (0 observed)
+        private const int MaxBlacklistEntries = 16;
         // Per entry: 2 ints = 8 bytes
         public int MaxSize => 4 + MaxBlacklistEntries * 8;
 

--- a/HermesProxy/World/Server/Packets/MiscPackets.cs
+++ b/HermesProxy/World/Server/Packets/MiscPackets.cs
@@ -16,11 +16,13 @@
  */
 
 
+using System;
+using System.Collections.Generic;
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
-using System.Collections.Generic;
 
 namespace HermesProxy.World.Server.Packets
 {
@@ -34,7 +36,7 @@ namespace HermesProxy.World.Server.Packets
         }
     }
 
-    public class BindPointUpdate : ServerPacket
+    public class BindPointUpdate : ServerPacket, ISpanWritable
     {
         public BindPointUpdate() : base(Opcode.SMSG_BIND_POINT_UPDATE, ConnectionType.Instance) { }
 
@@ -45,12 +47,23 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(BindAreaID);
         }
 
+        public int MaxSize => 12 + 4 + 4; // Vector3 (12) + 2x uint32 (8)
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteVector3(BindPosition);
+            writer.WriteUInt32(BindMapID);
+            writer.WriteUInt32(BindAreaID);
+            return writer.Position;
+        }
+
         public uint BindMapID = 0xFFFFFFFF;
         public Vector3 BindPosition;
         public uint BindAreaID;
     }
 
-    public class PlayerBound : ServerPacket
+    public class PlayerBound : ServerPacket, ISpanWritable
     {
         public PlayerBound() : base(Opcode.SMSG_PLAYER_BOUND) { }
 
@@ -60,17 +73,36 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(AreaID);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4; // Packed GUID + uint32
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(BinderGUID.Low, BinderGUID.High);
+            writer.WriteUInt32(AreaID);
+            return writer.Position;
+        }
+
         public WowGuid128 BinderGUID;
         public uint AreaID;
     }
 
-    public class ServerTimeOffset : ServerPacket
+    public class ServerTimeOffset : ServerPacket, ISpanWritable
     {
         public ServerTimeOffset() : base(Opcode.SMSG_SERVER_TIME_OFFSET) { }
 
         public override void Write()
         {
             _worldPacket.WriteInt64(Time);
+        }
+
+        public int MaxSize => 8;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt64(Time);
+            return writer.Position;
         }
 
         public long Time;
@@ -91,7 +123,7 @@ namespace HermesProxy.World.Server.Packets
         public uint TutorialBit;
     }
 
-    public class TutorialFlags : ServerPacket
+    public class TutorialFlags : ServerPacket, ISpanWritable
     {
         public TutorialFlags() : base(Opcode.SMSG_TUTORIAL_FLAGS) { }
 
@@ -101,10 +133,20 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteUInt32(TutorialData[i]);
         }
 
+        public int MaxSize => (int)Tutorials.Max * 4; // 8 uint32s = 32 bytes
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            for (byte i = 0; i < (int)Tutorials.Max; ++i)
+                writer.WriteUInt32(TutorialData[i]);
+            return writer.Position;
+        }
+
         public uint[] TutorialData = new uint[(int)Tutorials.Max];
     }
 
-    public class CorpseReclaimDelay : ServerPacket
+    public class CorpseReclaimDelay : ServerPacket, ISpanWritable
     {
         public CorpseReclaimDelay() : base(Opcode.SMSG_CORPSE_RECLAIM_DELAY, ConnectionType.Instance) { }
 
@@ -113,10 +155,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(Remaining);
         }
 
+        public int MaxSize => 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(Remaining);
+            return writer.Position;
+        }
+
         public uint Remaining;
     }
 
-    public class SetupCurrency : ServerPacket
+    public class SetupCurrency : ServerPacket, ISpanWritable
     {
         public SetupCurrency() : base(Opcode.SMSG_SETUP_CURRENCY, ConnectionType.Instance) { }
 
@@ -150,22 +201,64 @@ namespace HermesProxy.World.Server.Packets
             }
         }
 
+        // Cap for currencies - players typically have ~50-100 currencies
+        private const int MaxCurrencies = 128;
+        // Per currency max: 2 uints(8) + bits(2) + 5 optional uints(20) = 30 bytes
+        private const int MaxRecordSize = 30;
+        // count(4) + currencies
+        public int MaxSize => 4 + MaxCurrencies * MaxRecordSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Data.Count > MaxCurrencies)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Data.Count);
+
+            foreach (Record data in Data)
+            {
+                writer.WriteUInt32(data.Type);
+                writer.WriteUInt32(data.Quantity);
+
+                writer.WriteBit(data.WeeklyQuantity.HasValue);
+                writer.WriteBit(data.MaxWeeklyQuantity.HasValue);
+                writer.WriteBit(data.TrackedQuantity.HasValue);
+                writer.WriteBit(data.MaxQuantity.HasValue);
+                writer.WriteBit(data.Unused901.HasValue);
+                writer.WriteBits(data.Flags, 5);
+                writer.FlushBits();
+
+                if (data.WeeklyQuantity.HasValue)
+                    writer.WriteUInt32(data.WeeklyQuantity.Value);
+                if (data.MaxWeeklyQuantity.HasValue)
+                    writer.WriteUInt32(data.MaxWeeklyQuantity.Value);
+                if (data.TrackedQuantity.HasValue)
+                    writer.WriteUInt32(data.TrackedQuantity.Value);
+                if (data.MaxQuantity.HasValue)
+                    writer.WriteInt32(data.MaxQuantity.Value);
+                if (data.Unused901.HasValue)
+                    writer.WriteInt32(data.Unused901.Value);
+            }
+            return writer.Position;
+        }
+
         public List<Record> Data = new();
 
         public struct Record
         {
             public uint Type;
             public uint Quantity;
-            public uint? WeeklyQuantity;       // Currency count obtained this Week.  
+            public uint? WeeklyQuantity;       // Currency count obtained this Week.
             public uint? MaxWeeklyQuantity;    // Weekly Currency cap.
             public uint? TrackedQuantity;
             public int? MaxQuantity;
             public int? Unused901;
-            public byte Flags;                      // 0 = none, 
+            public byte Flags;                      // 0 = none,
         }
     }
 
-    class AllAccountCriteria : ServerPacket
+    class AllAccountCriteria : ServerPacket, ISpanWritable
     {
         public AllAccountCriteria() : base(Opcode.SMSG_ALL_ACCOUNT_CRITERIA, ConnectionType.Instance) { }
 
@@ -174,6 +267,38 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(Progress.Count);
             foreach (var progress in Progress)
                 progress.Write(_worldPacket);
+        }
+
+        // Cap for account criteria - reasonable limit
+        private const int MaxCriteria = 256;
+        // Per criteria: uint(4) + ulong(8) + GUID(18) + PackedTime(4) + 2 uints(8) + bits(1) + optional ulong(8) = 51 bytes max
+        private const int MaxCriteriaSize = 51;
+        // count(4) + criteria
+        public int MaxSize => 4 + MaxCriteria * MaxCriteriaSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Progress.Count > MaxCriteria)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Progress.Count);
+            foreach (var progress in Progress)
+            {
+                writer.WriteUInt32(progress.Id);
+                writer.WriteUInt64(progress.Quantity);
+                writer.WritePackedGuid128(progress.Player.Low, progress.Player.High);
+                writer.WriteUInt32(Time.GetPackedTimeFromUnixTime(progress.Date));
+                writer.WriteUInt32(progress.TimeFromStart);
+                writer.WriteUInt32(progress.TimeFromCreate);
+                writer.WriteBits(progress.Flags, 4);
+                writer.WriteBit(progress.RafAcceptanceID.HasValue);
+                writer.FlushBits();
+
+                if (progress.RafAcceptanceID.HasValue)
+                    writer.WriteUInt64(progress.RafAcceptanceID.Value);
+            }
+            return writer.Position;
         }
 
         public List<CriteriaProgressPkt> Progress = new();
@@ -207,13 +332,22 @@ namespace HermesProxy.World.Server.Packets
         public ulong? RafAcceptanceID;
     }
 
-    public class TimeSyncRequest : ServerPacket
+    public class TimeSyncRequest : ServerPacket, ISpanWritable
     {
         public TimeSyncRequest() : base(Opcode.SMSG_TIME_SYNC_REQUEST, ConnectionType.Instance) { }
 
         public override void Write()
         {
             _worldPacket.WriteUInt32(SequenceIndex);
+        }
+
+        public int MaxSize => 4; // uint32
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(SequenceIndex);
+            return writer.Position;
         }
 
         public uint SequenceIndex;
@@ -233,7 +367,7 @@ namespace HermesProxy.World.Server.Packets
         public uint SequenceIndex; // Same index as in request
     }
 
-    public class WeatherPkt : ServerPacket
+    public class WeatherPkt : ServerPacket, ISpanWritable
     {
         public WeatherPkt() : base(Opcode.SMSG_WEATHER, ConnectionType.Instance) { }
 
@@ -246,12 +380,24 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 4 + 4 + 1; // uint32 + float + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32((uint)WeatherID);
+            writer.WriteFloat(Intensity);
+            writer.WriteBit(Abrupt);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public bool Abrupt;
         public float Intensity;
         public WeatherState WeatherID;
     }
 
-    class StartLightningStorm : ServerPacket
+    class StartLightningStorm : ServerPacket, ISpanWritable
     {
         public StartLightningStorm() : base(Opcode.SMSG_START_LIGHTNING_STORM, ConnectionType.Instance) { }
 
@@ -260,10 +406,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(LightningStormId);
         }
 
+        public int MaxSize => 4; // uint32
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(LightningStormId);
+            return writer.Position;
+        }
+
         public uint LightningStormId;
     }
 
-    public class LoginSetTimeSpeed : ServerPacket
+    public class LoginSetTimeSpeed : ServerPacket, ISpanWritable
     {
         public LoginSetTimeSpeed() : base(Opcode.SMSG_LOGIN_SET_TIME_SPEED, ConnectionType.Instance) { }
 
@@ -274,6 +429,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteFloat(NewSpeed);
             _worldPacket.WriteInt32(ServerTimeHolidayOffset);
             _worldPacket.WriteInt32(GameTimeHolidayOffset);
+        }
+
+        public int MaxSize => 20; // 2 uints + float + 2 ints
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(ServerTime);
+            writer.WriteUInt32(GameTime);
+            writer.WriteFloat(NewSpeed);
+            writer.WriteInt32(ServerTimeHolidayOffset);
+            writer.WriteInt32(GameTimeHolidayOffset);
+            return writer.Position;
         }
 
         public uint ServerTime;
@@ -299,13 +467,22 @@ namespace HermesProxy.World.Server.Packets
         public bool FromClient;
     }
 
-    class AreaTriggerMessage : ServerPacket
+    class AreaTriggerMessage : ServerPacket, ISpanWritable
     {
         public AreaTriggerMessage() : base(Opcode.SMSG_AREA_TRIGGER_MESSAGE) { }
 
         public override void Write()
         {
             _worldPacket.WriteUInt32(AreaTriggerID);
+        }
+
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(AreaTriggerID);
+            return writer.Position;
         }
 
         public uint AreaTriggerID = 0;
@@ -323,7 +500,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 TargetGUID;
     }
 
-    public class WorldServerInfo : ServerPacket
+    public class WorldServerInfo : ServerPacket, ISpanWritable
     {
         public WorldServerInfo() : base(Opcode.SMSG_WORLD_SERVER_INFO, ConnectionType.Instance) { }
 
@@ -347,6 +524,32 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteUInt32(InstanceGroupSize.Value);
         }
 
+        // uint(4) + byte(1) + 4 bits(1) + optional uint(4) + optional ulong(8) + optional uint(4) = 22
+        public int MaxSize => 4 + 1 + 1 + 4 + 8 + 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(DifficultyID);
+            writer.WriteUInt8(IsTournamentRealm);
+            writer.WriteBit(XRealmPvpAlert);
+            writer.WriteBit(RestrictedAccountMaxLevel.HasValue);
+            writer.WriteBit(RestrictedAccountMaxMoney.HasValue);
+            writer.WriteBit(InstanceGroupSize.HasValue);
+            writer.FlushBits();
+
+            if (RestrictedAccountMaxLevel.HasValue)
+                writer.WriteUInt32(RestrictedAccountMaxLevel.Value);
+
+            if (RestrictedAccountMaxMoney.HasValue)
+                writer.WriteUInt64(RestrictedAccountMaxMoney.Value);
+
+            if (InstanceGroupSize.HasValue)
+                writer.WriteUInt32(InstanceGroupSize.Value);
+
+            return writer.Position;
+        }
+
         public uint DifficultyID;
         public byte IsTournamentRealm;
         public bool XRealmPvpAlert;
@@ -367,7 +570,7 @@ namespace HermesProxy.World.Server.Packets
         public uint DifficultyID;
     }
 
-    public class DungeonDifficultySet : ServerPacket
+    public class DungeonDifficultySet : ServerPacket, ISpanWritable
     {
         public DungeonDifficultySet() : base(Opcode.SMSG_SET_DUNGEON_DIFFICULTY) { }
 
@@ -376,10 +579,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(DifficultyID);
         }
 
+        public int MaxSize => 4; // int
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(DifficultyID);
+            return writer.Position;
+        }
+
         public int DifficultyID;
     }
 
-    public class SetAllTaskProgress : ServerPacket
+    public class SetAllTaskProgress : ServerPacket, ISpanWritable
     {
         public SetAllTaskProgress() : base(Opcode.SMSG_SET_ALL_TASK_PROGRESS, ConnectionType.Instance) { }
 
@@ -388,6 +600,42 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(Tasks.Count);
             foreach (var task in Tasks)
                 task.Write(_worldPacket);
+        }
+
+        // Cap for tasks
+        private const int MaxTasks = 64;
+        // Cap for progress items per task
+        private const int MaxProgressPerTask = 16;
+        // Per task: 4 uints(16) + count(4) + progress items(2 each) = 52 bytes max
+        private const int MaxTaskSize = 16 + 4 + MaxProgressPerTask * 2;
+        // count(4) + tasks
+        public int MaxSize => 4 + MaxTasks * MaxTaskSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Tasks.Count > MaxTasks)
+                return -1;
+
+            // Pre-validate progress counts
+            foreach (var task in Tasks)
+            {
+                if (task.Progress.Count > MaxProgressPerTask)
+                    return -1;
+            }
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Tasks.Count);
+            foreach (var task in Tasks)
+            {
+                writer.WriteUInt32(task.TaskID);
+                writer.WriteUInt32(task.FailureTime);
+                writer.WriteUInt32(task.Flags);
+                writer.WriteUInt32(task.Unk);
+                writer.WriteInt32(task.Progress.Count);
+                foreach (ushort progress in task.Progress)
+                    writer.WriteUInt16(progress);
+            }
+            return writer.Position;
         }
 
         public List<TaskProgress> Tasks = new List<TaskProgress>();
@@ -412,7 +660,7 @@ namespace HermesProxy.World.Server.Packets
         public List<ushort> Progress = new List<ushort>();
     }
 
-    public class InitialSetup : ServerPacket
+    public class InitialSetup : ServerPacket, ISpanWritable
     {
         public InitialSetup() : base(Opcode.SMSG_INITIAL_SETUP, ConnectionType.Instance) { }
 
@@ -420,6 +668,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WriteUInt8(ServerExpansionLevel);
             _worldPacket.WriteUInt8(ServerExpansionTier);
+        }
+
+        public int MaxSize => 2; // 2 bytes
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt8(ServerExpansionLevel);
+            writer.WriteUInt8(ServerExpansionTier);
+            return writer.Position;
         }
 
         public byte ServerExpansionLevel;
@@ -450,7 +708,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 Player;
     }
 
-    public class CorpseLocation : ServerPacket
+    public class CorpseLocation : ServerPacket, ISpanWritable
     {
         public CorpseLocation() : base(Opcode.SMSG_CORPSE_LOCATION) { }
 
@@ -466,6 +724,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(Transport);
         }
 
+        public int MaxSize => 1 + PackedGuidHelper.MaxPackedGuid128Size * 2 + 4 + 12 + 4; // bit + 2 GUIDs + int + Vector3 + int
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBit(Valid);
+            writer.FlushBits();
+            writer.WritePackedGuid128(Player.Low, Player.High);
+            writer.WriteInt32(ActualMapID);
+            writer.WriteVector3(Position);
+            writer.WriteInt32(MapID);
+            writer.WritePackedGuid128(Transport.Low, Transport.High);
+            return writer.Position;
+        }
+
         public WowGuid128 Player;
         public WowGuid128 Transport;
         public Vector3 Position;
@@ -474,7 +747,7 @@ namespace HermesProxy.World.Server.Packets
         public bool Valid;
     }
 
-    public class DeathReleaseLoc : ServerPacket
+    public class DeathReleaseLoc : ServerPacket, ISpanWritable
     {
         public DeathReleaseLoc() : base(Opcode.SMSG_DEATH_RELEASE_LOC) { }
 
@@ -482,6 +755,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WriteInt32(MapID);
             _worldPacket.WriteVector3(Location);
+        }
+
+        public int MaxSize => 16; // int + Vector3 (3 floats)
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(MapID);
+            writer.WriteVector3(Location);
+            return writer.Position;
         }
 
         public int MapID;
@@ -512,7 +795,7 @@ namespace HermesProxy.World.Server.Packets
         public uint StandState;
     }
 
-    public class StandStateUpdate : ServerPacket
+    public class StandStateUpdate : ServerPacket, ISpanWritable
     {
         public StandStateUpdate() : base(Opcode.SMSG_STAND_STATE_UPDATE) { }
 
@@ -522,11 +805,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt8(StandState);
         }
 
+        public int MaxSize => 5; // uint + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(AnimKitID);
+            writer.WriteUInt8(StandState);
+            return writer.Position;
+        }
+
         public uint AnimKitID;
         public byte StandState;
     }
 
-    public class ExplorationExperience : ServerPacket
+    public class ExplorationExperience : ServerPacket, ISpanWritable
     {
         public ExplorationExperience() : base(Opcode.SMSG_EXPLORATION_EXPERIENCE) { }
 
@@ -536,11 +829,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(Experience);
         }
 
+        public int MaxSize => 8; // 2 uints
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(AreaID);
+            writer.WriteUInt32(Experience);
+            return writer.Position;
+        }
+
         public uint AreaID;
         public uint Experience;
     }
 
-    public class PlayMusic : ServerPacket
+    public class PlayMusic : ServerPacket, ISpanWritable
     {
         public PlayMusic() : base(Opcode.SMSG_PLAY_MUSIC) { }
 
@@ -549,10 +852,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(SoundEntryID);
         }
 
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(SoundEntryID);
+            return writer.Position;
+        }
+
         public uint SoundEntryID;
     }
 
-    class PlaySound : ServerPacket
+    class PlaySound : ServerPacket, ISpanWritable
     {
         public PlaySound() : base(Opcode.SMSG_PLAY_SOUND) { }
 
@@ -564,12 +876,25 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteInt32(BroadcastTextId);
         }
 
+        // MaxSize: uint + GUID + optional int = 4 + 18 + 4 = 26
+        public int MaxSize => 4 + PackedGuidHelper.MaxPackedGuid128Size + 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(SoundEntryID);
+            writer.WritePackedGuid128(SourceObjectGuid.Low, SourceObjectGuid.High);
+            if (ModernVersion.AddedInVersion(9, 0, 1, 1, 14, 0, 2, 5, 1))
+                writer.WriteInt32(BroadcastTextId);
+            return writer.Position;
+        }
+
         public uint SoundEntryID;
         public WowGuid128 SourceObjectGuid;
         public int BroadcastTextId;
     }
 
-    class PlayObjectSound : ServerPacket
+    class PlayObjectSound : ServerPacket, ISpanWritable
     {
         public PlayObjectSound() : base(Opcode.SMSG_PLAY_OBJECT_SOUND) { }
 
@@ -583,6 +908,21 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteInt32(BroadcastTextID);
         }
 
+        // MaxSize: uint + 2 GUIDs + Vector3 + optional int = 4 + 18*2 + 12 + 4 = 56
+        public int MaxSize => 4 + PackedGuidHelper.MaxPackedGuid128Size * 2 + 12 + 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(SoundEntryID);
+            writer.WritePackedGuid128(SourceObjectGUID.Low, SourceObjectGUID.High);
+            writer.WritePackedGuid128(TargetObjectGUID.Low, TargetObjectGUID.High);
+            writer.WriteVector3(Position);
+            if (ModernVersion.AddedInVersion(9, 0, 1, 1, 14, 0, 2, 5, 1))
+                writer.WriteInt32(BroadcastTextID);
+            return writer.Position;
+        }
+
         public uint SoundEntryID;
         public WowGuid128 SourceObjectGUID;
         public WowGuid128 TargetObjectGUID;
@@ -590,13 +930,22 @@ namespace HermesProxy.World.Server.Packets
         public int BroadcastTextID;
     }
 
-    public class TriggerCinematic : ServerPacket
+    public class TriggerCinematic : ServerPacket, ISpanWritable
     {
         public TriggerCinematic() : base(Opcode.SMSG_TRIGGER_CINEMATIC) { }
 
         public override void Write()
         {
             _worldPacket.WriteUInt32(CinematicID);
+        }
+
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(CinematicID);
+            return writer.Position;
         }
 
         public uint CinematicID;
@@ -638,7 +987,7 @@ namespace HermesProxy.World.Server.Packets
         public int SequenceVariation;
     }
 
-    class SpecialMountAnim : ServerPacket
+    class SpecialMountAnim : ServerPacket, ISpanWritable
     {
         public SpecialMountAnim() : base(Opcode.SMSG_SPECIAL_MOUNT_ANIM, ConnectionType.Instance) { }
 
@@ -655,12 +1004,35 @@ namespace HermesProxy.World.Server.Packets
             }
         }
 
+        // Cap for spell visual kit IDs - rarely more than 1-2
+        private const int MaxSpellVisualKitIDs = 4;
+        // GUID(18) + count(4) + SequenceVariation(4) + IDs(4 each)
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4 + 4 + MaxSpellVisualKitIDs * 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (SpellVisualKitIDs.Count > MaxSpellVisualKitIDs)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(UnitGUID.Low, UnitGUID.High);
+            if (ModernVersion.AddedInVersion(9, 0, 5, 1, 14, 0, 2, 5, 1))
+            {
+                writer.WriteInt32(SpellVisualKitIDs.Count);
+                if (ModernVersion.AddedInVersion(9, 2, 0, 1, 14, 2, 2, 5, 3))
+                    writer.WriteInt32(SequenceVariation);
+                foreach (var id in SpellVisualKitIDs)
+                    writer.WriteInt32(id);
+            }
+            return writer.Position;
+        }
+
         public WowGuid128 UnitGUID;
         public List<int> SpellVisualKitIDs = new();
         public int SequenceVariation;
     }
 
-    public class StartMirrorTimer : ServerPacket
+    public class StartMirrorTimer : ServerPacket, ISpanWritable
     {
         public StartMirrorTimer() : base(Opcode.SMSG_START_MIRROR_TIMER) { }
 
@@ -675,6 +1047,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 21; // 5 ints + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32((int)Timer);
+            writer.WriteInt32(Value);
+            writer.WriteInt32(MaxValue);
+            writer.WriteInt32(Scale);
+            writer.WriteInt32(SpellID);
+            writer.WriteBit(Paused);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public MirrorTimerType Timer;
         public int Value;
         public int MaxValue;
@@ -683,7 +1070,7 @@ namespace HermesProxy.World.Server.Packets
         public bool Paused;
     }
 
-    public class PauseMirrorTimer : ServerPacket
+    public class PauseMirrorTimer : ServerPacket, ISpanWritable
     {
         public PauseMirrorTimer() : base(Opcode.SMSG_PAUSE_MIRROR_TIMER) { }
 
@@ -694,11 +1081,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 5; // int + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32((int)Timer);
+            writer.WriteBit(Paused);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public MirrorTimerType Timer;
         public bool Paused;
     }
 
-    public class StopMirrorTimer : ServerPacket
+    public class StopMirrorTimer : ServerPacket, ISpanWritable
     {
         public StopMirrorTimer() : base(Opcode.SMSG_STOP_MIRROR_TIMER) { }
 
@@ -707,10 +1105,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32((int)Timer);
         }
 
+        public int MaxSize => 4; // int
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32((int)Timer);
+            return writer.Position;
+        }
+
         public MirrorTimerType Timer;
     }
 
-    public class LFGListUpdateBlacklist : ServerPacket
+    public class LFGListUpdateBlacklist : ServerPacket, ISpanWritable
     {
         public LFGListUpdateBlacklist() : base(Opcode.SMSG_LFG_LIST_UPDATE_BLACKLIST, ConnectionType.Instance) { }
 
@@ -719,6 +1126,26 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(Blacklist.Count);
             foreach (var entry in Blacklist)
                 entry.Write(_worldPacket);
+        }
+
+        // Cap for blacklist entries
+        private const int MaxBlacklistEntries = 128;
+        // Per entry: 2 ints = 8 bytes
+        public int MaxSize => 4 + MaxBlacklistEntries * 8;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Blacklist.Count > MaxBlacklistEntries)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Blacklist.Count);
+            foreach (var entry in Blacklist)
+            {
+                writer.WriteInt32(entry.ActivityID);
+                writer.WriteInt32(entry.Reason);
+            }
+            return writer.Position;
         }
 
         public void AddBlacklist(int activity, int reason)
@@ -744,7 +1171,7 @@ namespace HermesProxy.World.Server.Packets
         public int Reason;
     }
 
-    public class ConquestFormulaConstants : ServerPacket
+    public class ConquestFormulaConstants : ServerPacket, ISpanWritable
     {
         public ConquestFormulaConstants() : base(Opcode.SMSG_CONQUEST_FORMULA_CONSTANTS, ConnectionType.Instance) { }
 
@@ -757,6 +1184,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteFloat(PvpCPNumerator);
         }
 
+        public int MaxSize => 20; // 2 ints + 3 floats
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(PvpMinCPPerWeek);
+            writer.WriteInt32(PvpMaxCPPerWeek);
+            writer.WriteFloat(PvpCPBaseCoefficient);
+            writer.WriteFloat(PvpCPExpCoefficient);
+            writer.WriteFloat(PvpCPNumerator);
+            return writer.Position;
+        }
+
         public int PvpMinCPPerWeek;
         public int PvpMaxCPPerWeek;
         public float PvpCPBaseCoefficient;
@@ -764,7 +1204,7 @@ namespace HermesProxy.World.Server.Packets
         public float PvpCPNumerator;
     }
 
-    public class SeasonInfo : ServerPacket
+    public class SeasonInfo : ServerPacket, ISpanWritable
     {
         public SeasonInfo() : base(Opcode.SMSG_SEASON_INFO) { }
 
@@ -779,6 +1219,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 21; // 5 ints + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(MythicPlusSeasonID);
+            writer.WriteInt32(CurrentSeason);
+            writer.WriteInt32(PreviousSeason);
+            writer.WriteInt32(ConquestWeeklyProgressCurrencyID);
+            writer.WriteInt32(PvpSeasonID);
+            writer.WriteBit(WeeklyRewardChestsEnabled);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public int MythicPlusSeasonID;
         public int PreviousSeason;
         public int CurrentSeason;
@@ -787,7 +1242,7 @@ namespace HermesProxy.World.Server.Packets
         public bool WeeklyRewardChestsEnabled;
     }
 
-    public class InvalidatePlayer : ServerPacket
+    public class InvalidatePlayer : ServerPacket, ISpanWritable
     {
         public InvalidatePlayer() : base(Opcode.SMSG_INVALIDATE_PLAYER) { }
 
@@ -796,16 +1251,34 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(Guid);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            return writer.Position;
+        }
+
         public WowGuid128 Guid;
     }
 
-    public class ZoneUnderAttack : ServerPacket
+    public class ZoneUnderAttack : ServerPacket, ISpanWritable
     {
         public ZoneUnderAttack() : base(Opcode.SMSG_ZONE_UNDER_ATTACK) { }
 
         public override void Write()
         {
             _worldPacket.WriteInt32(AreaID);
+        }
+
+        public int MaxSize => 4; // int
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(AreaID);
+            return writer.Position;
         }
 
         public int AreaID;

--- a/HermesProxy/World/Server/Packets/MovementPackets.cs
+++ b/HermesProxy/World/Server/Packets/MovementPackets.cs
@@ -64,8 +64,9 @@ namespace HermesProxy.World.Server.Packets
     {
         // Practical cap for spline points - covers real-world movement patterns
         // Real usage: Points=0-2 (next destination), PackedDeltas=0-15 (obstacle smoothing)
+        // Reduced from 64 to 16 based on actual usage data (74-116 bytes observed)
         // If exceeded, WriteToSpan returns -1 to trigger fallback to Write()
-        private const int MaxSplinePoints = 64;
+        private const int MaxSplinePoints = 16;
 
         public MonsterMove(WowGuid128 guid, ServerSideMovement moveSpline) : base(Opcode.SMSG_ON_MONSTER_MOVE, ConnectionType.Instance)
         {

--- a/HermesProxy/World/Server/Packets/MovementPackets.cs
+++ b/HermesProxy/World/Server/Packets/MovementPackets.cs
@@ -18,6 +18,7 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
@@ -39,7 +40,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 Guid;
         public MovementInfo MoveInfo;
     }
-    public class MoveUpdate : ServerPacket
+    public class MoveUpdate : ServerPacket, ISpanWritable
     {
         public MoveUpdate() : base(Opcode.SMSG_MOVE_UPDATE, ConnectionType.Instance) { }
 
@@ -48,12 +49,24 @@ namespace HermesProxy.World.Server.Packets
             MoveInfo.WriteMovementInfoModern(_worldPacket, MoverGUID);
         }
 
+        public int MaxSize => MovementInfo.MaxMovementInfoSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            return MoveInfo.WriteMovementInfoModernToSpan(buffer, MoverGUID.Low, MoverGUID.High);
+        }
+
         public WowGuid128 MoverGUID;
         public MovementInfo MoveInfo;
     }
 
-    public class MonsterMove : ServerPacket
+    public class MonsterMove : ServerPacket, ISpanWritable
     {
+        // Practical cap for spline points - covers real-world movement patterns
+        // Real usage: Points=0-2 (next destination), PackedDeltas=0-15 (obstacle smoothing)
+        // If exceeded, WriteToSpan returns -1 to trigger fallback to Write()
+        private const int MaxSplinePoints = 64;
+
         public MonsterMove(WowGuid128 guid, ServerSideMovement moveSpline) : base(Opcode.SMSG_ON_MONSTER_MOVE, ConnectionType.Instance)
         {
             if (moveSpline.SplineFlags.HasFlag(SplineFlagModern.UncompressedPath))
@@ -151,6 +164,70 @@ namespace HermesProxy.World.Server.Packets
             */
         }
 
+        // MaxSize computed from MaxSplinePoints:
+        // Fixed: GUID(18) + StartPos(12) + SplineId(4) + Dest(12) + flags/times(36) + bits(6) = 88
+        // SplineType FacingTarget (worst case): float(4) + GUID(18) = 22
+        // Points: MaxSplinePoints * Vector3(12)
+        // PackedDeltas: MaxSplinePoints * PackedXYZ(4)
+        private const int FixedSize = 88 + 22; // 110 bytes
+        public int MaxSize => FixedSize + MaxSplinePoints * 12 + MaxSplinePoints * 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            // Check if we exceed the cap - if so, return -1 to trigger fallback
+            if (Points.Count > MaxSplinePoints || PackedDeltas.Count > MaxSplinePoints)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+
+            writer.WritePackedGuid128(MoverGUID.Low, MoverGUID.High);
+            writer.WriteVector3(MoveSpline.StartPosition);
+
+            writer.WriteUInt32(MoveSpline.SplineId);
+            writer.WriteVector3(Vector3.Zero); // Destination
+            writer.WriteBit(false); // CrzTeleport
+            writer.WriteBits((uint)(Points.Count == 0 ? 2 : 0), 3); // StopDistanceTolerance
+
+            writer.WriteUInt32((uint)MoveSpline.SplineFlags);
+            writer.WriteInt32(0); // Elapsed
+            writer.WriteUInt32(MoveSpline.SplineTimeFull);
+            writer.WriteUInt32(0); // FadeObjectTime
+            writer.WriteUInt8(MoveSpline.SplineMode);
+            writer.WritePackedGuid128(MoveSpline.TransportGuid.Low, MoveSpline.TransportGuid.High);
+            writer.WriteInt8(MoveSpline.TransportSeat);
+            writer.WriteBits((uint)MoveSpline.SplineType, 2);
+            writer.WriteBits((uint)Points.Count, 16);
+            writer.WriteBit(false); // VehicleExitVoluntary
+            writer.WriteBit(false); // Interpolate
+            writer.WriteBits((uint)PackedDeltas.Count, 16);
+            writer.WriteBit(false); // SplineFilter.HasValue
+            writer.WriteBit(false); // SpellEffectExtraData.HasValue
+            writer.WriteBit(false); // JumpExtraData.HasValue
+            writer.FlushBits();
+
+            switch (MoveSpline.SplineType)
+            {
+                case SplineTypeModern.FacingSpot:
+                    writer.WriteVector3(MoveSpline.FinalFacingSpot);
+                    break;
+                case SplineTypeModern.FacingTarget:
+                    writer.WriteFloat(MoveSpline.FinalOrientation);
+                    writer.WritePackedGuid128(MoveSpline.FinalFacingGuid.Low, MoveSpline.FinalFacingGuid.High);
+                    break;
+                case SplineTypeModern.FacingAngle:
+                    writer.WriteFloat(MoveSpline.FinalOrientation);
+                    break;
+            }
+
+            foreach (Vector3 pos in Points)
+                writer.WriteVector3(pos);
+
+            foreach (Vector3 pos in PackedDeltas)
+                writer.WritePackXYZ(pos);
+
+            return writer.Position;
+        }
+
         public WowGuid128 MoverGUID;
         public ServerSideMovement MoveSpline;
         public List<Vector3> Points = new();
@@ -173,7 +250,7 @@ namespace HermesProxy.World.Server.Packets
         public uint MoveTime;
     }
 
-    public class MoveTeleport : ServerPacket
+    public class MoveTeleport : ServerPacket, ISpanWritable
     {
         public MoveTeleport() : base(Opcode.SMSG_MOVE_TELEPORT, ConnectionType.Instance) { }
 
@@ -201,6 +278,36 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WritePackedGuid128(TransportGUID);
         }
 
+        // MaxSize: GUID (18) + uint (4) + Vector3 (12) + float (4) + byte (1) + bits (1) + Vehicle (2) + TransportGUID (18) = 60
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4 + 12 + 4 + 1 + 1 + 2 + PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(MoverGUID.Low, MoverGUID.High);
+            writer.WriteUInt32(MoveCounter);
+            writer.WriteVector3(Position);
+            writer.WriteFloat(Orientation);
+            writer.WriteUInt8(PreloadWorld);
+
+            writer.WriteBit(TransportGUID != default);
+            writer.WriteBit(Vehicle != null);
+            writer.FlushBits();
+
+            if (Vehicle != null)
+            {
+                writer.WriteInt8(Vehicle.VehicleSeatIndex);
+                writer.WriteBit(Vehicle.VehicleExitVoluntary);
+                writer.WriteBit(Vehicle.VehicleExitTeleport);
+                writer.FlushBits();
+            }
+
+            if (TransportGUID != default)
+                writer.WritePackedGuid128(TransportGUID.Low, TransportGUID.High);
+
+            return writer.Position;
+        }
+
         public Vector3 Position;
         public VehicleTeleport Vehicle;
         public uint MoveCounter;
@@ -217,7 +324,7 @@ namespace HermesProxy.World.Server.Packets
         public bool VehicleExitTeleport;
     }
 
-    public class TransferPending : ServerPacket
+    public class TransferPending : ServerPacket, ISpanWritable
     {
         public TransferPending() : base(Opcode.SMSG_TRANSFER_PENDING) { }
 
@@ -240,6 +347,30 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        // MaxSize: uint (4) + Vector3 (12) + bits (1) + Ship (8) + TransferSpellID (4) = 29
+        public int MaxSize => 4 + 12 + 1 + 8 + 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(MapID);
+            writer.WriteVector3(OldMapPosition);
+            writer.WriteBit(Ship != null);
+            writer.WriteBit(TransferSpellID.HasValue);
+
+            if (Ship != null)
+            {
+                writer.WriteUInt32(Ship.Id);
+                writer.WriteInt32(Ship.OriginMapID);
+            }
+
+            if (TransferSpellID.HasValue)
+                writer.WriteInt32(TransferSpellID.Value);
+
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public uint MapID;
         public Vector3 OldMapPosition;
         public ShipTransferPending Ship;
@@ -252,7 +383,7 @@ namespace HermesProxy.World.Server.Packets
         }
     }
 
-    public class TransferAborted : ServerPacket
+    public class TransferAborted : ServerPacket, ISpanWritable
     {
         public TransferAborted() : base(Opcode.SMSG_TRANSFER_ABORTED) { }
 
@@ -265,13 +396,26 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 10; // uint + byte + int + 1 byte for 6 bits
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(MapID);
+            writer.WriteUInt8(Arg);
+            writer.WriteInt32(MapDifficultyXConditionID);
+            writer.WriteBits((uint)Reason, 6);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public uint MapID;
         public byte Arg;
         public int MapDifficultyXConditionID = -6;
         public TransferAbortReasonModern Reason;
     }
 
-    public class NewWorld : ServerPacket
+    public class NewWorld : ServerPacket, ISpanWritable
     {
         public NewWorld() : base(Opcode.SMSG_NEW_WORLD) { }
 
@@ -282,6 +426,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteFloat(Orientation);
             _worldPacket.WriteUInt32(Reason);
             _worldPacket.WriteVector3(MovementOffset);
+        }
+
+        public int MaxSize => 36; // 2 uint + 2 Vector3 (24 bytes) + float = 36
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(MapID);
+            writer.WriteVector3(Position);
+            writer.WriteFloat(Orientation);
+            writer.WriteUInt32(Reason);
+            writer.WriteVector3(MovementOffset);
+            return writer.Position;
         }
 
         public uint MapID;
@@ -299,7 +456,7 @@ namespace HermesProxy.World.Server.Packets
     }
 
     // for server controlled units
-    public class MoveSplineSetSpeed : ServerPacket
+    public class MoveSplineSetSpeed : ServerPacket, ISpanWritable
     {
         public MoveSplineSetSpeed(Opcode opcode) : base(opcode, ConnectionType.Instance) { }
 
@@ -309,12 +466,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteFloat(Speed);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4; // GUID + float
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(MoverGUID.Low, MoverGUID.High);
+            writer.WriteFloat(Speed);
+            return writer.Position;
+        }
+
         public WowGuid128 MoverGUID;
         public float Speed = 1.0f;
     }
 
     // for own player
-    public class MoveSetSpeed : ServerPacket
+    public class MoveSetSpeed : ServerPacket, ISpanWritable
     {
         public MoveSetSpeed(Opcode opcode) : base(opcode, ConnectionType.Instance) { }
 
@@ -323,6 +490,17 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(MoverGUID);
             _worldPacket.WriteUInt32(MoveCounter);
             _worldPacket.WriteFloat(Speed);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 8; // GUID + uint + float
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(MoverGUID.Low, MoverGUID.High);
+            writer.WriteUInt32(MoveCounter);
+            writer.WriteFloat(Speed);
+            return writer.Position;
         }
 
         public WowGuid128 MoverGUID;
@@ -360,7 +538,7 @@ namespace HermesProxy.World.Server.Packets
     }
 
     // for other players
-    public class MoveUpdateSpeed : ServerPacket
+    public class MoveUpdateSpeed : ServerPacket, ISpanWritable
     {
         public MoveUpdateSpeed(Opcode opcode) : base(opcode, ConnectionType.Instance) { }
 
@@ -370,12 +548,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteFloat(Speed);
         }
 
+        public int MaxSize => MovementInfo.MaxMovementInfoSize + 4; // MovementInfo + float
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int written = MoveInfo.WriteMovementInfoModernToSpan(buffer, MoverGUID.Low, MoverGUID.High);
+            var writer = new SpanPacketWriter(buffer.Slice(written));
+            writer.WriteFloat(Speed);
+            return written + writer.Position;
+        }
+
         public WowGuid128 MoverGUID;
         public MovementInfo MoveInfo;
         public float Speed = 1.0f;
     }
 
-    public class MoveSplineSetFlag : ServerPacket
+    public class MoveSplineSetFlag : ServerPacket, ISpanWritable
     {
         public MoveSplineSetFlag(Opcode opcode) : base(opcode, ConnectionType.Instance) { }
 
@@ -384,10 +572,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(MoverGUID);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size; // Just GUID
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(MoverGUID.Low, MoverGUID.High);
+            return writer.Position;
+        }
+
         public WowGuid128 MoverGUID;
     }
 
-    public class MoveSetFlag : ServerPacket
+    public class MoveSetFlag : ServerPacket, ISpanWritable
     {
         public MoveSetFlag(Opcode opcode) : base(opcode, ConnectionType.Instance) { }
 
@@ -395,6 +592,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WritePackedGuid128(MoverGUID);
             _worldPacket.WriteUInt32(MoveCounter);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4; // GUID + uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(MoverGUID.Low, MoverGUID.High);
+            writer.WriteUInt32(MoveCounter);
+            return writer.Position;
         }
 
         public WowGuid128 MoverGUID;
@@ -435,7 +642,7 @@ namespace HermesProxy.World.Server.Packets
         public byte Reason;
     }
 
-    class MoveSetCollisionHeight : ServerPacket
+    class MoveSetCollisionHeight : ServerPacket, ISpanWritable
     {
         public MoveSetCollisionHeight() : base(Opcode.SMSG_MOVE_SET_COLLISION_HEIGHT) { }
 
@@ -449,7 +656,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(MountDisplayID);
             _worldPacket.WriteInt32(ScaleDuration);
         }
-        
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 21; // GUID + uint + 2 float + byte + uint + int
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(MoverGUID.Low, MoverGUID.High);
+            writer.WriteUInt32(SequenceIndex);
+            writer.WriteFloat(Height);
+            writer.WriteFloat(Scale);
+            writer.WriteUInt8((byte)Reason);
+            writer.WriteUInt32(MountDisplayID);
+            writer.WriteInt32(ScaleDuration);
+            return writer.Position;
+        }
+
         public WowGuid128 MoverGUID;
         public uint SequenceIndex = 1;
         public float Height = 1.0f;
@@ -466,7 +688,7 @@ namespace HermesProxy.World.Server.Packets
         }
     }
 
-    class MoveKnockBack : ServerPacket
+    class MoveKnockBack : ServerPacket, ISpanWritable
     {
         public MoveKnockBack() : base(Opcode.SMSG_MOVE_KNOCK_BACK, ConnectionType.Instance) { }
 
@@ -479,6 +701,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteFloat(VerticalSpeed);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 20; // GUID + uint + 2 floats (Vector2) + 2 floats
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(MoverGUID.Low, MoverGUID.High);
+            writer.WriteUInt32(MoveCounter);
+            writer.WriteVector2(Direction);
+            writer.WriteFloat(HorizontalSpeed);
+            writer.WriteFloat(VerticalSpeed);
+            return writer.Position;
+        }
+
         public WowGuid128 MoverGUID;
         public uint MoveCounter;
         public Vector2 Direction;
@@ -486,7 +721,7 @@ namespace HermesProxy.World.Server.Packets
         public float VerticalSpeed;
     }
 
-    public class MoveUpdateKnockBack : ServerPacket
+    public class MoveUpdateKnockBack : ServerPacket, ISpanWritable
     {
         public MoveUpdateKnockBack() : base(Opcode.SMSG_MOVE_UPDATE_KNOCK_BACK) { }
 
@@ -495,11 +730,18 @@ namespace HermesProxy.World.Server.Packets
             MoveInfo.WriteMovementInfoModern(_worldPacket, MoverGUID);
         }
 
+        public int MaxSize => MovementInfo.MaxMovementInfoSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            return MoveInfo.WriteMovementInfoModernToSpan(buffer, MoverGUID.Low, MoverGUID.High);
+        }
+
         public WowGuid128 MoverGUID;
         public MovementInfo MoveInfo;
     }
 
-    class SuspendToken : ServerPacket
+    class SuspendToken : ServerPacket, ISpanWritable
     {
         public SuspendToken() : base(Opcode.SMSG_SUSPEND_TOKEN, ConnectionType.Instance) { }
 
@@ -510,11 +752,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 5; // uint + 1 byte for 2 bits
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(SequenceIndex);
+            writer.WriteBits(Reason, 2);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public uint SequenceIndex = 1;
         public uint Reason = 1;
     }
 
-    class ResumeToken : ServerPacket
+    class ResumeToken : ServerPacket, ISpanWritable
     {
         public ResumeToken() : base(Opcode.SMSG_RESUME_TOKEN, ConnectionType.Instance) { }
 
@@ -525,11 +778,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 5; // uint + 1 byte for 2 bits
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(SequenceIndex);
+            writer.WriteBits(Reason, 2);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public uint SequenceIndex = 1;
         public uint Reason = 1;
     }
 
-    public class ControlUpdate : ServerPacket
+    public class ControlUpdate : ServerPacket, ISpanWritable
     {
         public ControlUpdate() : base(Opcode.SMSG_CONTROL_UPDATE) { }
 
@@ -538,6 +802,17 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(Guid);
             _worldPacket.WriteBit(HasControl);
             _worldPacket.FlushBits();
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 1; // GUID + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            writer.WriteBit(HasControl);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public WowGuid128 Guid;

--- a/HermesProxy/World/Server/Packets/NPCPackets.cs
+++ b/HermesProxy/World/Server/Packets/NPCPackets.cs
@@ -18,11 +18,13 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace HermesProxy.World.Server.Packets
 {
@@ -178,7 +180,7 @@ namespace HermesProxy.World.Server.Packets
         public string PromotionCode;
     }
 
-    public class GossipComplete : ServerPacket
+    public class GossipComplete : ServerPacket, ISpanWritable
     {
         public GossipComplete() : base(Opcode.SMSG_GOSSIP_COMPLETE) { }
 
@@ -191,16 +193,39 @@ namespace HermesProxy.World.Server.Packets
             }
         }
 
+        // MaxSize: optional bit (1 byte when flushed)
+        public int MaxSize => 1;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            if (ModernVersion.AddedInVersion(9, 2, 0, 1, 14, 2, 2, 5, 3))
+            {
+                writer.WriteBit(SuppressSound);
+                writer.FlushBits();
+            }
+            return writer.Position;
+        }
+
         public bool SuppressSound;
     }
 
-    public class BinderConfirm : ServerPacket
+    public class BinderConfirm : ServerPacket, ISpanWritable
     {
         public BinderConfirm() : base(Opcode.SMSG_BINDER_CONFIRM) { }
 
         public override void Write()
         {
             _worldPacket.WritePackedGuid128(Guid);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            return writer.Position;
         }
 
         public WowGuid128 Guid;
@@ -256,13 +281,22 @@ namespace HermesProxy.World.Server.Packets
         public bool Refundable;
     }
 
-    public class ShowBank : ServerPacket
+    public class ShowBank : ServerPacket, ISpanWritable
     {
         public ShowBank() : base(Opcode.SMSG_SHOW_BANK, ConnectionType.Instance) { }
 
         public override void Write()
         {
             _worldPacket.WritePackedGuid128(Guid);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            return writer.Position;
         }
 
         public WowGuid128 Guid;
@@ -280,7 +314,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 Guid;
     }
 
-    public class TrainerList : ServerPacket
+    public class TrainerList : ServerPacket, ISpanWritable
     {
         public TrainerList() : base(Opcode.SMSG_TRAINER_LIST, ConnectionType.Instance) { }
 
@@ -308,6 +342,45 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteBits(Greeting.GetByteCount(), 11);
             _worldPacket.FlushBits();
             _worldPacket.WriteString(Greeting);
+        }
+
+        // MaxSize: GUID(18) + 2 ints(8) + count(4) + max 200 spells (30 each) + bits(2) + greeting(256) = 6288
+        // TrainerListSpell: 4 uints(16) + 3 reqAbility(12) + 2 bytes(2) = 30
+        private const int MaxSpells = 200;
+        private const int SpellSize = 30;
+        private const int MaxGreetingBytes = 256;
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 12 + MaxSpells * SpellSize + 2 + MaxGreetingBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int greetingBytes = Encoding.UTF8.GetByteCount(Greeting ?? "");
+            if (Spells.Count > MaxSpells || greetingBytes > 2047) // 11 bits max
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(TrainerGUID.Low, TrainerGUID.High);
+            writer.WriteInt32(TrainerType);
+            writer.WriteUInt32(TrainerID);
+
+            writer.WriteInt32(Spells.Count);
+            foreach (var spell in Spells)
+            {
+                writer.WriteUInt32(spell.SpellID);
+                writer.WriteUInt32(spell.MoneyCost);
+                writer.WriteUInt32(spell.ReqSkillLine);
+                writer.WriteUInt32(spell.ReqSkillRank);
+
+                for (int i = 0; i < 3; ++i)
+                    writer.WriteUInt32(spell.ReqAbility[i]);
+
+                writer.WriteUInt8((byte)spell.Usable);
+                writer.WriteUInt8(spell.ReqLevel);
+            }
+
+            writer.WriteBits((uint)greetingBytes, 11);
+            writer.FlushBits();
+            writer.WriteString(Greeting ?? "");
+            return writer.Position;
         }
 
         public WowGuid128 TrainerGUID;
@@ -344,7 +417,7 @@ namespace HermesProxy.World.Server.Packets
         public uint SpellID;
     }
 
-    class TrainerBuyFailed : ServerPacket
+    class TrainerBuyFailed : ServerPacket, ISpanWritable
     {
         public TrainerBuyFailed() : base(Opcode.SMSG_TRAINER_BUY_FAILED) { }
 
@@ -355,12 +428,23 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(TrainerFailedReason);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 8; // GUID + 2 uints
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(TrainerGUID.Low, TrainerGUID.High);
+            writer.WriteUInt32(SpellID);
+            writer.WriteUInt32(TrainerFailedReason);
+            return writer.Position;
+        }
+
         public WowGuid128 TrainerGUID;
         public uint SpellID;
         public uint TrainerFailedReason;
     }
 
-    class RespecWipeConfirm : ServerPacket
+    class RespecWipeConfirm : ServerPacket, ISpanWritable
     {
         public RespecWipeConfirm() : base(Opcode.SMSG_RESPEC_WIPE_CONFIRM) { }
 
@@ -369,6 +453,17 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt8((sbyte)RespecType);
             _worldPacket.WriteUInt32(Cost);
             _worldPacket.WritePackedGuid128(TrainerGUID);
+        }
+
+        public int MaxSize => 5 + PackedGuidHelper.MaxPackedGuid128Size; // sbyte + uint + GUID
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt8((sbyte)RespecType);
+            writer.WriteUInt32(Cost);
+            writer.WritePackedGuid128(TrainerGUID.Low, TrainerGUID.High);
+            return writer.Position;
         }
 
         public SpecResetType RespecType = SpecResetType.Talents;
@@ -390,7 +485,7 @@ namespace HermesProxy.World.Server.Packets
         public SpecResetType RespecType;
     }
 
-    class GossipPOI : ServerPacket
+    class GossipPOI : ServerPacket, ISpanWritable
     {
         public GossipPOI() : base(Opcode.SMSG_GOSSIP_POI) { }
 
@@ -409,6 +504,32 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(Name);
         }
 
+        // Cap for POI name - limited by 6 bits = 64 bytes max
+        private const int MaxNameBytes = 64;
+        // 4 uint(16) + 3 floats(12) + 3 bytes for bits + name
+        public int MaxSize => 16 + 12 + 3 + MaxNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int nameBytes = Encoding.UTF8.GetByteCount(Name);
+            if (nameBytes > MaxNameBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(Id);
+            writer.WriteFloat(Pos.X);
+            writer.WriteFloat(Pos.Y);
+            writer.WriteFloat(Pos.Z);
+            writer.WriteUInt32(Icon);
+            writer.WriteUInt32(Importance);
+            writer.WriteUInt32(Unknown905);
+            writer.WriteBits(Flags, 14);
+            writer.WriteBits((uint)nameBytes, 6);
+            writer.FlushBits();
+            writer.WriteString(Name);
+            return writer.Position;
+        }
+
         public uint Id = 1;
         public uint Flags;
         public Vector3 Pos;
@@ -418,13 +539,22 @@ namespace HermesProxy.World.Server.Packets
         public string Name;
     }
 
-    public class SpiritHealerConfirm : ServerPacket
+    public class SpiritHealerConfirm : ServerPacket, ISpanWritable
     {
         public SpiritHealerConfirm() : base(Opcode.SMSG_SPIRIT_HEALER_CONFIRM) { }
 
         public override void Write()
         {
             _worldPacket.WritePackedGuid128(Guid);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            return writer.Position;
         }
 
         public WowGuid128 Guid;

--- a/HermesProxy/World/Server/Packets/PetPackets.cs
+++ b/HermesProxy/World/Server/Packets/PetPackets.cs
@@ -18,10 +18,12 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace HermesProxy.World.Server.Packets
 {
@@ -98,13 +100,17 @@ namespace HermesProxy.World.Server.Packets
         public sbyte ConsumedCharges;
     }
 
-    public class PetClearSpells : ServerPacket
+    public class PetClearSpells : ServerPacket, ISpanWritable
     {
         public PetClearSpells() : base(Opcode.SMSG_PET_CLEAR_SPELLS, ConnectionType.Instance) { }
 
         public override void Write()
         {
         }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
     class PetAction : ClientPacket
@@ -156,7 +162,7 @@ namespace HermesProxy.World.Server.Packets
         public uint Action;
     }
 
-    class PetActionSound : ServerPacket
+    class PetActionSound : ServerPacket, ISpanWritable
     {
         public PetActionSound() : base(Opcode.SMSG_PET_ACTION_SOUND) { }
 
@@ -164,6 +170,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WritePackedGuid128(UnitGUID);
             _worldPacket.WriteUInt32(Action);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4; // GUID + uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(UnitGUID.Low, UnitGUID.High);
+            writer.WriteUInt32(Action);
+            return writer.Position;
         }
 
         public WowGuid128 UnitGUID;
@@ -232,7 +248,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 StableMaster;
     }
 
-    class PetStableList : ServerPacket
+    class PetStableList : ServerPacket, ISpanWritable
     {
         public PetStableList() : base(Opcode.SMSG_PET_STABLE_LIST, ConnectionType.Instance) { }
 
@@ -252,6 +268,45 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteBits(pet.PetName.GetByteCount(), 8);
                 _worldPacket.WriteString(pet.PetName);
             }
+        }
+
+        // Cap for stable slots - max 5 stable slots + active
+        private const int MaxPets = 6;
+        // Cap for pet name - 8 bits = max 256
+        private const int MaxPetNameBytes = 64;
+        // Per pet: 4 uints(16) + 2 bytes(2) + bits(1) + name
+        private const int PetInfoSize = 16 + 2 + 1 + MaxPetNameBytes;
+        // GUID(18) + count(4) + byte(1) + pets
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4 + 1 + MaxPets * PetInfoSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Pets.Count > MaxPets)
+                return -1;
+
+            // Pre-validate name lengths
+            foreach (var pet in Pets)
+            {
+                if (Encoding.UTF8.GetByteCount(pet.PetName) > MaxPetNameBytes)
+                    return -1;
+            }
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(StableMaster.Low, StableMaster.High);
+            writer.WriteInt32(Pets.Count);
+            writer.WriteUInt8(NumStableSlots);
+            foreach (PetStableInfo pet in Pets)
+            {
+                writer.WriteUInt32(pet.PetNumber);
+                writer.WriteUInt32(pet.CreatureID);
+                writer.WriteUInt32(pet.DisplayID);
+                writer.WriteUInt32(pet.ExperienceLevel);
+                writer.WriteUInt8(pet.LoyaltyLevel);
+                writer.WriteUInt8(pet.PetFlags);
+                writer.WriteBits((uint)Encoding.UTF8.GetByteCount(pet.PetName), 8);
+                writer.WriteString(pet.PetName);
+            }
+            return writer.Position;
         }
 
         public WowGuid128 StableMaster;
@@ -282,7 +337,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 StableMaster;
     }
 
-    public class PetGuids : ServerPacket
+    public class PetGuids : ServerPacket, ISpanWritable
     {
         public PetGuids() : base(Opcode.SMSG_PET_GUIDS, ConnectionType.Instance) { }
 
@@ -293,16 +348,42 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WritePackedGuid128(guid);
         }
 
+        // Cap for pet GUIDs - max 5 stable slots + active pet
+        private const int MaxPets = 6;
+        // count(4) + GUIDs(18 each)
+        public int MaxSize => 4 + MaxPets * PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Guids.Count > MaxPets)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Guids.Count);
+            foreach (var guid in Guids)
+                writer.WritePackedGuid128(guid.Low, guid.High);
+            return writer.Position;
+        }
+
         public List<WowGuid128> Guids = new List<WowGuid128>();
     }
 
-    class PetStableResult : ServerPacket
+    class PetStableResult : ServerPacket, ISpanWritable
     {
         public PetStableResult() : base(Opcode.SMSG_PET_STABLE_RESULT, ConnectionType.Instance) { }
 
         public override void Write()
         {
             _worldPacket.WriteUInt8(Result);
+        }
+
+        public int MaxSize => 1; // byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt8(Result);
+            return writer.Position;
         }
 
         public byte Result;

--- a/HermesProxy/World/Server/Packets/PetitionPackets.cs
+++ b/HermesProxy/World/Server/Packets/PetitionPackets.cs
@@ -16,13 +16,15 @@
  */
 
 
+using System;
+using System.Collections.Generic;
+using System.Text;
 using Framework.Collections;
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
-using System;
-using System.Collections.Generic;
 
 namespace HermesProxy.World.Server.Packets
 {
@@ -40,7 +42,7 @@ namespace HermesProxy.World.Server.Packets
         public uint PetitionID;
     }
 
-    public class QueryPetitionResponse : ServerPacket
+    public class QueryPetitionResponse : ServerPacket, ISpanWritable
     {
         public QueryPetitionResponse() : base(Opcode.SMSG_QUERY_PETITION_RESPONSE) { }
 
@@ -52,6 +54,65 @@ namespace HermesProxy.World.Server.Packets
 
             if (Allow)
                 Info.Write(_worldPacket);
+        }
+
+        // MaxSize: uint(4) + bit(1) + PetitionInfo
+        // PetitionInfo: uint(4) + GUID(18) + 11 fixed fields(46) + bits(7+12+10*6=79->10) + title(48) + body(256) + 10 choice texts(64 each) = 1022
+        private const int MaxTitleBytes = 48;
+        private const int MaxBodyBytes = 256;
+        private const int MaxChoiceBytes = 64;
+        private const int MaxChoices = 10;
+        public int MaxSize => 5 + 4 + PackedGuidHelper.MaxPackedGuid128Size + 46 + 10 + MaxTitleBytes + MaxBodyBytes + MaxChoices * MaxChoiceBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(PetitionID);
+            writer.WriteBit(Allow);
+            writer.FlushBits();
+
+            if (Allow && Info != null)
+            {
+                // Validate string lengths
+                int titleBytes = Encoding.UTF8.GetByteCount(Info.Title ?? "");
+                int bodyBytes = Encoding.UTF8.GetByteCount(Info.BodyText ?? "");
+                if (titleBytes > 127 || bodyBytes > 4095) // 7 bits and 12 bits max
+                    return -1;
+
+                writer.WriteUInt32(Info.PetitionID);
+                writer.WritePackedGuid128(Info.Petitioner.Low, Info.Petitioner.High);
+                writer.WriteUInt32(Info.MinSignatures);
+                writer.WriteUInt32(Info.MaxSignatures);
+                writer.WriteInt32(Info.DeadLine);
+                writer.WriteInt32(Info.IssueDate);
+                writer.WriteInt32(Info.AllowedGuildID);
+                writer.WriteInt32(Info.AllowedClasses);
+                writer.WriteInt32(Info.AllowedRaces);
+                writer.WriteInt16(Info.AllowedGender);
+                writer.WriteInt32(Info.AllowedMinLevel);
+                writer.WriteInt32(Info.AllowedMaxLevel);
+                writer.WriteInt32(Info.NumChoices);
+                writer.WriteInt32(Info.StaticType);
+                writer.WriteUInt32(Info.Muid);
+
+                writer.WriteBits((uint)titleBytes, 7);
+                writer.WriteBits((uint)bodyBytes, 12);
+
+                for (int i = 0; i < Info.Choicetext.Length; i++)
+                {
+                    string choice = Info.Choicetext[i] ?? "";
+                    writer.WriteBits((uint)Encoding.UTF8.GetByteCount(choice), 6);
+                }
+
+                writer.FlushBits();
+
+                for (int i = 0; i < Info.Choicetext.Length; i++)
+                    writer.WriteString(Info.Choicetext[i] ?? "");
+
+                writer.WriteString(Info.Title ?? "");
+                writer.WriteString(Info.BodyText ?? "");
+            }
+            return writer.Position;
         }
 
         public uint PetitionID = 0;
@@ -115,7 +176,7 @@ namespace HermesProxy.World.Server.Packets
         public StringArray Choicetext = new(10);
     }
 
-    public class ServerPetitionShowList : ServerPacket
+    public class ServerPetitionShowList : ServerPacket, ISpanWritable
     {
         public ServerPetitionShowList() : base(Opcode.SMSG_PETITION_SHOW_LIST) { }
 
@@ -125,6 +186,32 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(Petitions.Count);
             foreach (var petition in Petitions)
                 petition.Write(_worldPacket);
+        }
+
+        // Cap for petitions - typically just 1 (guild charter)
+        private const int MaxPetitions = 4;
+        // Each PetitionEntry: 5 uints = 20 bytes
+        private const int PetitionEntrySize = 20;
+        // GUID(18) + int(4) + petitions
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4 + MaxPetitions * PetitionEntrySize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Petitions.Count > MaxPetitions)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Unit.Low, Unit.High);
+            writer.WriteInt32(Petitions.Count);
+            foreach (var petition in Petitions)
+            {
+                writer.WriteUInt32(petition.Index);
+                writer.WriteUInt32(petition.CharterCost);
+                writer.WriteUInt32(petition.CharterEntry);
+                writer.WriteUInt32(petition.IsArena);
+                writer.WriteUInt32(petition.RequiredSignatures);
+            }
+            return writer.Position;
         }
 
         public WowGuid128 Unit;
@@ -178,7 +265,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 Item;
     }
 
-    public class ServerPetitionShowSignatures : ServerPacket
+    public class ServerPetitionShowSignatures : ServerPacket, ISpanWritable
     {
         public ServerPetitionShowSignatures() : base(Opcode.SMSG_PETITION_SHOW_SIGNATURES)
         {
@@ -198,6 +285,33 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WritePackedGuid128(signature.Signer);
                 _worldPacket.WriteInt32(signature.Choice);
             }
+        }
+
+        // Cap for signatures - guild charters need 4 (or 9 for classic)
+        private const int MaxSignatures = 16;
+        // Each signature: GUID(18) + int(4) = 22 bytes
+        private const int SignatureSize = PackedGuidHelper.MaxPackedGuid128Size + 4;
+        // 3 GUIDs(54) + 2 ints(8) + signatures
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 3 + 8 + MaxSignatures * SignatureSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Signatures.Count > MaxSignatures)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Item.Low, Item.High);
+            writer.WritePackedGuid128(Owner.Low, Owner.High);
+            writer.WritePackedGuid128(OwnerAccountID.Low, OwnerAccountID.High);
+            writer.WriteInt32(PetitionID);
+
+            writer.WriteInt32(Signatures.Count);
+            foreach (PetitionSignature signature in Signatures)
+            {
+                writer.WritePackedGuid128(signature.Signer.Low, signature.Signer.High);
+                writer.WriteInt32(signature.Choice);
+            }
+            return writer.Position;
         }
 
         public WowGuid128 Item;
@@ -231,7 +345,7 @@ namespace HermesProxy.World.Server.Packets
         public string NewGuildName;
     }
 
-    public class PetitionRenameGuildResponse : ServerPacket
+    public class PetitionRenameGuildResponse : ServerPacket, ISpanWritable
     {
         public PetitionRenameGuildResponse() : base(Opcode.SMSG_PETITION_RENAME_GUILD_RESPONSE) { }
 
@@ -243,6 +357,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
 
             _worldPacket.WriteString(NewGuildName);
+        }
+
+        // MaxSize: PackedGuid128 (18) + bits (7 -> 1) + guild name (48) = 67
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 1 + GameLimits.MaxGuildNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(PetitionGuid.Low, PetitionGuid.High);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(NewGuildName), 7);
+            writer.FlushBits();
+            writer.WriteString(NewGuildName);
+            return writer.Position;
         }
 
         public WowGuid128 PetitionGuid;
@@ -291,7 +418,7 @@ namespace HermesProxy.World.Server.Packets
         public byte Choice;
     }
 
-    public class PetitionSignResults : ServerPacket
+    public class PetitionSignResults : ServerPacket, ISpanWritable
     {
         public PetitionSignResults() : base(Opcode.SMSG_PETITION_SIGN_RESULTS) { }
 
@@ -302,6 +429,18 @@ namespace HermesProxy.World.Server.Packets
 
             _worldPacket.WriteBits(Error, 4);
             _worldPacket.FlushBits();
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 1; // 2 GUIDs + bits
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Item.Low, Item.High);
+            writer.WritePackedGuid128(Player.Low, Player.High);
+            writer.WriteBits((uint)Error, 4);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public WowGuid128 Item;
@@ -335,7 +474,7 @@ namespace HermesProxy.World.Server.Packets
         public uint BorderColor;
     }
 
-    public class TurnInPetitionResult : ServerPacket
+    public class TurnInPetitionResult : ServerPacket, ISpanWritable
     {
         public TurnInPetitionResult() : base(Opcode.SMSG_TURN_IN_PETITION_RESULT) { }
 
@@ -343,6 +482,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WriteBits(Result, 4);
             _worldPacket.FlushBits();
+        }
+
+        public int MaxSize => 1; // 4 bits packed into 1 byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)Result, 4);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public PetitionTurnResult Result = 0;

--- a/HermesProxy/World/Server/Packets/QueryPackets.cs
+++ b/HermesProxy/World/Server/Packets/QueryPackets.cs
@@ -17,21 +17,32 @@
 
 using HermesProxy.World.Enums;
 using System;
+using System.Text;
 using HermesProxy.World.Objects;
 using Framework.Collections;
 using Framework.Constants;
 using System.Collections.Generic;
 using Framework.IO;
+using Framework.GameMath;
 
 namespace HermesProxy.World.Server.Packets
 {
-    public class QueryTimeResponse : ServerPacket
+    public class QueryTimeResponse : ServerPacket, ISpanWritable
     {
         public QueryTimeResponse() : base(Opcode.SMSG_QUERY_TIME_RESPONSE, ConnectionType.Instance) { }
 
         public override void Write()
         {
             _worldPacket.WriteInt64(CurrentTime);
+        }
+
+        public int MaxSize => 8; // int64
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt64(CurrentTime);
+            return writer.Position;
         }
 
         public long CurrentTime;
@@ -49,7 +60,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 UnitGUID;
     }
 
-    class QueryPetNameResponse : ServerPacket
+    class QueryPetNameResponse : ServerPacket, ISpanWritable
     {
         public QueryPetNameResponse() : base(Opcode.SMSG_QUERY_PET_NAME_RESPONSE, ConnectionType.Instance) { }
 
@@ -74,6 +85,34 @@ namespace HermesProxy.World.Server.Packets
             }
 
             _worldPacket.FlushBits();
+        }
+
+        // MaxSize: PackedGuid128 (18) + bits (45 -> 6) + 5 declined names (120) + timestamp (8) + name (24) = 176
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 6 + (PlayerConst.MaxDeclinedNameCases * GameLimits.MaxPetNameBytes) + 8 + GameLimits.MaxPetNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(UnitGUID.Low, UnitGUID.High);
+            writer.WriteBit(Allow);
+
+            if (Allow)
+            {
+                writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Name), 8);
+                writer.WriteBit(HasDeclined);
+
+                for (byte i = 0; i < PlayerConst.MaxDeclinedNameCases; ++i)
+                    writer.WriteBits((uint)Encoding.UTF8.GetByteCount(DeclinedNames.name[i]), 7);
+
+                for (byte i = 0; i < PlayerConst.MaxDeclinedNameCases; ++i)
+                    writer.WriteString(DeclinedNames.name[i]);
+
+                writer.WriteInt64(Timestamp);
+                writer.WriteString(Name);
+            }
+
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public WowGuid128 UnitGUID;
@@ -111,7 +150,7 @@ namespace HermesProxy.World.Server.Packets
         public List<WowGuid128> Players = new List<WowGuid128>();
     }
 
-    public class QueryPlayerNameResponse : ServerPacket
+    public class QueryPlayerNameResponse : ServerPacket, ISpanWritable
     {
         public QueryPlayerNameResponse() : base(Opcode.SMSG_QUERY_PLAYER_NAME_RESPONSE)
         {
@@ -125,6 +164,45 @@ namespace HermesProxy.World.Server.Packets
 
             if (Result == 0)
                 Data.Write(_worldPacket);
+        }
+
+        // Result byte(1) + GUID(18) + Data: bits(6) + 5 declined names(120) + 3 GUIDs(54) + ulong(8) + uint(4) + 5 bytes(5) + name(24) = 240 bytes max
+        public int MaxSize => 1 + PackedGuidHelper.MaxPackedGuid128Size + 6 +
+            (PlayerConst.MaxDeclinedNameCases * GameLimits.MaxPlayerNameBytes) +
+            PackedGuidHelper.MaxPackedGuid128Size * 3 + 8 + 4 + 5 + GameLimits.MaxPlayerNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt8((sbyte)Result);
+            writer.WritePackedGuid128(Player.Low, Player.High);
+
+            if (Result == 0)
+            {
+                // Inline PlayerGuidLookupData.Write
+                writer.WriteBit(Data.IsDeleted);
+                writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Data.Name), 6);
+
+                for (byte i = 0; i < PlayerConst.MaxDeclinedNameCases; ++i)
+                    writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Data.DeclinedNames.name[i]), 7);
+
+                writer.FlushBits();
+                for (byte i = 0; i < PlayerConst.MaxDeclinedNameCases; ++i)
+                    writer.WriteString(Data.DeclinedNames.name[i]);
+
+                writer.WritePackedGuid128(Data.AccountID.Low, Data.AccountID.High);
+                writer.WritePackedGuid128(Data.BnetAccountID.Low, Data.BnetAccountID.High);
+                writer.WritePackedGuid128(Data.GuidActual.Low, Data.GuidActual.High);
+                writer.WriteUInt64(Data.GuildClubMemberID);
+                writer.WriteUInt32(Data.VirtualRealmAddress);
+                writer.WriteUInt8((byte)Data.RaceID);
+                writer.WriteUInt8((byte)Data.Sex);
+                writer.WriteUInt8((byte)Data.ClassID);
+                writer.WriteUInt8(Data.Level);
+                writer.WriteUInt8(Data.Unused915);
+                writer.WriteString(Data.Name);
+            }
+            return writer.Position;
         }
 
         public WowGuid128 Player;
@@ -593,7 +671,7 @@ namespace HermesProxy.World.Server.Packets
         public uint TextID;
     }
 
-    public class QueryNPCTextResponse : ServerPacket
+    public class QueryNPCTextResponse : ServerPacket, ISpanWritable
     {
         public QueryNPCTextResponse() : base(Opcode.SMSG_QUERY_NPC_TEXT_RESPONSE, ConnectionType.Instance) { }
 
@@ -611,6 +689,27 @@ namespace HermesProxy.World.Server.Packets
                 for (uint i = 0; i < 8; ++i)
                     _worldPacket.WriteUInt32(BroadcastTextID[i]);
             }
+        }
+
+        // Fixed size: uint(4) + bit(1) + int(4) + 8 floats(32) + 8 uints(32) = 73 bytes
+        public int MaxSize => 4 + 1 + 4 + 32 + 32;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(TextID);
+            writer.WriteBit(Allow);
+
+            writer.WriteInt32(Allow ? 8 * (4 + 4) : 0);
+            if (Allow)
+            {
+                for (uint i = 0; i < 8; ++i)
+                    writer.WriteFloat(Probabilities[i]);
+
+                for (uint i = 0; i < 8; ++i)
+                    writer.WriteUInt32(BroadcastTextID[i]);
+            }
+            return writer.Position;
         }
 
         public uint TextID;

--- a/HermesProxy/World/Server/Packets/QuestPackets.cs
+++ b/HermesProxy/World/Server/Packets/QuestPackets.cs
@@ -18,10 +18,12 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace HermesProxy.World.Server.Packets
 {
@@ -303,7 +305,7 @@ namespace HermesProxy.World.Server.Packets
         public override void Read() { }
     }
 
-    public class QuestGiverStatusPkt : ServerPacket
+    public class QuestGiverStatusPkt : ServerPacket, ISpanWritable
     {
         public QuestGiverStatusPkt() : base(Opcode.SMSG_QUEST_GIVER_STATUS, ConnectionType.Instance)
         {
@@ -316,10 +318,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32((uint)QuestGiver.Status);
         }
 
+        // GUID(18) + uint(4) = 22 bytes
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(QuestGiver.Guid.Low, QuestGiver.Guid.High);
+            writer.WriteUInt32((uint)QuestGiver.Status);
+            return writer.Position;
+        }
+
         public QuestGiverInfo QuestGiver;
     }
 
-    public class QuestGiverStatusMultiple : ServerPacket
+    public class QuestGiverStatusMultiple : ServerPacket, ISpanWritable
     {
         public QuestGiverStatusMultiple() : base(Opcode.SMSG_QUEST_GIVER_STATUS_MULTIPLE, ConnectionType.Instance) { }
 
@@ -331,6 +344,26 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WritePackedGuid128(questGiver.Guid);
                 _worldPacket.WriteUInt32((uint)questGiver.Status);
             }
+        }
+
+        // Cap for quest givers in view - typically only a handful visible at once
+        private const int MaxQuestGivers = 32;
+        // Each entry: PackedGuid128 (18) + uint (4) = 22 bytes
+        public int MaxSize => 4 + MaxQuestGivers * (PackedGuidHelper.MaxPackedGuid128Size + 4);
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (QuestGivers.Count > MaxQuestGivers)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(QuestGivers.Count);
+            foreach (QuestGiverInfo questGiver in QuestGivers)
+            {
+                writer.WritePackedGuid128(questGiver.Guid.Low, questGiver.Guid.High);
+                writer.WriteUInt32((uint)questGiver.Status);
+            }
+            return writer.Position;
         }
 
         public List<QuestGiverInfo> QuestGivers = new();
@@ -651,7 +684,7 @@ namespace HermesProxy.World.Server.Packets
         public bool FromScript; // 0 - standart complete quest mode with npc, 1 - auto-complete mode
     }
 
-    class QuestGiverQuestFailed : ServerPacket
+    class QuestGiverQuestFailed : ServerPacket, ISpanWritable
     {
         public QuestGiverQuestFailed() : base(Opcode.SMSG_QUEST_GIVER_QUEST_FAILED) { }
 
@@ -661,11 +694,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32((uint)Reason);
         }
 
+        public int MaxSize => 8; // 2 uints
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(QuestID);
+            writer.WriteUInt32((uint)Reason);
+            return writer.Position;
+        }
+
         public uint QuestID;
         public InventoryResult Reason;
     }
 
-    class QuestGiverInvalidQuest : ServerPacket
+    class QuestGiverInvalidQuest : ServerPacket, ISpanWritable
     {
         public QuestGiverInvalidQuest() : base(Opcode.SMSG_QUEST_GIVER_INVALID_QUEST) { }
 
@@ -681,13 +724,34 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteString(ReasonText);
         }
 
+        // Cap for reason text - usually short error messages
+        private const int MaxReasonTextBytes = 256;
+        // uint(4) + int(4) + 10 bits(2) + text
+        public int MaxSize => 4 + 4 + 2 + MaxReasonTextBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int textBytes = Encoding.UTF8.GetByteCount(ReasonText);
+            if (textBytes > MaxReasonTextBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32((uint)Reason);
+            writer.WriteInt32(ContributionRewardID);
+            writer.WriteBit(SendErrorMessage);
+            writer.WriteBits((uint)textBytes, 9);
+            writer.FlushBits();
+            writer.WriteString(ReasonText);
+            return writer.Position;
+        }
+
         public QuestFailedReasons Reason;
         public int ContributionRewardID;
         public bool SendErrorMessage = true;
         public string ReasonText = "";
     }
 
-    class QuestUpdateStatus : ServerPacket
+    class QuestUpdateStatus : ServerPacket, ISpanWritable
     {
         public QuestUpdateStatus(Opcode opcode) : base(opcode) { }
 
@@ -696,9 +760,18 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(QuestID);
         }
 
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(QuestID);
+            return writer.Position;
+        }
+
         public uint QuestID;
     }
-    public class QuestUpdateAddCredit : ServerPacket
+    public class QuestUpdateAddCredit : ServerPacket, ISpanWritable
     {
         public QuestUpdateAddCredit() : base(Opcode.SMSG_QUEST_UPDATE_ADD_CREDIT, ConnectionType.Instance) { }
 
@@ -712,6 +785,20 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt8((byte)ObjectiveType);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 13; // GUID + uint + int + 2 ushorts + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(VictimGUID.Low, VictimGUID.High);
+            writer.WriteUInt32(QuestID);
+            writer.WriteInt32(ObjectID);
+            writer.WriteUInt16(Count);
+            writer.WriteUInt16(Required);
+            writer.WriteUInt8((byte)ObjectiveType);
+            return writer.Position;
+        }
+
         public WowGuid128 VictimGUID;
         public int ObjectID;
         public uint QuestID;
@@ -720,7 +807,7 @@ namespace HermesProxy.World.Server.Packets
         public QuestObjectiveType ObjectiveType;
     }
 
-    class QuestUpdateAddCreditSimple : ServerPacket
+    class QuestUpdateAddCreditSimple : ServerPacket, ISpanWritable
     {
         public QuestUpdateAddCreditSimple() : base(Opcode.SMSG_QUEST_UPDATE_ADD_CREDIT_SIMPLE, ConnectionType.Instance) { }
 
@@ -731,12 +818,23 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt8((byte)ObjectiveType);
         }
 
+        public int MaxSize => 9; // uint + int + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(QuestID);
+            writer.WriteInt32(ObjectID);
+            writer.WriteUInt8((byte)ObjectiveType);
+            return writer.Position;
+        }
+
         public uint QuestID;
         public int ObjectID;
         public QuestObjectiveType ObjectiveType;
     }
 
-    class QuestConfirmAccept : ServerPacket
+    class QuestConfirmAccept : ServerPacket, ISpanWritable
     {
         public QuestConfirmAccept() : base(Opcode.SMSG_QUEST_CONFIRM_ACCEPT) { }
 
@@ -747,6 +845,25 @@ namespace HermesProxy.World.Server.Packets
 
             _worldPacket.WriteBits(QuestTitle.GetByteCount(), 10);
             _worldPacket.WriteString(QuestTitle);
+        }
+
+        // Cap for quest title - most are well under 128 bytes
+        private const int MaxTitleBytes = 128;
+        // uint(4) + GUID(18) + 10 bits(2) + title
+        public int MaxSize => 4 + PackedGuidHelper.MaxPackedGuid128Size + 2 + MaxTitleBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int titleBytes = Encoding.UTF8.GetByteCount(QuestTitle);
+            if (titleBytes > MaxTitleBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(QuestID);
+            writer.WritePackedGuid128(InitiatedBy.Low, InitiatedBy.High);
+            writer.WriteBits((uint)titleBytes, 10);
+            writer.WriteString(QuestTitle);
+            return writer.Position;
         }
 
         public WowGuid128 InitiatedBy;
@@ -778,7 +895,7 @@ namespace HermesProxy.World.Server.Packets
         public uint QuestID;
     }
 
-    class QuestPushResult : ServerPacket
+    class QuestPushResult : ServerPacket, ISpanWritable
     {
         public QuestPushResult() : base(Opcode.SMSG_QUEST_PUSH_RESULT) { }
 
@@ -786,6 +903,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WritePackedGuid128(SenderGUID);
             _worldPacket.WriteUInt8((byte)Result);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 1; // GUID + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(SenderGUID.Low, SenderGUID.High);
+            writer.WriteUInt8((byte)Result);
+            return writer.Position;
         }
 
         public WowGuid128 SenderGUID;

--- a/HermesProxy/World/Server/Packets/ReputationPackets.cs
+++ b/HermesProxy/World/Server/Packets/ReputationPackets.cs
@@ -16,15 +16,17 @@
  */
 
 
+using System;
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System.Collections.Generic;
 
 namespace HermesProxy.World.Server.Packets
 {
-    public class InitializeFactions : ServerPacket
+    public class InitializeFactions : ServerPacket, ISpanWritable
     {
         const ushort FactionCount = 400;
 
@@ -44,12 +46,32 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        // Fixed size: 400 factions × (byte + int) + 400 bits = 2000 + 50 = 2050 bytes
+        public int MaxSize => FactionCount * 5 + 50;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+
+            for (ushort i = 0; i < FactionCount; ++i)
+            {
+                writer.WriteUInt8((byte)((ushort)FactionFlags[i] & 0xFF));
+                writer.WriteInt32(FactionStandings[i]);
+            }
+
+            for (ushort i = 0; i < FactionCount; ++i)
+                writer.WriteBit(FactionHasBonus[i]);
+
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public int[] FactionStandings = new int[FactionCount];
         public bool[] FactionHasBonus = new bool[FactionCount]; //@todo: implement faction bonus
         public ReputationFlags[] FactionFlags = new ReputationFlags[FactionCount];
     }
 
-    class SetFactionStanding : ServerPacket
+    class SetFactionStanding : ServerPacket, ISpanWritable
     {
         public SetFactionStanding() : base(Opcode.SMSG_SET_FACTION_STANDING, ConnectionType.Instance) { }
 
@@ -64,6 +86,30 @@ namespace HermesProxy.World.Server.Packets
 
             _worldPacket.WriteBit(ShowVisual);
             _worldPacket.FlushBits();
+        }
+
+        // Cap for faction standing changes - usually just a few at once
+        private const int MaxFactions = 16;
+        // 2 floats(8) + count(4) + factions(8 each) + 1 bit
+        public int MaxSize => 8 + 4 + MaxFactions * 8 + 1;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Factions.Count > MaxFactions)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteFloat(ReferAFriendBonus);
+            writer.WriteFloat(BonusFromAchievementSystem);
+            writer.WriteInt32(Factions.Count);
+            foreach (FactionStandingData factionStanding in Factions)
+            {
+                writer.WriteInt32(factionStanding.Index);
+                writer.WriteInt32(factionStanding.Standing);
+            }
+            writer.WriteBit(ShowVisual);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public float ReferAFriendBonus;
@@ -134,7 +180,7 @@ namespace HermesProxy.World.Server.Packets
         public uint FactionIndex;
     }
 
-    class SetForcedReactions : ServerPacket
+    class SetForcedReactions : ServerPacket, ISpanWritable
     {
         public SetForcedReactions() : base(Opcode.SMSG_SET_FORCED_REACTIONS, ConnectionType.Instance) { }
 
@@ -143,6 +189,26 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(Reactions.Count);
             foreach (ForcedReaction reaction in Reactions)
                 reaction.Write(_worldPacket);
+        }
+
+        // Cap for forced reactions - rarely more than a few
+        private const int MaxReactions = 8;
+        // count(4) + reactions(8 each)
+        public int MaxSize => 4 + MaxReactions * 8;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Reactions.Count > MaxReactions)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Reactions.Count);
+            foreach (ForcedReaction reaction in Reactions)
+            {
+                writer.WriteInt32(reaction.Faction);
+                writer.WriteInt32(reaction.Reaction);
+            }
+            return writer.Position;
         }
 
         public List<ForcedReaction> Reactions = new();
@@ -160,13 +226,22 @@ namespace HermesProxy.World.Server.Packets
         public int Reaction;
     }
 
-    class SetFactionVisible : ServerPacket
+    class SetFactionVisible : ServerPacket, ISpanWritable
     {
         public SetFactionVisible(bool visible) : base(visible ? Opcode.SMSG_SET_FACTION_VISIBLE : Opcode.SMSG_SET_FACTION_NOT_VISIBLE, ConnectionType.Instance) { }
 
         public override void Write()
         {
             _worldPacket.WriteUInt32(FactionIndex);
+        }
+
+        public int MaxSize => 4; // uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(FactionIndex);
+            return writer.Position;
         }
 
         public uint FactionIndex;

--- a/HermesProxy/World/Server/Packets/SessionPackets.cs
+++ b/HermesProxy/World/Server/Packets/SessionPackets.cs
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+using System;
 using Framework.Constants;
 using Framework.IO;
 using HermesProxy.World.Enums;
@@ -56,7 +57,7 @@ namespace HermesProxy.World.Server.Packets
         public ByteBuffer Data = new();
     }
 
-    class ConnectionStatus : ServerPacket
+    class ConnectionStatus : ServerPacket, ISpanWritable
     {
         public ConnectionStatus() : base(Opcode.SMSG_BATTLE_NET_CONNECTION_STATUS) { }
 
@@ -65,6 +66,17 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteBits(State, 2);
             _worldPacket.WriteBit(SuppressNotification);
             _worldPacket.FlushBits();
+        }
+
+        public int MaxSize => 1; // 3 bits = 1 byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits(State, 2);
+            writer.WriteBit(SuppressNotification);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public byte State;

--- a/HermesProxy/World/Server/Packets/SocialPackets.cs
+++ b/HermesProxy/World/Server/Packets/SocialPackets.cs
@@ -56,8 +56,8 @@ namespace HermesProxy.World.Server.Packets
                 contact.Write(_worldPacket);
         }
 
-        // Cap for contacts (8 bits = 256 max, using 200)
-        private const int MaxContacts = 200;
+        // Cap for contacts (8 bits = 256 max, reduced from 200 to 16 based on typical usage)
+        private const int MaxContacts = 16;
         // Cap for note string (10 bits = 1024, using 128)
         private const int MaxNoteBytes = 128;
         // Per contact: 2 GUIDs(36) + 4 uints(16) + byte(1) + bits(2) + note = 183 bytes max

--- a/HermesProxy/World/Server/Packets/SocialPackets.cs
+++ b/HermesProxy/World/Server/Packets/SocialPackets.cs
@@ -17,8 +17,10 @@
 
 
 using System;
+using System.Text;
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System.Collections.Generic;
@@ -37,7 +39,7 @@ namespace HermesProxy.World.Server.Packets
         public SocialFlag Flags;
     }
 
-    public class ContactList : ServerPacket
+    public class ContactList : ServerPacket, ISpanWritable
     {
         public ContactList() : base(Opcode.SMSG_CONTACT_LIST)
         {
@@ -52,6 +54,51 @@ namespace HermesProxy.World.Server.Packets
 
             foreach (ContactInfo contact in Contacts)
                 contact.Write(_worldPacket);
+        }
+
+        // Cap for contacts (8 bits = 256 max, using 200)
+        private const int MaxContacts = 200;
+        // Cap for note string (10 bits = 1024, using 128)
+        private const int MaxNoteBytes = 128;
+        // Per contact: 2 GUIDs(36) + 4 uints(16) + byte(1) + bits(2) + note = 183 bytes max
+        private const int ContactSize = PackedGuidHelper.MaxPackedGuid128Size * 2 + 16 + 1 + 2 + MaxNoteBytes;
+        // uint(4) + bits(1) + contacts
+        public int MaxSize => 4 + 1 + MaxContacts * ContactSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Contacts.Count > MaxContacts)
+                return -1;
+
+            // Pre-validate note lengths
+            foreach (var contact in Contacts)
+            {
+                if (Encoding.UTF8.GetByteCount(contact.Note) > MaxNoteBytes)
+                    return -1;
+            }
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32((uint)Flags);
+            writer.WriteBits((uint)Contacts.Count, 8);
+            writer.FlushBits();
+
+            foreach (ContactInfo contact in Contacts)
+            {
+                writer.WritePackedGuid128(contact.Guid.Low, contact.Guid.High);
+                writer.WritePackedGuid128(contact.WowAccountGuid.Low, contact.WowAccountGuid.High);
+                writer.WriteUInt32(contact.VirtualRealmAddr);
+                writer.WriteUInt32(contact.NativeRealmAddr);
+                writer.WriteUInt32((uint)contact.TypeFlags);
+                writer.WriteUInt8((byte)contact.Status);
+                writer.WriteUInt32(contact.AreaID);
+                writer.WriteUInt32(contact.Level);
+                writer.WriteUInt32((uint)contact.ClassID);
+                writer.WriteBits((uint)Encoding.UTF8.GetByteCount(contact.Note), 10);
+                writer.WriteBit(contact.Mobile);
+                writer.FlushBits();
+                writer.WriteString(contact.Note);
+            }
+            return writer.Position;
         }
 
         public List<ContactInfo> Contacts;
@@ -90,7 +137,7 @@ namespace HermesProxy.World.Server.Packets
         public string Note = "";
     }
 
-    public class FriendStatusPkt : ServerPacket
+    public class FriendStatusPkt : ServerPacket, ISpanWritable
     {
         public FriendStatusPkt() : base(Opcode.SMSG_FRIEND_STATUS) { }
 
@@ -108,6 +155,34 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteBit(Mobile);
             _worldPacket.FlushBits();
             _worldPacket.WriteString(Notes);
+        }
+
+        // Cap for friend notes - 10 bits = 1024 max, using 128
+        private const int MaxNotesBytes = 128;
+        // byte(1) + 2 GUIDs(36) + 4 uints(16) + byte(1) + 11 bits(2) + notes
+        public int MaxSize => 1 + PackedGuidHelper.MaxPackedGuid128Size * 2 + 16 + 1 + 2 + MaxNotesBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int notesBytes = Notes != null ? Encoding.UTF8.GetByteCount(Notes) : 0;
+            if (notesBytes > MaxNotesBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt8((byte)FriendResult);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            writer.WritePackedGuid128(WowAccountGuid.Low, WowAccountGuid.High);
+            writer.WriteUInt32(VirtualRealmAddress);
+            writer.WriteUInt8((byte)Status);
+            writer.WriteUInt32(AreaID);
+            writer.WriteUInt32(Level);
+            writer.WriteUInt32((uint)ClassID);
+            writer.WriteBits((uint)notesBytes, 10);
+            writer.WriteBit(Mobile);
+            writer.FlushBits();
+            if (Notes != null)
+                writer.WriteString(Notes);
+            return writer.Position;
         }
 
         public FriendsResult FriendResult;

--- a/HermesProxy/World/Server/Packets/SpellPackets.cs
+++ b/HermesProxy/World/Server/Packets/SpellPackets.cs
@@ -100,9 +100,10 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteUInt32(spellId);
         }
 
-        // MaxSize: bit(1) + 2 counts(8) + max spells (1024) * 4 + max favorites (128) * 4 = 4617
-        private const int MaxKnownSpells = 1024;
-        private const int MaxFavoriteSpells = 128;
+        // MaxSize: bit(1) + 2 counts(8) + spells + favorites
+        // Reduced from 1024/128 to 256/16 based on typical usage (161-165 bytes = ~40 spells)
+        private const int MaxKnownSpells = 256;
+        private const int MaxFavoriteSpells = 16;
         public int MaxSize => 1 + 8 + MaxKnownSpells * 4 + MaxFavoriteSpells * 4;
 
         public int WriteToSpan(Span<byte> buffer)

--- a/HermesProxy/World/Server/Packets/SpellPackets.cs
+++ b/HermesProxy/World/Server/Packets/SpellPackets.cs
@@ -18,14 +18,72 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace HermesProxy.World.Server.Packets
 {
-    public class SendKnownSpells : ServerPacket
+    /// <summary>
+    /// Helper methods for writing combat-related structures to SpanPacketWriter.
+    /// </summary>
+    internal static class SpellPacketHelpers
+    {
+        /// <summary>
+        /// Writes SpellCastLogData to a SpanPacketWriter.
+        /// Returns false if PowerData exceeds maxPowerEntries (triggers fallback).
+        /// </summary>
+        public static bool WriteSpellCastLogData(ref SpanPacketWriter writer, SpellCastLogData logData, int maxPowerEntries)
+        {
+            if (logData.PowerData.Count > maxPowerEntries)
+                return false;
+
+            writer.WriteInt64(logData.Health);
+            writer.WriteInt32(logData.AttackPower);
+            writer.WriteInt32(logData.SpellPower);
+            writer.WriteUInt32(logData.Armor);
+            writer.WriteBits((uint)logData.PowerData.Count, 9);
+            writer.FlushBits();
+
+            foreach (var powerData in logData.PowerData)
+            {
+                writer.WriteInt32(powerData.PowerType);
+                writer.WriteInt32(powerData.Amount);
+                writer.WriteInt32(powerData.Cost);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Writes ContentTuningParams to a SpanPacketWriter.
+        /// </summary>
+        public static void WriteContentTuningParams(ref SpanPacketWriter writer, ContentTuningParams tuning)
+        {
+            writer.WriteFloat(tuning.PlayerItemLevel);
+            writer.WriteFloat(tuning.TargetItemLevel);
+            writer.WriteInt16(tuning.PlayerLevelDelta);
+            writer.WriteUInt16(tuning.ScalingHealthItemLevelCurveID);
+            writer.WriteUInt8(tuning.TargetLevel);
+            writer.WriteUInt8(tuning.Expansion);
+            writer.WriteUInt8(tuning.TargetMinScalingLevel);
+            writer.WriteUInt8(tuning.TargetMaxScalingLevel);
+            writer.WriteInt8(tuning.TargetScalingLevelDelta);
+            writer.WriteUInt32((uint)tuning.Flags);
+            writer.WriteBits((uint)tuning.TuningType, 4);
+            writer.FlushBits();
+        }
+
+        // Size constants for MaxSize calculations
+        public const int SpellCastLogDataFixedSize = 22; // 8 + 4 + 4 + 4 + 2 (bits flushed)
+        public const int SpellLogPowerDataSize = 12;     // 3 ints
+        public const int ContentTuningParamsSize = 22;   // 8 + 2 + 2 + 5 + 4 + 1 (bits flushed)
+    }
+
+    public class SendKnownSpells : ServerPacket, ISpanWritable
     {
         public SendKnownSpells() : base(Opcode.SMSG_SEND_KNOWN_SPELLS, ConnectionType.Instance) { }
 
@@ -42,12 +100,36 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteUInt32(spellId);
         }
 
+        // MaxSize: bit(1) + 2 counts(8) + max spells (1024) * 4 + max favorites (128) * 4 = 4617
+        private const int MaxKnownSpells = 1024;
+        private const int MaxFavoriteSpells = 128;
+        public int MaxSize => 1 + 8 + MaxKnownSpells * 4 + MaxFavoriteSpells * 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (KnownSpells.Count > MaxKnownSpells || FavoriteSpells.Count > MaxFavoriteSpells)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBit(InitialLogin);
+            writer.WriteInt32(KnownSpells.Count);
+            writer.WriteInt32(FavoriteSpells.Count);
+
+            foreach (var spellId in KnownSpells)
+                writer.WriteUInt32(spellId);
+
+            foreach (var spellId in FavoriteSpells)
+                writer.WriteUInt32(spellId);
+
+            return writer.Position;
+        }
+
         public bool InitialLogin;
         public List<uint> KnownSpells = new();
         public List<uint> FavoriteSpells = new(); // tradeskill recipes
     }
 
-    public class SupercededSpells : ServerPacket
+    public class SupercededSpells : ServerPacket, ISpanWritable
     {
         public SupercededSpells() : base(Opcode.SMSG_SUPERCEDED_SPELLS, ConnectionType.Instance) { }
 
@@ -67,13 +149,45 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteInt32(spellId);
         }
 
+        // Cap for spell lists - usually 1 spell superceded at a time
+        private const int MaxSpellsPerList = 8;
+        // 3 counts(12) + 3 lists of spells(96)
+        public int MaxSize => 12 + MaxSpellsPerList * 4 * 3;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (SpellID.Count > MaxSpellsPerList ||
+                Superceded.Count > MaxSpellsPerList ||
+                FavoriteSpellID.Count > MaxSpellsPerList)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(SpellID.Count);
+            writer.WriteInt32(Superceded.Count);
+            writer.WriteInt32(FavoriteSpellID.Count);
+
+            foreach (var spellId in SpellID)
+                writer.WriteUInt32(spellId);
+
+            foreach (var spellId in Superceded)
+                writer.WriteUInt32(spellId);
+
+            foreach (var spellId in FavoriteSpellID)
+                writer.WriteInt32(spellId);
+
+            return writer.Position;
+        }
+
         public List<uint> SpellID = new();
         public List<uint> Superceded = new();
         public List<int> FavoriteSpellID = new();
     }
 
-    public class LearnedSpells : ServerPacket
+    public class LearnedSpells : ServerPacket, ISpanWritable
     {
+        // Practical cap - usually 1 spell per trainer click, hunter pet quest ~5
+        private const int MaxSpells = 8;
+
         public LearnedSpells() : base(Opcode.SMSG_LEARNED_SPELLS, ConnectionType.Instance) { }
 
         public override void Write()
@@ -92,14 +206,40 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        // MaxSize: 3 int32 (12) + 2 lists capped at 8 (64) + 1 bit byte = 77
+        public int MaxSize => 12 + MaxSpells * 4 * 2 + 1;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Spells.Count > MaxSpells || FavoriteSpellID.Count > MaxSpells)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Spells.Count);
+            writer.WriteInt32(FavoriteSpellID.Count);
+            writer.WriteUInt32(SpecializationID);
+
+            foreach (uint spell in Spells)
+                writer.WriteUInt32(spell);
+
+            foreach (int spell in FavoriteSpellID)
+                writer.WriteInt32(spell);
+
+            writer.WriteBit(SuppressMessaging);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public List<uint> Spells = new();
         public List<int> FavoriteSpellID = new();
         public uint SpecializationID;
         public bool SuppressMessaging;
     }
 
-    public class SendUnlearnSpells : ServerPacket
+    public class SendUnlearnSpells : ServerPacket, ISpanWritable
     {
+        private const int MaxSpells = 8;
+
         public SendUnlearnSpells() : base(Opcode.SMSG_SEND_UNLEARN_SPELLS, ConnectionType.Instance) { }
 
         public override void Write()
@@ -108,11 +248,29 @@ namespace HermesProxy.World.Server.Packets
             foreach (var spell in Spells)
                 _worldPacket.WriteUInt32(spell);
         }
+
+        // MaxSize: int32 count (4) + 8 spells (32) = 36
+        public int MaxSize => 4 + MaxSpells * 4;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Spells.Count > MaxSpells)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Spells.Count);
+            foreach (var spell in Spells)
+                writer.WriteUInt32(spell);
+            return writer.Position;
+        }
+
         public List<uint> Spells = new();
     }
 
-    public class UnlearnedSpells : ServerPacket
+    public class UnlearnedSpells : ServerPacket, ISpanWritable
     {
+        private const int MaxSpells = 8;
+
         public UnlearnedSpells() : base(Opcode.SMSG_UNLEARNED_SPELLS, ConnectionType.Instance) { }
 
         public override void Write()
@@ -125,18 +283,67 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        // MaxSize: int32 count (4) + 8 spells (32) + 1 bit byte = 37
+        public int MaxSize => 4 + MaxSpells * 4 + 1;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Spells.Count > MaxSpells)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Spells.Count);
+            foreach (uint spellId in Spells)
+                writer.WriteUInt32(spellId);
+            writer.WriteBit(SuppressMessaging);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public List<uint> Spells = new();
         public bool SuppressMessaging;
     }
 
-    public class SendSpellHistory : ServerPacket
+    public class SendSpellHistory : ServerPacket, ISpanWritable
     {
+        // Practical cap for spell history at login
+        private const int MaxEntries = 64;
+        // Each entry: 6 fixed fields (24) + bits (1) = 25 bytes (unused optionals)
+        private const int MaxEntrySize = 25;
+
         public SendSpellHistory() : base(Opcode.SMSG_SEND_SPELL_HISTORY, ConnectionType.Instance) { }
 
         public override void Write()
         {
             _worldPacket.WriteInt32(Entries.Count);
             Entries.ForEach(p => p.Write(_worldPacket));
+        }
+
+        // MaxSize: count (4) + 64 entries (25 each) = 1604
+        public int MaxSize => 4 + MaxEntries * MaxEntrySize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Entries.Count > MaxEntries)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Entries.Count);
+            foreach (var entry in Entries)
+            {
+                writer.WriteUInt32(entry.SpellID);
+                writer.WriteUInt32(entry.ItemID);
+                writer.WriteUInt32(entry.Category);
+                writer.WriteInt32(entry.RecoveryTime);
+                writer.WriteInt32(entry.CategoryRecoveryTime);
+                writer.WriteFloat(entry.ModRate);
+                writer.WriteBit(false); // unused622_1
+                writer.WriteBit(false); // unused622_2
+                writer.WriteBit(entry.OnHold);
+                writer.FlushBits();
+                // unused622_1 and unused622_2 are never set
+            }
+            return writer.Position;
         }
 
         public List<SpellHistoryEntry> Entries = new();
@@ -174,14 +381,39 @@ namespace HermesProxy.World.Server.Packets
         uint? unused622_2;   // This field is not used for anything in the client in 6.2.2.20444
     }
 
-    public class SendSpellCharges : ServerPacket
+    public class SendSpellCharges : ServerPacket, ISpanWritable
     {
+        // Practical cap for spell charges - limited charge categories
+        private const int MaxEntries = 16;
+        // Each entry: uint + uint + float + byte = 13 bytes
+        private const int EntrySize = 13;
+
         public SendSpellCharges() : base(Opcode.SMSG_SEND_SPELL_CHARGES, ConnectionType.Instance) { }
 
         public override void Write()
         {
             _worldPacket.WriteInt32(Entries.Count);
             Entries.ForEach(p => p.Write(_worldPacket));
+        }
+
+        // MaxSize: count (4) + 16 entries (13 each) = 212
+        public int MaxSize => 4 + MaxEntries * EntrySize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Entries.Count > MaxEntries)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Entries.Count);
+            foreach (var entry in Entries)
+            {
+                writer.WriteUInt32(entry.Category);
+                writer.WriteUInt32(entry.NextRecoveryTime);
+                writer.WriteFloat(entry.ChargeModRate);
+                writer.WriteUInt8(entry.ConsumedCharges);
+            }
+            return writer.Position;
         }
 
         public List<SpellChargeEntry> Entries = new();
@@ -224,13 +456,22 @@ namespace HermesProxy.World.Server.Packets
         public override void Read() { }
     }
 
-    public class CancelAutoRepeat : ServerPacket
+    public class CancelAutoRepeat : ServerPacket, ISpanWritable
     {
         public CancelAutoRepeat() : base(Opcode.SMSG_CANCEL_AUTO_REPEAT) { }
 
         public override void Write()
         {
             _worldPacket.WritePackedGuid128(Guid);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            return writer.Position;
         }
 
         public WowGuid128 Guid;
@@ -570,7 +811,7 @@ namespace HermesProxy.World.Server.Packets
                                  // does not match SpellCastResult enum
     }
 
-    class SpellPrepare : ServerPacket
+    class SpellPrepare : ServerPacket, ISpanWritable
     {
         public SpellPrepare() : base(Opcode.SMSG_SPELL_PREPARE) { }
 
@@ -580,11 +821,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(ServerCastID);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2; // 2 packed GUIDs
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(ClientCastID.Low, ClientCastID.High);
+            writer.WritePackedGuid128(ServerCastID.Low, ServerCastID.High);
+            return writer.Position;
+        }
+
         public WowGuid128 ClientCastID;
         public WowGuid128 ServerCastID;
     }
 
-    class CastFailed : ServerPacket
+    class CastFailed : ServerPacket, ISpanWritable
     {
         public CastFailed() : base(Opcode.SMSG_CAST_FAILED, ConnectionType.Instance) { }
 
@@ -598,6 +849,20 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(FailedArg2);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4 * 4 + 4 * 2; // GUID + 4 uint32 + 2 int32
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(CastID.Low, CastID.High);
+            writer.WriteUInt32(SpellID);
+            writer.WriteUInt32(SpellXSpellVisualID);
+            writer.WriteUInt32(Reason);
+            writer.WriteInt32(FailedArg1);
+            writer.WriteInt32(FailedArg2);
+            return writer.Position;
+        }
+
         public WowGuid128 CastID;
         public uint SpellID;
         public uint Reason;
@@ -606,7 +871,7 @@ namespace HermesProxy.World.Server.Packets
         public uint SpellXSpellVisualID;
     }
 
-    class PetCastFailed : ServerPacket
+    class PetCastFailed : ServerPacket, ISpanWritable
     {
         public PetCastFailed() : base(Opcode.SMSG_PET_CAST_FAILED, ConnectionType.Instance) { }
 
@@ -619,6 +884,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(FailedArg2);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4 * 3 + 4 * 2; // GUID + 3 uint32 + 2 int32
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(CastID.Low, CastID.High);
+            writer.WriteUInt32(SpellID);
+            writer.WriteUInt32(Reason);
+            writer.WriteInt32(FailedArg1);
+            writer.WriteInt32(FailedArg2);
+            return writer.Position;
+        }
+
         public WowGuid128 CastID;
         public uint SpellID;
         public uint Reason;
@@ -626,7 +904,7 @@ namespace HermesProxy.World.Server.Packets
         public int FailedArg2 = -1;
     }
 
-    public class SpellFailure : ServerPacket
+    public class SpellFailure : ServerPacket, ISpanWritable
     {
         public SpellFailure() : base(Opcode.SMSG_SPELL_FAILURE, ConnectionType.Instance) { }
 
@@ -639,6 +917,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt16(Reason);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 4 * 2 + 2; // 2 GUIDs + 2 uint32 + ushort
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(CasterUnit.Low, CasterUnit.High);
+            writer.WritePackedGuid128(CastID.Low, CastID.High);
+            writer.WriteUInt32(SpellID);
+            writer.WriteUInt32(SpellXSpellVisualID);
+            writer.WriteUInt16(Reason);
+            return writer.Position;
+        }
+
         public WowGuid128 CasterUnit;
         public WowGuid128 CastID;
         public uint SpellID;
@@ -646,7 +937,7 @@ namespace HermesProxy.World.Server.Packets
         public ushort Reason;
     }
 
-    public class SpellFailedOther : ServerPacket
+    public class SpellFailedOther : ServerPacket, ISpanWritable
     {
         public SpellFailedOther() : base(Opcode.SMSG_SPELL_FAILED_OTHER, ConnectionType.Instance) { }
 
@@ -657,6 +948,19 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(SpellID);
             _worldPacket.WriteUInt32(SpellXSpellVisualID);
             _worldPacket.WriteUInt8(Reason);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 4 * 2 + 1; // 2 GUIDs + 2 uint32 + byte
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(CasterUnit.Low, CasterUnit.High);
+            writer.WritePackedGuid128(CastID.Low, CastID.High);
+            writer.WriteUInt32(SpellID);
+            writer.WriteUInt32(SpellXSpellVisualID);
+            writer.WriteUInt8(Reason);
+            return writer.Position;
         }
 
         public WowGuid128 CasterUnit;
@@ -972,8 +1276,11 @@ namespace HermesProxy.World.Server.Packets
         public ushort Rank;
     }
 
-    public class SpellCooldownPkt : ServerPacket
+    public class SpellCooldownPkt : ServerPacket, ISpanWritable
     {
+        // Practical cap for cooldowns at login
+        private const int MaxCooldowns = 64;
+
         public SpellCooldownPkt() : base(Opcode.SMSG_SPELL_COOLDOWN, ConnectionType.Instance) { }
 
         public override void Write()
@@ -983,6 +1290,27 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(SpellCooldowns.Count);
             foreach (var cd in SpellCooldowns)
                 cd.Write(_worldPacket);
+        }
+
+        // MaxSize: GUID (18) + byte (1) + count (4) + 64 cooldowns (12 each) = 791
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 1 + 4 + MaxCooldowns * 12;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (SpellCooldowns.Count > MaxCooldowns)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Caster.Low, Caster.High);
+            writer.WriteUInt8(Flags);
+            writer.WriteInt32(SpellCooldowns.Count);
+            foreach (var cd in SpellCooldowns)
+            {
+                writer.WriteUInt32(cd.SpellID);
+                writer.WriteUInt32(cd.ForcedCooldown);
+                writer.WriteFloat(cd.ModRate);
+            }
+            return writer.Position;
         }
 
         public List<SpellCooldownStruct> SpellCooldowns = new();
@@ -1004,7 +1332,7 @@ namespace HermesProxy.World.Server.Packets
         public float ModRate = 1.0f;
     }
 
-    public class CooldownEvent : ServerPacket
+    public class CooldownEvent : ServerPacket, ISpanWritable
     {
         public CooldownEvent() : base(Opcode.SMSG_COOLDOWN_EVENT, ConnectionType.Instance) { }
 
@@ -1015,11 +1343,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 5; // uint + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(SpellID);
+            writer.WriteBit(IsPet);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public bool IsPet;
         public uint SpellID;
     }
 
-    public class ClearCooldown : ServerPacket
+    public class ClearCooldown : ServerPacket, ISpanWritable
     {
         public ClearCooldown() : base(Opcode.SMSG_CLEAR_COOLDOWN, ConnectionType.Instance) { }
 
@@ -1031,12 +1370,24 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => 5; // uint + 1 byte for 2 bits
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(SpellID);
+            writer.WriteBit(ClearOnHold);
+            writer.WriteBit(IsPet);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public bool IsPet;
         public uint SpellID;
         public bool ClearOnHold;
     }
 
-    public class CooldownCheat : ServerPacket
+    public class CooldownCheat : ServerPacket, ISpanWritable
     {
         public CooldownCheat() : base(Opcode.SMSG_COOLDOWN_CHEAT, ConnectionType.Instance) { }
 
@@ -1045,11 +1396,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WritePackedGuid128(Guid);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            return writer.Position;
+        }
+
         public WowGuid128 Guid;
     }
 
-    class SpellNonMeleeDamageLog : ServerPacket
+    class SpellNonMeleeDamageLog : ServerPacket, ISpanWritable
     {
+        private const int MaxPowerDataEntries = 10;
+
         public SpellNonMeleeDamageLog() : base(Opcode.SMSG_SPELL_NON_MELEE_DAMAGE_LOG, ConnectionType.Instance) { }
 
         public override void Write()
@@ -1082,6 +1444,46 @@ namespace HermesProxy.World.Server.Packets
                 ContentTuning.Write(_worldPacket);
         }
 
+        // MaxSize: 3 GUIDs (54) + fixed values (33) + bits (2) + SpellCastLogData (142) + ContentTuning (22) = 253
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 3 + 33 + 2 +
+            SpellPacketHelpers.SpellCastLogDataFixedSize + MaxPowerDataEntries * SpellPacketHelpers.SpellLogPowerDataSize +
+            SpellPacketHelpers.ContentTuningParamsSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(TargetGUID.Low, TargetGUID.High);
+            writer.WritePackedGuid128(CasterGUID.Low, CasterGUID.High);
+            writer.WritePackedGuid128(CastID.Low, CastID.High);
+            writer.WriteUInt32(SpellID);
+            writer.WriteUInt32(SpellXSpellVisualID);
+            writer.WriteInt32(Damage);
+            writer.WriteInt32(OriginalDamage);
+            writer.WriteInt32(Overkill);
+            writer.WriteUInt8(SchoolMask);
+            writer.WriteInt32(Absorbed);
+            writer.WriteInt32(Resisted);
+            writer.WriteInt32(ShieldBlock);
+
+            writer.WriteBit(Periodic);
+            writer.WriteBits((uint)Flags, 7);
+            writer.WriteBit(false); // Debug info
+            writer.WriteBit(LogData != null);
+            writer.WriteBit(ContentTuning != null);
+            writer.FlushBits();
+
+            if (LogData != null)
+            {
+                if (!SpellPacketHelpers.WriteSpellCastLogData(ref writer, LogData, MaxPowerDataEntries))
+                    return -1;
+            }
+
+            if (ContentTuning != null)
+                SpellPacketHelpers.WriteContentTuningParams(ref writer, ContentTuning);
+
+            return writer.Position;
+        }
+
         public WowGuid128 TargetGUID;
         public WowGuid128 CasterGUID;
         public WowGuid128 CastID;
@@ -1100,8 +1502,10 @@ namespace HermesProxy.World.Server.Packets
         public ContentTuningParams ContentTuning;
     }
 
-    class SpellHealLog : ServerPacket
+    class SpellHealLog : ServerPacket, ISpanWritable
     {
+        private const int MaxPowerDataEntries = 10;
+
         public SpellHealLog() : base(Opcode.SMSG_SPELL_HEAL_LOG, ConnectionType.Instance) { }
 
         public override void Write()
@@ -1136,6 +1540,47 @@ namespace HermesProxy.World.Server.Packets
                 ContentTuning.Write(_worldPacket);
         }
 
+        // MaxSize: 2 GUIDs (36) + 5 values (20) + bits (1) + SpellCastLogData (142) + 2 floats (8) + ContentTuning (22) = 229
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 20 + 1 +
+            SpellPacketHelpers.SpellCastLogDataFixedSize + MaxPowerDataEntries * SpellPacketHelpers.SpellLogPowerDataSize +
+            8 + SpellPacketHelpers.ContentTuningParamsSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(TargetGUID.Low, TargetGUID.High);
+            writer.WritePackedGuid128(CasterGUID.Low, CasterGUID.High);
+            writer.WriteUInt32(SpellID);
+            writer.WriteInt32(HealAmount);
+            writer.WriteInt32(OriginalHealAmount);
+            writer.WriteUInt32(OverHeal);
+            writer.WriteUInt32(Absorbed);
+
+            writer.WriteBit(Crit);
+            writer.WriteBit(CritRollMade.HasValue);
+            writer.WriteBit(CritRollNeeded.HasValue);
+            writer.WriteBit(LogData != null);
+            writer.WriteBit(ContentTuning != null);
+            writer.FlushBits();
+
+            if (LogData != null)
+            {
+                if (!SpellPacketHelpers.WriteSpellCastLogData(ref writer, LogData, MaxPowerDataEntries))
+                    return -1;
+            }
+
+            if (CritRollMade.HasValue)
+                writer.WriteFloat(CritRollMade.Value);
+
+            if (CritRollNeeded.HasValue)
+                writer.WriteFloat(CritRollNeeded.Value);
+
+            if (ContentTuning != null)
+                SpellPacketHelpers.WriteContentTuningParams(ref writer, ContentTuning);
+
+            return writer.Position;
+        }
+
         public WowGuid128 CasterGUID;
         public WowGuid128 TargetGUID;
         public uint SpellID;
@@ -1150,7 +1595,7 @@ namespace HermesProxy.World.Server.Packets
         public ContentTuningParams ContentTuning;
     }
 
-    public class SpellDelayed : ServerPacket
+    public class SpellDelayed : ServerPacket, ISpanWritable
     {
         public SpellDelayed() : base(Opcode.SMSG_SPELL_DELAYED, ConnectionType.Instance) { }
 
@@ -1160,11 +1605,21 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(Delay);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4; // GUID + int
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(CasterGUID.Low, CasterGUID.High);
+            writer.WriteInt32(Delay);
+            return writer.Position;
+        }
+
         public WowGuid128 CasterGUID;
         public int Delay;
     }
 
-    public class SpellChannelStart : ServerPacket
+    public class SpellChannelStart : ServerPacket, ISpanWritable
     {
         public SpellChannelStart() : base(Opcode.SMSG_SPELL_CHANNEL_START, ConnectionType.Instance) { }
 
@@ -1183,6 +1638,38 @@ namespace HermesProxy.World.Server.Packets
 
             if (HealPrediction != null)
                 HealPrediction.Write(_worldPacket);
+        }
+
+        // MaxSize: GUID (18) + 3 uints (12) + bits (1) + InterruptImmunities (8) + HealPrediction (41) = 80
+        // HealPrediction: TargetGUID (18) + Points (4) + Type (1) + BeaconGUID (18) = 41
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 12 + 1 + 8 + 41;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(CasterGUID.Low, CasterGUID.High);
+            writer.WriteUInt32(SpellID);
+            writer.WriteUInt32(SpellXSpellVisualID);
+            writer.WriteUInt32(Duration);
+            writer.WriteBit(InterruptImmunities != null);
+            writer.WriteBit(HealPrediction != null);
+            writer.FlushBits();
+
+            if (InterruptImmunities != null)
+            {
+                writer.WriteInt32(InterruptImmunities.SchoolImmunities);
+                writer.WriteInt32(InterruptImmunities.Immunities);
+            }
+
+            if (HealPrediction != null)
+            {
+                writer.WritePackedGuid128(HealPrediction.TargetGUID.Low, HealPrediction.TargetGUID.High);
+                writer.WriteUInt32(HealPrediction.Predict.Points);
+                writer.WriteUInt8(HealPrediction.Predict.Type);
+                writer.WritePackedGuid128(HealPrediction.Predict.BeaconGUID.Low, HealPrediction.Predict.BeaconGUID.High);
+            }
+
+            return writer.Position;
         }
 
         public WowGuid128 CasterGUID;
@@ -1217,7 +1704,7 @@ namespace HermesProxy.World.Server.Packets
         public SpellHealPrediction Predict;
     }
 
-    public class SpellChannelUpdate : ServerPacket
+    public class SpellChannelUpdate : ServerPacket, ISpanWritable
     {
         public SpellChannelUpdate() : base(Opcode.SMSG_SPELL_CHANNEL_UPDATE, ConnectionType.Instance) { }
 
@@ -1225,6 +1712,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WritePackedGuid128(CasterGUID);
             _worldPacket.WriteInt32(TimeRemaining);
+        }
+
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4; // GUID + int
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(CasterGUID.Low, CasterGUID.High);
+            writer.WriteInt32(TimeRemaining);
+            return writer.Position;
         }
 
         public WowGuid128 CasterGUID;
@@ -1303,8 +1800,11 @@ namespace HermesProxy.World.Server.Packets
         }
     }
 
-    class SpellEnergizeLog : ServerPacket
+    class SpellEnergizeLog : ServerPacket, ISpanWritable
     {
+        // Cap for power types in SpellCastLogData
+        private const int MaxPowerDataEntries = 10;
+
         public SpellEnergizeLog() : base(Opcode.SMSG_SPELL_ENERGIZE_LOG, ConnectionType.Instance) { }
 
         public override void Write()
@@ -1324,6 +1824,30 @@ namespace HermesProxy.World.Server.Packets
                 LogData.Write(_worldPacket);
         }
 
+        // MaxSize: 2 GUIDs (36) + 4 ints (16) + bit (1) + SpellCastLogData (22 + 10*12) = 195
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 16 + 1 + 22 + MaxPowerDataEntries * 12;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(TargetGUID.Low, TargetGUID.High);
+            writer.WritePackedGuid128(CasterGUID.Low, CasterGUID.High);
+            writer.WriteUInt32(SpellID);
+            writer.WriteUInt32((uint)Type);
+            writer.WriteInt32(Amount);
+            writer.WriteInt32(OverEnergize);
+            writer.WriteBit(LogData != null);
+            writer.FlushBits();
+
+            if (LogData != null)
+            {
+                if (!SpellPacketHelpers.WriteSpellCastLogData(ref writer, LogData, MaxPowerDataEntries))
+                    return -1;
+            }
+
+            return writer.Position;
+        }
+
         public WowGuid128 TargetGUID;
         public WowGuid128 CasterGUID;
         public uint SpellID;
@@ -1333,8 +1857,10 @@ namespace HermesProxy.World.Server.Packets
         public SpellCastLogData LogData;
     }
 
-    class SpellDamageShield : ServerPacket
+    class SpellDamageShield : ServerPacket, ISpanWritable
     {
+        private const int MaxPowerDataEntries = 10;
+
         public SpellDamageShield() : base(Opcode.SMSG_SPELL_DAMAGE_SHIELD, ConnectionType.Instance) { }
 
         public override void Write()
@@ -1355,6 +1881,33 @@ namespace HermesProxy.World.Server.Packets
                 LogData.Write(_worldPacket);
         }
 
+        // MaxSize: 2 GUIDs (36) + 6 ints (24) + bit (1) + SpellCastLogData (22 + 10*12) = 203
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 24 + 1 +
+            SpellPacketHelpers.SpellCastLogDataFixedSize + MaxPowerDataEntries * SpellPacketHelpers.SpellLogPowerDataSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(VictimGUID.Low, VictimGUID.High);
+            writer.WritePackedGuid128(CasterGUID.Low, CasterGUID.High);
+            writer.WriteUInt32(SpellID);
+            writer.WriteInt32(Damage);
+            writer.WriteInt32(OriginalDamage);
+            writer.WriteUInt32(OverKill);
+            writer.WriteUInt32(SchoolMask);
+            writer.WriteUInt32(LogAbsorbed);
+            writer.WriteBit(LogData != null);
+            writer.FlushBits();
+
+            if (LogData != null)
+            {
+                if (!SpellPacketHelpers.WriteSpellCastLogData(ref writer, LogData, MaxPowerDataEntries))
+                    return -1;
+            }
+
+            return writer.Position;
+        }
+
         public WowGuid128 VictimGUID;
         public WowGuid128 CasterGUID;
         public uint SpellID;
@@ -1366,8 +1919,10 @@ namespace HermesProxy.World.Server.Packets
         public SpellCastLogData LogData;
     }
 
-    class EnvironmentalDamageLog : ServerPacket
+    class EnvironmentalDamageLog : ServerPacket, ISpanWritable
     {
+        private const int MaxPowerDataEntries = 10;
+
         public EnvironmentalDamageLog() : base(Opcode.SMSG_ENVIRONMENTAL_DAMAGE_LOG) { }
 
         public override void Write()
@@ -1385,6 +1940,30 @@ namespace HermesProxy.World.Server.Packets
                 LogData.Write(_worldPacket);
         }
 
+        // MaxSize: 1 GUID (18) + byte + 3 ints (13) + bit (1) + SpellCastLogData (22 + 10*12) = 174
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 13 + 1 +
+            SpellPacketHelpers.SpellCastLogDataFixedSize + MaxPowerDataEntries * SpellPacketHelpers.SpellLogPowerDataSize;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Victim.Low, Victim.High);
+            writer.WriteUInt8((byte)Type);
+            writer.WriteInt32(Amount);
+            writer.WriteInt32(Resisted);
+            writer.WriteInt32(Absorbed);
+            writer.WriteBit(LogData != null);
+            writer.FlushBits();
+
+            if (LogData != null)
+            {
+                if (!SpellPacketHelpers.WriteSpellCastLogData(ref writer, LogData, MaxPowerDataEntries))
+                    return -1;
+            }
+
+            return writer.Position;
+        }
+
         public WowGuid128 Victim;
         public EnvironmentalDamage Type;
         public int Amount;
@@ -1393,7 +1972,7 @@ namespace HermesProxy.World.Server.Packets
         public SpellCastLogData LogData;
     }
 
-    public class SpellInstakillLog : ServerPacket
+    public class SpellInstakillLog : ServerPacket, ISpanWritable
     {
         public SpellInstakillLog() : base(Opcode.SMSG_SPELL_INSTAKILL_LOG, ConnectionType.Instance) { }
 
@@ -1404,12 +1983,23 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteUInt32(SpellID);
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 4; // 2 GUIDs + uint
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(TargetGUID.Low, TargetGUID.High);
+            writer.WritePackedGuid128(CasterGUID.Low, CasterGUID.High);
+            writer.WriteUInt32(SpellID);
+            return writer.Position;
+        }
+
         public WowGuid128 TargetGUID;
         public WowGuid128 CasterGUID;
         public uint SpellID;
     }
 
-    class SpellDispellLog : ServerPacket
+    class SpellDispellLog : ServerPacket, ISpanWritable
     {
         public SpellDispellLog() : base(Opcode.SMSG_SPELL_DISPELL_LOG, ConnectionType.Instance) { }
 
@@ -1437,6 +2027,41 @@ namespace HermesProxy.World.Server.Packets
             }
         }
 
+        // Cap for dispells - typically 1-3 auras dispelled at once
+        private const int MaxDispells = 8;
+        // 1 byte (2 bits) + 2 GUIDs(36) + uint(4) + count(4) + entries(13 max each)
+        // Each entry: SpellID(4) + 1 byte (3 bits flushed) + Rolled(4) + Needed(4) = 13
+        public int MaxSize => 1 + PackedGuidHelper.MaxPackedGuid128Size * 2 + 4 + 4 + MaxDispells * 13;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (DispellData.Count > MaxDispells)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBit(IsSteal);
+            writer.WriteBit(IsBreak);
+            writer.WritePackedGuid128(TargetGUID.Low, TargetGUID.High);
+            writer.WritePackedGuid128(CasterGUID.Low, CasterGUID.High);
+            writer.WriteUInt32(DispelledBySpellID);
+
+            writer.WriteInt32(DispellData.Count);
+            foreach (var data in DispellData)
+            {
+                writer.WriteUInt32(data.SpellID);
+                writer.WriteBit(data.Harmful);
+                writer.WriteBit(data.Rolled.HasValue);
+                writer.WriteBit(data.Needed.HasValue);
+                if (data.Rolled.HasValue)
+                    writer.WriteInt32(data.Rolled.Value);
+                if (data.Needed.HasValue)
+                    writer.WriteInt32(data.Needed.Value);
+
+                writer.FlushBits();
+            }
+            return writer.Position;
+        }
+
         public bool IsSteal;
         public bool IsBreak;
         public WowGuid128 TargetGUID;
@@ -1453,7 +2078,7 @@ namespace HermesProxy.World.Server.Packets
         public int? Needed;
     }
 
-    class PlaySpellVisualKit : ServerPacket
+    class PlaySpellVisualKit : ServerPacket, ISpanWritable
     {
         public PlaySpellVisualKit() : base(Opcode.SMSG_PLAY_SPELL_VISUAL_KIT) { }
 
@@ -1467,6 +2092,20 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 13; // GUID + 3 uint + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Unit.Low, Unit.High);
+            writer.WriteUInt32(KitRecID);
+            writer.WriteUInt32(KitType);
+            writer.WriteUInt32(Duration);
+            writer.WriteBit(MountedVisual);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public WowGuid128 Unit;
         public uint KitRecID;
         public uint KitType;
@@ -1474,7 +2113,7 @@ namespace HermesProxy.World.Server.Packets
         public bool MountedVisual = false;
     }
 
-    class ResurrectRequest : ServerPacket
+    class ResurrectRequest : ServerPacket, ISpanWritable
     {
         public ResurrectRequest() : base(Opcode.SMSG_RESURRECT_REQUEST) { }
 
@@ -1490,6 +2129,25 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
 
             _worldPacket.WriteString(Name);
+        }
+
+        // MaxSize: GUID (18) + 3 uints (12) + bits (11+1+1=13 -> 2) + name (24) = 56
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 12 + 2 + GameLimits.MaxPlayerNameBytes;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(CasterGUID.Low, CasterGUID.High);
+            writer.WriteUInt32(CasterVirtualRealmAddress);
+            writer.WriteUInt32(PetNumber);
+            writer.WriteUInt32(SpellID);
+            writer.WriteBits((uint)Encoding.UTF8.GetByteCount(Name), 11);
+            writer.WriteBit(UseTimer);
+            writer.WriteBit(Sickness);
+            writer.FlushBits();
+
+            writer.WriteString(Name);
+            return writer.Position;
         }
 
         public WowGuid128 CasterGUID;
@@ -1527,7 +2185,7 @@ namespace HermesProxy.World.Server.Packets
         public uint SpellId;
     }
 
-    class TotemCreated : ServerPacket
+    class TotemCreated : ServerPacket, ISpanWritable
     {
         public TotemCreated() : base(Opcode.SMSG_TOTEM_CREATED) { }
 
@@ -1541,6 +2199,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteBit(CannotDismiss);
             _worldPacket.FlushBits();
         }
+
+        public int MaxSize => 1 + PackedGuidHelper.MaxPackedGuid128Size + 12 + 1; // byte + GUID + 2 uint + float + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt8(Slot);
+            writer.WritePackedGuid128(Totem.Low, Totem.High);
+            writer.WriteUInt32(Duration);
+            writer.WriteUInt32(SpellId);
+            writer.WriteFloat(TimeMod);
+            writer.WriteBit(CannotDismiss);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public byte Slot;
         public WowGuid128 Totem;
         public uint Duration;
@@ -1562,7 +2236,7 @@ namespace HermesProxy.World.Server.Packets
         public WowGuid128 Guid;
     }
 
-    public class SetSpellModifier : ServerPacket
+    public class SetSpellModifier : ServerPacket, ISpanWritable
     {
         public SetSpellModifier(Opcode opcode) : base(opcode, ConnectionType.Instance) { }
 
@@ -1571,6 +2245,34 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(Modifiers.Count);
             foreach (SpellModifierInfo spellMod in Modifiers)
                 spellMod.Write(_worldPacket);
+        }
+
+        private const int MaxModifiers = 8;
+        private const int MaxDataPerModifier = 8;
+        // 4 (count) + 8 * (1 + 4 + 8 * 5) = 4 + 8 * 45 = 364 bytes
+        public int MaxSize => 4 + MaxModifiers * (1 + 4 + MaxDataPerModifier * 5);
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Modifiers.Count > MaxModifiers)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteInt32(Modifiers.Count);
+            foreach (SpellModifierInfo spellMod in Modifiers)
+            {
+                if (spellMod.ModifierData.Count > MaxDataPerModifier)
+                    return -1;
+
+                writer.WriteUInt8(spellMod.ModIndex);
+                writer.WriteInt32(spellMod.ModifierData.Count);
+                foreach (SpellModifierData modData in spellMod.ModifierData)
+                {
+                    writer.WriteInt32(modData.ModifierValue);
+                    writer.WriteUInt8(modData.ClassIndex);
+                }
+            }
+            return writer.Position;
         }
 
         public List<SpellModifierInfo> Modifiers = new();

--- a/HermesProxy/World/Server/Packets/SystemPackets.cs
+++ b/HermesProxy/World/Server/Packets/SystemPackets.cs
@@ -404,8 +404,8 @@ namespace HermesProxy.World.Server.Packets
             }
         }
 
-        // Cap for MOTD lines (4 bits = max 16 lines)
-        private const int MaxLines = 16;
+        // Cap for MOTD lines - reduced from 16 to 4 based on typical usage (1 byte = empty)
+        private const int MaxLines = 4;
         // Cap per line (7 bits = max 128 chars)
         private const int MaxLineBytes = 128;
         // 4 bits(1) + per line: 7 bits(1) + text

--- a/HermesProxy/World/Server/Packets/SystemPackets.cs
+++ b/HermesProxy/World/Server/Packets/SystemPackets.cs
@@ -15,9 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+using Framework.IO;
 using HermesProxy.World.Enums;
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace HermesProxy.World.Server.Packets
 {
@@ -385,7 +387,7 @@ namespace HermesProxy.World.Server.Packets
         public uint KioskSessionMinutes;
     }
 
-    public class MOTD : ServerPacket
+    public class MOTD : ServerPacket, ISpanWritable
     {
         public MOTD() : base(Opcode.SMSG_MOTD) { }
 
@@ -402,10 +404,43 @@ namespace HermesProxy.World.Server.Packets
             }
         }
 
+        // Cap for MOTD lines (4 bits = max 16 lines)
+        private const int MaxLines = 16;
+        // Cap per line (7 bits = max 128 chars)
+        private const int MaxLineBytes = 128;
+        // 4 bits(1) + per line: 7 bits(1) + text
+        public int MaxSize => 1 + MaxLines * (1 + MaxLineBytes);
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Text.Count > MaxLines)
+                return -1;
+
+            // Pre-validate all line lengths
+            foreach (var line in Text)
+            {
+                if (Encoding.UTF8.GetByteCount(line) > MaxLineBytes)
+                    return -1;
+            }
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)Text.Count, 4);
+            writer.FlushBits();
+
+            foreach (var line in Text)
+            {
+                int lineBytes = Encoding.UTF8.GetByteCount(line);
+                writer.WriteBits((uint)lineBytes, 7);
+                writer.FlushBits();
+                writer.WriteString(line);
+            }
+            return writer.Position;
+        }
+
         public List<string> Text = new List<string>();
     }
 
-    public class SetTimeZoneInformation : ServerPacket
+    public class SetTimeZoneInformation : ServerPacket, ISpanWritable
     {
         public SetTimeZoneInformation() : base(Opcode.SMSG_SET_TIME_ZONE_INFORMATION) { }
 
@@ -415,6 +450,26 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteBits(GameTimeTZ.GetByteCount(), 7);
             _worldPacket.WriteString(ServerTimeTZ);
             _worldPacket.WriteString(GameTimeTZ);
+        }
+
+        // Cap for timezone strings - 7 bits = max 128 chars each
+        private const int MaxTZBytes = 64;
+        // 14 bits (2 bytes) + 2 strings
+        public int MaxSize => 2 + MaxTZBytes * 2;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            int serverBytes = Encoding.UTF8.GetByteCount(ServerTimeTZ);
+            int gameBytes = Encoding.UTF8.GetByteCount(GameTimeTZ);
+            if (serverBytes > MaxTZBytes || gameBytes > MaxTZBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)serverBytes, 7);
+            writer.WriteBits((uint)gameBytes, 7);
+            writer.WriteString(ServerTimeTZ);
+            writer.WriteString(GameTimeTZ);
+            return writer.Position;
         }
 
         public string ServerTimeTZ;

--- a/HermesProxy/World/Server/Packets/TaxiPackets.cs
+++ b/HermesProxy/World/Server/Packets/TaxiPackets.cs
@@ -16,15 +16,17 @@
  */
 
 
+using System;
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System.Collections.Generic;
 
 namespace HermesProxy.World.Server.Packets
 {
-    class TaxiNodeStatusPkt : ServerPacket
+    class TaxiNodeStatusPkt : ServerPacket, ISpanWritable
     {
         public TaxiNodeStatusPkt() : base(Opcode.SMSG_TAXI_NODE_STATUS) { }
 
@@ -35,11 +37,22 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.FlushBits();
         }
 
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 1; // GUID + 1 byte for 2 bits
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(FlightMaster.Low, FlightMaster.High);
+            writer.WriteBits((uint)Status, 2);
+            writer.FlushBits();
+            return writer.Position;
+        }
+
         public WowGuid128 FlightMaster;
         public TaxiNodeStatus Status;
     }
 
-    public class ShowTaxiNodes : ServerPacket
+    public class ShowTaxiNodes : ServerPacket, ISpanWritable
     {
         public ShowTaxiNodes() : base(Opcode.SMSG_SHOW_TAXI_NODES) { }
 
@@ -60,12 +73,60 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WritePackedGuid128(WindowInfo.UnitGUID);
                 _worldPacket.WriteUInt32(WindowInfo.CurrentNode);
             }
-            
+
             foreach (var node in canLandNodes)
                 _worldPacket.WriteUInt8(node);
-            
+
             foreach (var node in canUseNodes)
                 _worldPacket.WriteUInt8(node);
+        }
+
+        // Cap for taxi node bitmasks - enough for all taxi nodes
+        private const int MaxNodeBytes = 128;
+        // 1 bit(1) + 2 ints(8) + optional WindowInfo (GUID(18)+uint(4)) + 2 node lists
+        public int MaxSize => 1 + 8 + PackedGuidHelper.MaxPackedGuid128Size + 4 + MaxNodeBytes * 2;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            // Calculate cleaned lengths (don't modify originals)
+            int landLength = GetCleanedLength(CanLandNodes);
+            int useLength = GetCleanedLength(CanUseNodes);
+
+            if (landLength > MaxNodeBytes || useLength > MaxNodeBytes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBit(WindowInfo != null);
+            writer.FlushBits();
+
+            writer.WriteInt32(landLength);
+            writer.WriteInt32(useLength);
+
+            if (WindowInfo != null)
+            {
+                writer.WritePackedGuid128(WindowInfo.UnitGUID.Low, WindowInfo.UnitGUID.High);
+                writer.WriteUInt32(WindowInfo.CurrentNode);
+            }
+
+            for (int i = 0; i < landLength; i++)
+                writer.WriteUInt8(CanLandNodes[i]);
+
+            for (int i = 0; i < useLength; i++)
+                writer.WriteUInt8(CanUseNodes[i]);
+
+            return writer.Position;
+        }
+
+        // Get cleaned length without modifying the list
+        private static int GetCleanedLength(List<byte> nodes)
+        {
+            int lastNonZero = -1;
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                if (nodes[i] != 0)
+                    lastNonZero = i;
+            }
+            return lastNonZero + 1;
         }
 
         // remove extra zeroes after last node
@@ -119,14 +180,18 @@ namespace HermesProxy.World.Server.Packets
         public uint FlyingMountID;
     }
 
-    class NewTaxiPath : ServerPacket
+    class NewTaxiPath : ServerPacket, ISpanWritable
     {
         public NewTaxiPath() : base(Opcode.SMSG_NEW_TAXI_PATH) { }
 
         public override void Write() { }
+
+        public int MaxSize => 0;
+
+        public int WriteToSpan(Span<byte> buffer) => 0;
     }
 
-    class ActivateTaxiReplyPkt : ServerPacket
+    class ActivateTaxiReplyPkt : ServerPacket, ISpanWritable
     {
         public ActivateTaxiReplyPkt() : base(Opcode.SMSG_ACTIVATE_TAXI_REPLY) { }
 
@@ -134,6 +199,16 @@ namespace HermesProxy.World.Server.Packets
         {
             _worldPacket.WriteBits(Reply, 4);
             _worldPacket.FlushBits();
+        }
+
+        public int MaxSize => 1; // 1 byte for 4 bits
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBits((uint)Reply, 4);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public ActivateTaxiReply Reply;

--- a/HermesProxy/World/Server/Packets/TradePackets.cs
+++ b/HermesProxy/World/Server/Packets/TradePackets.cs
@@ -18,6 +18,7 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System;
@@ -61,7 +62,7 @@ namespace HermesProxy.World.Server.Packets
         public byte TradeSlot;
     }
 
-    public class TradeStatusPkt : ServerPacket
+    public class TradeStatusPkt : ServerPacket, ISpanWritable
     {
         public TradeStatusPkt() : base(Opcode.SMSG_TRADE_STATUS, ConnectionType.Instance) { }
 
@@ -96,6 +97,49 @@ namespace HermesProxy.World.Server.Packets
                     _worldPacket.FlushBits();
                     break;
             }
+        }
+
+        // Max size: bits(1) + largest case is Proposed with 2 GUIDs(36) = 37 bytes
+        // Failed: bits(1) + int(4) + uint(4) = 9
+        // Initiated: bits(1) + uint(4) = 5
+        // Proposed: bits(1) + 2 GUIDs(36) = 37
+        // WrongRealm/NotOnTaplist: bits(1) + byte(1) = 2
+        // Currency: bits(1) + 2 ints(8) = 9
+        public int MaxSize => 1 + PackedGuidHelper.MaxPackedGuid128Size * 2;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteBit(PartnerIsSameBnetAccount);
+            writer.WriteBits((uint)Status, 5);
+            switch (Status)
+            {
+                case TradeStatus.Failed:
+                    writer.WriteBit(FailureForYou);
+                    writer.WriteInt32((int)BagResult);
+                    writer.WriteUInt32(ItemID);
+                    break;
+                case TradeStatus.Initiated:
+                    writer.WriteUInt32(Id);
+                    break;
+                case TradeStatus.Proposed:
+                    writer.WritePackedGuid128(Partner.Low, Partner.High);
+                    writer.WritePackedGuid128(PartnerAccount.Low, PartnerAccount.High);
+                    break;
+                case TradeStatus.WrongRealm:
+                case TradeStatus.NotOnTaplist:
+                    writer.WriteUInt8(TradeSlot);
+                    break;
+                case TradeStatus.NotEnoughCurrency:
+                case TradeStatus.CurrencyNotTradable:
+                    writer.WriteInt32(CurrencyType);
+                    writer.WriteInt32(CurrencyQuantity);
+                    break;
+                default:
+                    writer.FlushBits();
+                    break;
+            }
+            return writer.Position;
         }
 
         public bool PartnerIsSameBnetAccount;

--- a/HermesProxy/World/Server/Packets/UpdatePackets.cs
+++ b/HermesProxy/World/Server/Packets/UpdatePackets.cs
@@ -18,6 +18,7 @@
 
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
@@ -349,8 +350,12 @@ namespace HermesProxy.World.Server.Packets
         public List<ObjectUpdate> ObjectUpdates = new List<ObjectUpdate>();
     }
 
-    public class PowerUpdate : ServerPacket
+    public class PowerUpdate : ServerPacket, ISpanWritable
     {
+        // WoW has ~20 power types (mana, rage, focus, energy, combo points, runes, etc.)
+        // Practical cap is much lower since a unit only has a few power types
+        private const int MaxPowerTypes = 16;
+
         public PowerUpdate(WowGuid128 guid) : base(Opcode.SMSG_POWER_UPDATE)
         {
             Guid = guid;
@@ -366,6 +371,27 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteInt32(power.Power);
                 _worldPacket.WriteUInt8(power.PowerType);
             }
+        }
+
+        // MaxSize: PackedGuid128 (18) + int (4) + 16 * (int (4) + byte (1)) = 102
+        public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 4 + MaxPowerTypes * 5;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Powers.Count > MaxPowerTypes)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WritePackedGuid128(Guid.Low, Guid.High);
+            writer.WriteInt32(Powers.Count);
+
+            foreach (var power in Powers)
+            {
+                writer.WriteInt32(power.Power);
+                writer.WriteUInt8(power.PowerType);
+            }
+
+            return writer.Position;
         }
 
         public WowGuid128 Guid;

--- a/HermesProxy/World/Server/Packets/WorldStatePackets.cs
+++ b/HermesProxy/World/Server/Packets/WorldStatePackets.cs
@@ -16,15 +16,17 @@
  */
 
 
+using System;
 using Framework.Constants;
 using Framework.GameMath;
+using Framework.IO;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System.Collections.Generic;
 
 namespace HermesProxy.World.Server.Packets
 {
-    public class InitWorldStates : ServerPacket
+    public class InitWorldStates : ServerPacket, ISpanWritable
     {
         public InitWorldStates() : base(Opcode.SMSG_INIT_WORLD_STATES, ConnectionType.Instance) { }
 
@@ -40,6 +42,29 @@ namespace HermesProxy.World.Server.Packets
                 _worldPacket.WriteUInt32(wsi.VariableID);
                 _worldPacket.WriteInt32(wsi.Value);
             }
+        }
+
+        // Cap for world states - battlegrounds can have many, classic adds ~30
+        private const int MaxWorldStates = 128;
+        // 3 uints(12) + count(4) + states(8 each)
+        public int MaxSize => 12 + 4 + MaxWorldStates * 8;
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            if (Worldstates.Count > MaxWorldStates)
+                return -1;
+
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(MapID);
+            writer.WriteUInt32(ZoneID);
+            writer.WriteUInt32(AreaID);
+            writer.WriteInt32(Worldstates.Count);
+            foreach (WorldStateInfo wsi in Worldstates)
+            {
+                writer.WriteUInt32(wsi.VariableID);
+                writer.WriteInt32(wsi.Value);
+            }
+            return writer.Position;
         }
 
         public void AddState(uint variableID, int value)
@@ -168,7 +193,7 @@ namespace HermesProxy.World.Server.Packets
         }
     }
 
-    public class UpdateWorldState : ServerPacket
+    public class UpdateWorldState : ServerPacket, ISpanWritable
     {
         public UpdateWorldState() : base(Opcode.SMSG_UPDATE_WORLD_STATE, ConnectionType.Instance) { }
 
@@ -178,6 +203,18 @@ namespace HermesProxy.World.Server.Packets
             _worldPacket.WriteInt32(Value);
             _worldPacket.WriteBit(Hidden);
             _worldPacket.FlushBits();
+        }
+
+        public int MaxSize => 9; // uint + int + 1 byte for bit
+
+        public int WriteToSpan(Span<byte> buffer)
+        {
+            var writer = new SpanPacketWriter(buffer);
+            writer.WriteUInt32(VariableID);
+            writer.WriteInt32(Value);
+            writer.WriteBit(Hidden);
+            writer.FlushBits();
+            return writer.Position;
         }
 
         public uint VariableID;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HermesProxy ![Build](https://github.com/WowLegacyCore/HermesProxy/actions/workflows/Build_Proxy.yml/badge.svg)
+# HermesProxy ![Build](https://github.com/Xian55/HermesProxy/actions/workflows/Build_Proxy.yml/badge.svg)
 
 This project enables play on existing legacy WoW emulation cores using the modern clients. It serves as a translation layer, converting all network traffic to the appropriate format each side can understand.
 
@@ -197,9 +197,389 @@ The core `ByteBuffer` class has been refactored for improved performance:
 - **BnetTcpSession**: Zero-allocation buffer management with `Span<T>`
 - **Movement Handlers**: Fixed monster/pet movement zig-zag at tile boundaries
 
+## ISpanWritable Implementation Status
+
+This section tracks the progress of implementing `ISpanWritable` interface for server packets to enable zero-allocation span-based packet writing.
+
+### Current Progress
+
+| Metric | Count |
+|--------|-------|
+| **Packets WITH ISpanWritable** | 272 |
+| **Packets WITHOUT ISpanWritable** | 49 |
+| **Total ServerPackets** | 321 |
+| **Coverage** | 84.7% |
+
+### Converted Packets (272)
+
+<details>
+<summary>Click to expand full list</summary>
+
+#### AuthenticationPackets.cs (3)
+- `Pong`
+- `WaitQueueFinish`
+- `ResumeComms`
+
+#### AuctionPackets.cs (5)
+- `AuctionHelloResponse`
+- `AuctionClosedNotification` *(uses AuctionPacketHelpers for ItemInstance)*
+- `AuctionOwnerBidNotification` *(uses AuctionPacketHelpers for ItemInstance)*
+- `AuctionWonNotification` *(uses AuctionPacketHelpers for ItemInstance)*
+- `AuctionOutbidNotification` *(uses AuctionPacketHelpers for ItemInstance)*
+
+#### BattleGroundPackets.cs (5)
+- `BattlegroundInit`
+- `BattlegroundPlayerLeftOrJoined`
+- `AreaSpiritHealerTime`
+- `PvPCredit`
+- `PlayerSkinned`
+
+#### CharacterPackets.cs (13)
+- `CreateChar`
+- `DeleteChar`
+- `LoginVerifyWorld`
+- `CharacterLoginFailed`
+- `LogoutResponse`
+- `LogoutComplete`
+- `LogoutCancelAck`
+- `LogXPGain`
+- `PlayedTime`
+- `InspectHonorStatsResultClassic`
+- `InspectHonorStatsResultTBC`
+- `GenerateRandomCharacterNameResult` *(bounded string - player name)*
+- `CharacterRenameResult` *(bounded string - player name)*
+
+#### ChatPackets.cs (2)
+- `STextEmote`
+- `ChatPlayerNotfound` *(bounded string - player name)*
+
+#### ClientConfigPackets.cs (1)
+- `ClientCacheVersion`
+
+#### CombatPackets.cs (6)
+- `AttackSwingError`
+- `SAttackStart`
+- `SAttackStop`
+- `CancelCombat`
+- `AIReaction`
+- `PartyKillLog`
+
+#### DuelPackets.cs (7)
+- `CanDuelResult`
+- `DuelRequested`
+- `DuelCountdown`
+- `DuelComplete`
+- `DuelInBounds`
+- `DuelOutOfBounds`
+- `DuelWinner` *(bounded string - 2 player names)*
+
+#### GameObjectPackets.cs (5)
+- `GameObjectDespawn`
+- `GameObjectResetState`
+- `GameObjectCustomAnim`
+- `FishNotHooked`
+- `FishEscaped`
+
+#### GroupPackets.cs (12)
+- `GroupUninvite`
+- `ReadyCheckStarted`
+- `ReadyCheckResponse`
+- `ReadyCheckCompleted`
+- `SendRaidTargetUpdateSingle`
+- `SendRaidTargetUpdateAll` *(capped 8 raid markers)*
+- `SummonRequest`
+- `MinimapPing`
+- `RandomRoll`
+- `GroupDecline` *(bounded string - player name)*
+- `GroupNewLeader` *(bounded string - player name)*
+- `PartyCommandResult` *(bounded string - player name)*
+
+#### GuildPackets.cs (16)
+- `GuildCommandResult` *(bounded string - guild/player name)*
+- `GuildSendRankChange`
+- `GuildEventDisbanded`
+- `GuildEventRanksUpdated`
+- `GuildEventTabAdded`
+- `GuildEventBankMoneyChanged`
+- `GuildEventTabTextChanged`
+- `PlayerTabardVendorActivate`
+- `PlayerSaveGuildEmblem`
+- `GuildBankRemainingWithdrawMoney`
+- `GuildEventPlayerJoined` *(bounded string - player name)*
+- `GuildEventPlayerLeft` *(bounded string - player names)*
+- `GuildEventNewLeader` *(bounded string - 2 player names)*
+- `GuildEventPresenceChange` *(bounded string - player name)*
+- `GuildInviteDeclined` *(bounded string - player name)*
+
+#### InstancePackets.cs (8)
+- `UpdateInstanceOwnership`
+- `UpdateLastInstance`
+- `InstanceReset`
+- `InstanceResetFailed`
+- `ResetFailedNotify`
+- `InstanceSaveCreated`
+- `RaidGroupOnly`
+- `RaidInstanceMessage`
+
+#### ItemPackets.cs (13)
+- `SetProficiency`
+- `BuySucceeded`
+- `BuyFailed`
+- `SellResponse`
+- `ReadItemResultFailed`
+- `ReadItemResultOK`
+- `SocketGemsSuccess`
+- `DurabilityDamageDeath`
+- `ItemCooldown`
+- `ItemEnchantTimeUpdate`
+- `EnchantmentLog`
+- `ItemPushResult` *(uses ItemPacketHelpers for ItemInstance)*
+- `InventoryChangeFailure` *(conditional fields based on BagResult)*
+
+#### LootPackets.cs (8)
+- `LootReleaseResponse`
+- `LootMoneyNotify`
+- `CoinRemoved`
+- `LootRemoved`
+- `LootRollsComplete`
+- `MasterLootCandidateList` *(capped 40 raid members)*
+- `LootList` *(optional fields)*
+- `LootResponse` *(capped 16 items, 4 currencies)*
+
+#### MailPackets.cs (2)
+- `NotifyReceivedMail`
+- `MailCommandResult`
+
+#### MiscPackets.cs (22)
+- `BindPointUpdate`
+- `PlayerBound`
+- `ServerTimeOffset`
+- `TutorialFlags`
+- `CorpseReclaimDelay`
+- `TimeSyncRequest`
+- `WeatherPkt`
+- `StartLightningStorm`
+- `LoginSetTimeSpeed`
+- `AreaTriggerMessage`
+- `DungeonDifficultySet`
+- `InitialSetup`
+- `CorpseLocation`
+- `DeathReleaseLoc`
+- `StandStateUpdate`
+- `ExplorationExperience`
+- `PlayMusic`
+- `PlaySound` *(version-specific)*
+- `PlayObjectSound` *(version-specific)*
+- `TriggerCinematic`
+- `StartMirrorTimer`
+- `PauseMirrorTimer`
+- `StopMirrorTimer`
+- `ConquestFormulaConstants`
+- `SeasonInfo`
+- `InvalidatePlayer`
+- `ZoneUnderAttack`
+
+#### MovementPackets.cs (17)
+- `MonsterMove` *(capped 64 waypoints, real usage: 1-2 points)*
+- `MoveUpdate`
+- `MoveTeleport` *(optional Vehicle + TransportGUID)*
+- `TransferPending` *(optional Ship + TransferSpellID)*
+- `TransferAborted`
+- `NewWorld`
+- `MoveSplineSetSpeed`
+- `MoveSetSpeed`
+- `MoveUpdateSpeed`
+- `MoveSplineSetFlag`
+- `MoveSetFlag`
+- `MoveSetCollisionHeight`
+- `MoveKnockBack`
+- `MoveUpdateKnockBack`
+- `SuspendToken`
+- `ResumeToken`
+- `ControlUpdate`
+
+#### NPCPackets.cs (6)
+- `GossipComplete` *(version-specific)*
+- `BinderConfirm`
+- `ShowBank`
+- `TrainerBuyFailed`
+- `RespecWipeConfirm`
+- `SpiritHealerConfirm`
+
+#### PetitionPackets.cs (3)
+- `PetitionSignResults`
+- `TurnInPetitionResult`
+- `PetitionRenameGuildResponse` *(bounded string - guild name)*
+
+#### PetPackets.cs (3)
+- `PetClearSpells`
+- `PetActionSound`
+- `PetStableResult`
+
+#### QueryPackets.cs (2)
+- `QueryTimeResponse`
+- `QueryPetNameResponse` *(bounded string - pet name + declined names)*
+
+#### QuestPackets.cs (5)
+- `QuestGiverQuestFailed`
+- `QuestUpdateStatus`
+- `QuestUpdateAddCredit`
+- `QuestUpdateAddCreditSimple`
+- `QuestPushResult`
+
+#### ReputationPackets.cs (1)
+- `SetFactionVisible`
+
+#### SessionPackets.cs (1)
+- `ConnectionStatus`
+
+#### SpellPackets.cs (28)
+- `CancelAutoRepeat`
+- `SpellPrepare`
+- `CastFailed`
+- `PetCastFailed`
+- `SpellFailure`
+- `SpellFailedOther`
+- `CooldownEvent`
+- `ClearCooldown`
+- `CooldownCheat`
+- `SpellDelayed`
+- `SpellChannelStart` *(optional InterruptImmunities + HealPrediction)*
+- `SpellChannelUpdate`
+- `SpellInstakillLog`
+- `PlaySpellVisualKit`
+- `TotemCreated`
+- `ResurrectRequest` *(bounded string - player name)*
+- `LearnedSpells` *(capped 8 spells)*
+- `UnlearnedSpells` *(capped 8 spells)*
+- `SendUnlearnSpells` *(capped 8 spells)*
+- `SpellCooldownPkt` *(capped 64 cooldowns)*
+- `SendSpellHistory` *(capped 64 entries)*
+- `SendSpellCharges` *(capped 16 entries)*
+- `SpellEnergizeLog` *(optional SpellCastLogData, capped 10 power entries)*
+- `SpellDamageShield` *(optional SpellCastLogData, capped 10 power entries)*
+- `EnvironmentalDamageLog` *(optional SpellCastLogData, capped 10 power entries)*
+- `SpellHealLog` *(optional SpellCastLogData + ContentTuning, high-frequency)*
+- `SpellNonMeleeDamageLog` *(optional SpellCastLogData + ContentTuning, high-frequency)*
+- `SetSpellModifier` *(capped 8 modifiers × 8 data entries, high-frequency)*
+
+#### ArenaPackets.cs (2)
+- `ArenaTeamCommandResult` *(bounded string - team + player names)*
+- `ArenaTeamInvite` *(bounded string - team + player names)*
+
+#### TaxiPackets.cs (3)
+- `TaxiNodeStatusPkt`
+- `NewTaxiPath`
+- `ActivateTaxiReplyPkt`
+
+#### UpdatePackets.cs (1)
+- `PowerUpdate` *(capped 16 power types)*
+
+#### WorldStatePackets.cs (1)
+- `UpdateWorldState`
+
+</details>
+
+### Unconverted Packets (49)
+
+These packets cannot implement `ISpanWritable` due to dynamic lists or complex data structures that cannot determine `MaxSize` at compile time.
+
+<details>
+<summary>Dynamic Lists / Complex Data</summary>
+
+| Packet | File | Blocking Field(s) |
+|--------|------|-------------------|
+| `AuctionListMyItemsResult` | AuctionPackets.cs | `List<AuctionItem>` |
+| `AuctionListItemsResult` | AuctionPackets.cs | `List<AuctionItem>` |
+| `PVPMatchStatisticsMessage` | BattleGroundPackets.cs | `List<PVPMatchPlayerStatistics>` |
+| `EnumCharactersResult` | CharacterPackets.cs | `List<CharacterListEntry> Characters` |
+| `GetAccountCharacterListResult` | CharacterPackets.cs | `List<AccountCharacterListEntry>` |
+| `InspectResult` | CharacterPackets.cs | Multiple lists (talents, glyphs, items) |
+| `AttackerStateUpdate` | CombatPackets.cs | Complex damage info with lists |
+| `PartyUpdate` | GroupPackets.cs | `List<PartyPlayerInfo> PlayerList` |
+| `PartyMemberPartialState` | GroupPackets.cs | Complex nested state |
+| `PartyMemberFullState` | GroupPackets.cs | Complex nested state |
+| `QueryGuildInfoResponse` | GuildPackets.cs | Multiple rank names |
+| `GuildRoster` | GuildPackets.cs | `List<GuildRosterMemberData>` |
+| `GuildRanks` | GuildPackets.cs | `List<GuildRankData>` |
+| `GuildBankQueryResults` | GuildPackets.cs | `List<GuildBankItemInfo>` |
+| `GuildBankLogQueryResults` | GuildPackets.cs | `List<GuildBankLogEntry>` |
+| `DBReply` | HotfixPackets.cs | Dynamic data blob |
+| `AvailableHotfixes` | HotfixPackets.cs | `List<HotfixRecord>` |
+| `HotfixConnect` | HotfixPackets.cs | `List<HotfixRecord>` |
+| `HotFixMessage` | HotfixPackets.cs | `List<HotfixData>` |
+| `MailListResult` | MailPackets.cs | `List<MailListEntry>` |
+| `GossipMessagePkt` | NPCPackets.cs | `List<GossipOption>`, `List<GossipQuest>` |
+| `VendorInventory` | NPCPackets.cs | `List<VendorItem>` |
+| `PetSpells` | PetPackets.cs | `List<uint> ActionButtons`, `List<PetSpellCooldown>` |
+| `QueryQuestInfoResponse` | QueryPackets.cs | Complex quest data with lists |
+| `QueryCreatureResponse` | QueryPackets.cs | Variable-length strings |
+| `QueryGameObjectResponse` | QueryPackets.cs | Variable-length strings |
+| `QueryPageTextResponse` | QueryPackets.cs | Variable-length text |
+| `WhoResponsePkt` | QueryPackets.cs | `List<WhoEntry>` |
+| `QuestGiverQuestDetails` | QuestPackets.cs | Multiple lists (rewards, objectives) |
+| `QuestGiverQuestListMessage` | QuestPackets.cs | `List<GossipQuest>` |
+| `QuestGiverRequestItems` | QuestPackets.cs | `List<QuestObjectiveCollect>` |
+| `QuestGiverOfferRewardMessage` | QuestPackets.cs | Multiple reward lists |
+| `QuestGiverQuestComplete` | QuestPackets.cs | Optional reward display |
+| `DisplayToast` | QuestPackets.cs | Multiple switch-based writes |
+| `AuraUpdate` | SpellPackets.cs | `List<AuraInfo> Auras` |
+| `SpellStart` | SpellPackets.cs | Complex spell cast data |
+| `SpellGo` | SpellPackets.cs | Complex spell cast data |
+| `SpellPeriodicAuraLog` | SpellPackets.cs | `List<SpellLogEffect>` |
+| `FeatureSystemStatus` | SystemPackets.cs | Complex with many optional fields |
+| `FeatureSystemStatusGlueScreen` | SystemPackets.cs | Complex with version-dependent lists |
+| `TradeUpdated` | TradePackets.cs | `List<TradeItem>` |
+| `UpdateObject` | UpdatePackets.cs | Complex object update data |
+
+</details>
+
+<details>
+<summary>Complex Authentication / Session Packets</summary>
+
+| Packet | File | Reason |
+|--------|------|--------|
+| `AuthResponse` | AuthenticationPackets.cs | Complex with optional sections |
+| `ConnectTo` | AuthenticationPackets.cs | Connection data with addresses |
+| `EnterEncryptedMode` | AuthenticationPackets.cs | Encryption keys |
+| `BattlenetNotification` | SessionPackets.cs | Bnet protocol data |
+| `BattlenetResponse` | SessionPackets.cs | Bnet protocol data |
+| `ChangeRealmTicketResponse` | SessionPackets.cs | Auth ticket data |
+
+</details>
+
+<details>
+<summary>Unbounded Strings / Other</summary>
+
+| Packet | File | Reason |
+|--------|------|--------|
+| `PartyInvite` | GroupPackets.cs | Multiple unbounded strings (realm names, etc.) |
+
+</details>
+
+### MaxSize Optimizations
+
+Based on `spanstats.log` analysis, several packets were allocating far more memory than needed. These have been optimized with reduced caps that still use fallback to `Write()` for rare oversized cases.
+
+| Packet | Old MaxSize | New MaxSize | Reduction |
+|--------|-------------|-------------|-----------|
+| `ContactList` | 36,605 | ~2,933 | **92%** |
+| `UpdateAccountData` | 16,419 | ~2,083 | **87%** |
+| `AllAccountCriteria` | 13,060 | ~1,636 | **87%** |
+| `ChatPkt` | 8,511 | ~1,087 | **87%** |
+| `SendKnownSpells` | 4,617 | ~1,097 | **76%** |
+| `SetupCurrency` | 3,844 | ~484 | **87%** |
+| `SetAllTaskProgress` | 3,332 | ~420 | **87%** |
+| `LoadCUFProfiles` | 2,048 | 256 | **88%** |
+| `MOTD` | 2,065 | ~517 | **75%** |
+| `MonsterMove` | 1,134 | ~366 | **68%** |
+| `LFGListUpdateBlacklist` | 1,028 | ~132 | **87%** |
+| `ChannelNotifyJoined` | 357 | ~165 | **54%** |
+| `MoveUpdate` | 256 | 192 | **25%** |
+
 ## Acknowledgements
 
 Parts of this project's code are based on [CypherCore](https://github.com/CypherCore/CypherCore) and [BotFarm](https://github.com/jackpoz/BotFarm). I would like to extend my sincere thanks to these projects, as the creation of this app might have never happened without them. And I would also like to expressly thank [Modox](https://github.com/mdx7) for all his work on reverse engineering the classic clients and all the help he has personally given me.
 
 ## Download HermesProxy
-Stable Downloads: [Releases](https://github.com/WowLegacyCore/HermesProxy/releases)
+Stable Downloads: [Releases](https://github.com/Xian55/HermesProxy/releases)

--- a/README.md
+++ b/README.md
@@ -4,16 +4,45 @@ This project enables play on existing legacy WoW emulation cores using the moder
 
 There are 4 major components to the application:
 - The modern BNetServer to which the client initially logs into.
-- The legacy AuthClient which will in turn login to the remote authentication server (realmd). 
-- The modern WorldServer to which the game client will connect once a realm has been selected. 
+- The legacy AuthClient which will in turn login to the remote authentication server (realmd).
+- The modern WorldServer to which the game client will connect once a realm has been selected.
 - The legacy WorldClient which communicates with the remote world server (mangosd).
 
 ## Supported Versions
 
-| Modern Versions | Legacy Versions |
-|-----------------|-----------------|
-| 1.14.0          | 1.12.1          |
-| 2.5.2           | 2.4.3           |
+HermesProxy translates between modern WoW Classic clients and legacy private server emulators.
+
+### Modern Client Versions (What You Play With)
+
+These are the Blizzard WoW Classic client versions you can use:
+
+| Version | Expansion      | Build Range       | Notes                    |
+|---------|----------------|-------------------|--------------------------|
+| 1.14.0  | Classic Era    | 39802 - 40618     | Season of Mastery        |
+| 1.14.1  | Classic Era    | 40487 - 42032     |                          |
+| 1.14.2  | Classic Era    | 41858 - 42597     |                          |
+| 2.5.2   | TBC Classic    | 39570 - 41510     |                          |
+| 2.5.3   | TBC Classic    | 41402 - 42598     |                          |
+
+### Legacy Server Versions (What Emulators Run)
+
+These are the private server versions HermesProxy can connect to:
+
+| Version | Expansion | Build | Server Software          |
+|---------|-----------|-------|--------------------------|
+| 1.12.1  | Vanilla   | 5875  | CMaNGOS, VMaNGOS, etc.   |
+| 1.12.2  | Vanilla   | 6005  | CMaNGOS, VMaNGOS, etc.   |
+| 1.12.3  | Vanilla   | 6141  | CMaNGOS, VMaNGOS, etc.   |
+| 2.4.3   | TBC       | 8606  | CMaNGOS, etc.            |
+
+### Version Mapping
+
+The proxy automatically selects the best legacy version based on your client:
+
+| Modern Client | Connects To    |
+|---------------|----------------|
+| 1.14.x        | 1.12.x (Vanilla) |
+| 2.5.x         | 2.4.3 (TBC)    |
 
 ## Ingame Settings
 Note: Keep `Optimize Network for Speed` **enabled** (it's under `System` -> `Network`), otherwise you will get kicked every now and then.
@@ -22,12 +51,13 @@ Note: Keep `Optimize Network for Speed` **enabled** (it's under `System` -> `Net
 
 - Edit the app's config to specify the exact versions of your game client and the remote server, along with the address.
 - Go into your game folder, in the Classic or Classic Era subdirectory, and edit WTF/Config.wtf to set the portal to 127.0.0.1.
-- Download [Arctium Launcher](https://github.com/Arctium/WoW-Launcher/releases/tag/latest) into the main game folder, and then run it  
-with `--staticseed --version=ClassicEra` for vanilla  
+- Download [Arctium Launcher](https://github.com/Arctium/WoW-Launcher/releases/tag/latest) into the main game folder, and then run it
+with `--staticseed --version=ClassicEra` for vanilla
 or `--staticseed --version=Classic` for TBC.
 - Start the proxy app and login through the game with your usual credentials.
 
-## Chat commands
+## Chat Commands
+
 HermesProxy provides some internal chat commands:
 
 | Command                    | Description                                                                  |
@@ -35,14 +65,141 @@ HermesProxy provides some internal chat commands:
 | `!qcomplete <questId>`     | Manually marks a quest as already completed (useful for quest helper addons) |
 | `!quncomplete <questId>`   | Unmarks a quest as completed                                                 |
 
-## Start Arguments
- - `--config <filename>` to specify a config (default `HermesProxy.config`)
- - `--set <key>=<value>` to overwrite a specific config value (example `--set ServerAddress=logon.example.com`)
- - `--no-version-check`  to disable the check for newer versions
+## Command Line Arguments
+
+| Argument                   | Description                                                  |
+|----------------------------|--------------------------------------------------------------|
+| `--config <filename>`      | Specify a config file (default: `HermesProxy.config`)        |
+| `--set <key>=<value>`      | Override a specific config value at runtime                  |
+| `--no-version-check`       | Disable the check for newer versions on startup              |
+
+**Examples:**
+```bash
+# Use a custom config file
+HermesProxy --config MyServer.config
+
+# Override server address
+HermesProxy --set ServerAddress=logon.example.com
+
+# Override multiple values
+HermesProxy --set ServerAddress=logon.example.com --set ServerPort=3725
+
+# Combine config file with overrides
+HermesProxy --config Production.config --set DebugOutput=true
+```
+
+## Configuration Reference
+
+Configuration is stored in `HermesProxy.config` (XML format). All settings can also be overridden via `--set` command line arguments.
+
+### Connection Settings
+
+| Setting         | Default       | Description                                                              |
+|-----------------|---------------|--------------------------------------------------------------------------|
+| `ServerAddress` | `127.0.0.1`   | Address of the legacy server (what you'd use in `SET REALMLIST`)         |
+| `ServerPort`    | `3724`        | Port of the legacy authentication server                                 |
+| `ExternalAddress` | `127.0.0.1` | Your IP address for others to connect (for hosting)                      |
+
+### Version Settings
+
+| Setting       | Default                            | Valid Values                                    |
+|---------------|------------------------------------|-------------------------------------------------|
+| `ClientBuild` | `40618` (1.14.0)                   | `40618` (1.14.0), `41794` (1.14.1), `42597` (1.14.2), `40892` (2.5.2), `42328` (2.5.3) |
+| `ServerBuild` | `auto`                             | `auto`, `5875` (1.12.1), `8606` (2.4.3)         |
+| `ClientSeed`  | `179D3DC3235629D07113A9B3867F97A7` | 32-character hex string (16 bytes)              |
+
+### Port Settings
+
+All ports must be in the range `1-65535`.
+
+| Setting        | Default | Description                                                        |
+|----------------|---------|--------------------------------------------------------------------|
+| `BNetPort`     | `1119`  | Port for BNet/Portal server (use this in your `Config.wtf`)        |
+| `RestPort`     | `8081`  | Port for the REST API server                                       |
+| `RealmPort`    | `8084`  | Port for the realm server                                          |
+| `InstancePort` | `8086`  | Port for the instance server                                       |
+
+### Platform Settings
+
+| Setting            | Default | Valid Values                    | Description                              |
+|--------------------|---------|---------------------------------|------------------------------------------|
+| `ReportedOS`       | `OSX`   | `OSX`, `Win`, etc.              | OS identifier sent to the legacy server  |
+| `ReportedPlatform` | `x86`   | `x86`, `x64`                    | Platform identifier sent to legacy server|
+
+### Logging Settings
+
+| Setting        | Default | Description                                                          |
+|----------------|---------|----------------------------------------------------------------------|
+| `DebugOutput`  | `false` | Print additional debug information to console                        |
+| `PacketsLog`   | `true`  | Save each session's packets to files in `PacketsLog` directory       |
+| `SpanStatsLog` | `false` | Log statistics about Span-based packet serialization (for profiling) |
+
+### Example Configuration
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <appSettings>
+    <add key="ClientBuild" value="40618" />
+    <add key="ServerBuild" value="auto" />
+    <add key="ServerAddress" value="logon.example.com" />
+    <add key="ServerPort" value="3724" />
+    <add key="BNetPort" value="1119" />
+    <add key="DebugOutput" value="false" />
+    <add key="PacketsLog" value="true" />
+  </appSettings>
+</configuration>
+```
+
+## Performance Optimizations
+
+HermesProxy has been extensively optimized to minimize latency and memory allocations in packet handling hot paths.
+
+### Span-Based Packet I/O (Zero-Allocation)
+
+The packet serialization system uses `Span<T>` and `ref struct` types for zero-allocation packet writing and reading:
+
+**SpanPacketWriter vs ByteBuffer (Write Operations)**
+
+| Operation    | ByteBuffer | SpanWriter | Speedup | Memory      |
+|--------------|------------|------------|---------|-------------|
+| WriteInt64   | 93.37 ns   | 0.29 ns    | ~317x   | 80B → 0B    |
+| WriteVector3 | 102.99 ns  | 0.68 ns    | ~151x   | 88B → 0B    |
+| WriteMixed   | 109.30 ns  | 1.29 ns    | ~85x    | 96B → 0B    |
+
+**SpanPacketReader vs ByteBuffer (Read Operations)**
+
+| Operation    | ByteBuffer | SpanReader | Speedup  | Memory      |
+|--------------|------------|------------|----------|-------------|
+| ReadInt64    | 157.98 ns  | 0.08 ns    | ~1948x   | 48B → 0B    |
+| ReadVector3  | 178.31 ns  | 0.75 ns    | ~238x    | 48B → 0B    |
+| ReadCString  | 294.61 ns  | 23.51 ns   | ~12.5x   | 104B → 56B  |
+
+### ByteBuffer Optimizations
+
+The core `ByteBuffer` class has been refactored for improved performance:
+- ArrayPool-based buffer management reduces GC pressure
+- Direct `BinaryPrimitives` usage eliminates BinaryReader/BinaryWriter overhead
+- `MemoryStream.ToArray()` optimization for `GetData()`:
+
+| Buffer Size | Original     | Optimized   | Speedup |
+|-------------|--------------|-------------|---------|
+| Small       | 46.87 ns     | 10.31 ns    | ~4.5x   |
+| Medium      | 649.49 ns    | 70.88 ns    | ~9.2x   |
+| Large       | 36,383.19 ns | 4,234.92 ns | ~8.6x   |
+
+### Additional Optimizations
+
+- **Enum Conversions**: Cached name-based mappings replace `Enum.Parse(typeof(T), x.ToString())` pattern (8-25x speedup, 95% memory reduction)
+- **Opcode Lookups**: `FrozenDictionary` for O(1) opcode resolution
+- **WowGuid**: Refactored to value-type record structs eliminating heap allocations
+- **NetworkThread**: O(1) socket removal with `ConcurrentQueue`
+- **BnetTcpSession**: Zero-allocation buffer management with `Span<T>`
+- **Movement Handlers**: Fixed monster/pet movement zig-zag at tile boundaries
 
 ## Acknowledgements
 
-Parts of this poject's code are based on [CypherCore](https://github.com/CypherCore/CypherCore) and [BotFarm](https://github.com/jackpoz/BotFarm). I would like to extend my sincere thanks to these projects, as the creation of this app might have never happened without them. And I would also like to expressly thank [Modox](https://github.com/mdx7) for all his work on reverse engineering the classic clients and all the help he has personally given me. 
+Parts of this project's code are based on [CypherCore](https://github.com/CypherCore/CypherCore) and [BotFarm](https://github.com/jackpoz/BotFarm). I would like to extend my sincere thanks to these projects, as the creation of this app might have never happened without them. And I would also like to expressly thank [Modox](https://github.com/mdx7) for all his work on reverse engineering the classic clients and all the help he has personally given me.
 
 ## Download HermesProxy
 Stable Downloads: [Releases](https://github.com/WowLegacyCore/HermesProxy/releases)

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Configuration is stored in `HermesProxy.config` (XML format). All settings can a
 
 | Setting       | Default                            | Valid Values                                    |
 |---------------|------------------------------------|-------------------------------------------------|
-| `ClientBuild` | `40618` (1.14.0)                   | `40618` (1.14.0), `41794` (1.14.1), `42597` (1.14.2), `40892` (2.5.2), `42328` (2.5.3) |
-| `ServerBuild` | `auto`                             | `auto`, `5875` (1.12.1), `8606` (2.4.3)         |
+| `ClientBuild` | `40618` (1.14.0)                   | `40618` (1.14.0)<br>`41794` (1.14.1)<br>`42597` (1.14.2)<br>`40892` (2.5.2)<br>`42328` (2.5.3) |
+| `ServerBuild` | `auto`                             | `auto`<br>`5875` (1.12.1)<br>`8606` (2.4.3)         |
 | `ClientSeed`  | `179D3DC3235629D07113A9B3867F97A7` | 32-character hex string (16 bytes)              |
 
 ### Port Settings


### PR DESCRIPTION
## Summary

Introduces a zero-allocation packet I/O layer built on `Span<T>` and `ref struct` types, and rolls it out across the server packet set. The goal is to cut GC pressure and latency on the packet-handling hot paths — every packet HermesProxy serializes currently round-trips through `ByteBuffer` (`BinaryWriter`/`MemoryStream`), which heap-allocates per operation.

Targets the `feature/dotnet10` branch.

## New Framework Components

| Type | Purpose |
|------|---------|
| `SpanPacketWriter` | Stack-allocated `ref struct` for zero-allocation writes over `Span<byte>`, using `BinaryPrimitives` for endian-aware ops |
| `SpanPacketReader` | Stack-allocated `ref struct` for zero-allocation reads over `ReadOnlySpan<byte>`, inlined hot-path methods |
| `ISpanWritable` | Opt-in interface: packets implement `WriteToSpan()` + a `MaxSize` hint for buffer pre-allocation |
| `PackedGuidHelper` | Optimized packed GUID128 / UInt64 encoding via `BitOperations.TrailingZeroCount` and unrolled mask computation |
| `GameLimits` | Constants for WoW name/string byte limits (player/guild/pet/arena-team names), UTF-8 aware |

## ByteBuffer Refactoring

- Replaces `BinaryWriter`/`BinaryReader` with direct `byte[]` manipulation
- `ArrayPool<byte>.Shared` buffer pooling to reduce allocations
- `BinaryPrimitives` for little-endian read/write
- Proper `IDisposable` + finalizer for pooled buffers
- `AggressiveInlining` on hot-path methods

## Packet Rollout

- `ISpanWritable` implemented on **272 packet classes across 32 packet files** (84.7% of 321 server packets; remaining 49 fall back to `Write()`).
- Each packet returns bytes-written from `WriteToSpan()` and exposes a `MaxSize`. A negative return triggers the standard `Write()` fallback path, so correctness is preserved when a packet exceeds its hint.
- New `AuctionPacketHelpers` shares `ItemInstance` writing across the 4 auction notification packets.

### MaxSize tuning (commit 4: `spanstats.log`-driven)

`MaxSize` caps were measured against real login-sequence traffic and tightened to avoid over-allocating the pooled buffer:

- `ContactList` 36KB → 3KB (MaxContacts 200→16)
- `UpdateAccountData` 16KB → 2KB
- `AllAccountCriteria` 13KB → 1.6KB
- `SendKnownSpells` 4.6KB → 1KB
- `SetupCurrency` 3.8KB → 484B, `SetAllTaskProgress` 3.3KB → 420B
- `ChatPkt` 8.5KB → 1KB, `MonsterMove` 1.1KB → 366B, + 5 more
- Net **~88% allocation reduction** across the login sequence; all retain `Write()` fallback.

## Benchmarks

**SpanPacketWriter vs ByteBuffer (write)**

| Operation | ByteBuffer | SpanWriter | Speedup | Alloc |
|-----------|-----------|-----------|---------|-------|
| WriteInt64 | 93.37 ns | 0.29 ns | ~317x | 80B → 0B |
| WriteVector3 | 102.99 ns | 0.68 ns | ~151x | 88B → 0B |
| WriteMixed | 109.30 ns | 1.29 ns | ~85x | 96B → 0B |

**SpanPacketReader vs ByteBuffer (read)**

| Operation | ByteBuffer | SpanReader | Speedup | Alloc |
|-----------|-----------|-----------|---------|-------|
| ReadInt64 | 157.98 ns | 0.08 ns | ~1948x | 48B → 0B |
| ReadVector3 | 178.31 ns | 0.75 ns | ~238x | 48B → 0B |
| ReadCString | 294.61 ns | 23.51 ns | ~12.5x | 104B → 56B |

`ByteBuffer.GetData()` itself also improved ~4.5–9.2x (small→large buffers) from the `MemoryStream.ToArray()` rework.

## Tests

- New `HermesProxy.Tests/Framework/SpanPacketTests.cs` — 34 facts/theories verifying `SpanPacketWriter` output matches `ByteBuffer` **byte-for-byte** across bit packing, packed GUIDs, vectors, strings, and all primitives.
- New `HermesProxy.Benchmarks/SpanPacketBenchmarks.cs` for regression tracking.

## Docs

- `README.md` rewritten: expanded supported-version tables (modern client builds + legacy server builds + mapping), full config reference, command-line examples, and a Performance Optimizations section documenting the above plus the `ISpanWritable` coverage tracker.
- New `SpanStatsLog` config setting to log span-serialization stats for profiling.

Net: +7933 / −444 across 47 files.
