### PR TITLE
Perf: Eliminate WowGuid128 boxing in UpdateFieldsArray

### DIFF
--- a/HermesProxy.Benchmarks/MonsterMoveBenchmarks.cs
+++ b/HermesProxy.Benchmarks/MonsterMoveBenchmarks.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Framework.GameMath;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using HermesProxy.World.Server.Packets;
+
+namespace HermesProxy.Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class MonsterMoveWriteBenchmarks
+{
+    private WowGuid128 _guid;
+    private ServerSideMovement _splineFacingSpot = null!;
+    private ServerSideMovement _splineFacingTarget = null!;
+    private ServerSideMovement _splineFacingAngle = null!;
+    private ServerSideMovement _splineNone = null!;
+    private ServerSideMovement _splineWithPoints = null!;
+    private byte[] _spanBuffer = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V9_0_1_36216;
+
+        _guid = WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
+
+        _splineFacingSpot = CreateSpline(SplineTypeModern.FacingSpot);
+        _splineFacingTarget = CreateSpline(SplineTypeModern.FacingTarget);
+        _splineFacingAngle = CreateSpline(SplineTypeModern.FacingAngle);
+        _splineNone = CreateSpline(SplineTypeModern.None);
+        _splineWithPoints = CreateSplineWithPoints(8);
+
+        // Large enough for any packet
+        _spanBuffer = new byte[1024];
+    }
+
+    private static ServerSideMovement CreateSpline(SplineTypeModern splineType)
+    {
+        return new ServerSideMovement
+        {
+            SplineType = splineType,
+            SplineFlags = SplineFlagModern.None,
+            SplineId = 1,
+            SplineTimeFull = 1000,
+            SplineMode = 0,
+            StartPosition = new Vector3(100f, 200f, 300f),
+            EndPosition = new Vector3(110f, 210f, 310f),
+            TransportGuid = WowGuid128.Empty,
+            TransportSeat = 0,
+            FinalOrientation = 1.5f,
+            FinalFacingSpot = new Vector3(120f, 220f, 320f),
+            FinalFacingGuid = WowGuid128.Create(HighGuidType703.Player, 99),
+            SplinePoints = new List<Vector3>(),
+        };
+    }
+
+    private static ServerSideMovement CreateSplineWithPoints(int pointCount)
+    {
+        var spline = new ServerSideMovement
+        {
+            SplineType = SplineTypeModern.None,
+            SplineFlags = SplineFlagModern.UncompressedPath,
+            SplineId = 1,
+            SplineTimeFull = 2000,
+            SplineMode = 0,
+            StartPosition = new Vector3(100f, 200f, 300f),
+            EndPosition = new Vector3(110f, 210f, 310f),
+            TransportGuid = WowGuid128.Empty,
+            TransportSeat = 0,
+            FinalOrientation = 0f,
+            FinalFacingSpot = Vector3.Zero,
+            FinalFacingGuid = WowGuid128.Empty,
+            SplinePoints = new List<Vector3>(),
+        };
+
+        for (int i = 0; i < pointCount; i++)
+            spline.SplinePoints.Add(new Vector3(100 + i, 200 + i, 300 + i));
+
+        return spline;
+    }
+
+    // ========== ByteBuffer Write (baseline) ==========
+
+    [Benchmark(Baseline = true)]
+    public byte[] Write_FacingSpot_ByteBuffer()
+    {
+        var packet = new MonsterMove(_guid, _splineFacingSpot);
+        packet.Write();
+        packet.WritePacketData();
+        return packet.GetData()!;
+    }
+
+    [Benchmark]
+    public byte[] Write_FacingTarget_ByteBuffer()
+    {
+        var packet = new MonsterMove(_guid, _splineFacingTarget);
+        packet.Write();
+        packet.WritePacketData();
+        return packet.GetData()!;
+    }
+
+    [Benchmark]
+    public byte[] Write_FacingAngle_ByteBuffer()
+    {
+        var packet = new MonsterMove(_guid, _splineFacingAngle);
+        packet.Write();
+        packet.WritePacketData();
+        return packet.GetData()!;
+    }
+
+    [Benchmark]
+    public byte[] Write_None_ByteBuffer()
+    {
+        var packet = new MonsterMove(_guid, _splineNone);
+        packet.Write();
+        packet.WritePacketData();
+        return packet.GetData()!;
+    }
+
+    // ========== Span Write ==========
+
+    [Benchmark]
+    public int Write_FacingSpot_Span()
+    {
+        var packet = new MonsterMove(_guid, _splineFacingSpot);
+        return packet.WriteToSpan(_spanBuffer);
+    }
+
+    [Benchmark]
+    public int Write_FacingTarget_Span()
+    {
+        var packet = new MonsterMove(_guid, _splineFacingTarget);
+        return packet.WriteToSpan(_spanBuffer);
+    }
+
+    [Benchmark]
+    public int Write_FacingAngle_Span()
+    {
+        var packet = new MonsterMove(_guid, _splineFacingAngle);
+        return packet.WriteToSpan(_spanBuffer);
+    }
+
+    [Benchmark]
+    public int Write_None_Span()
+    {
+        var packet = new MonsterMove(_guid, _splineNone);
+        return packet.WriteToSpan(_spanBuffer);
+    }
+
+    // ========== With Points ==========
+
+    [Benchmark]
+    public byte[] Write_WithPoints_ByteBuffer()
+    {
+        var packet = new MonsterMove(_guid, _splineWithPoints);
+        packet.Write();
+        packet.WritePacketData();
+        return packet.GetData()!;
+    }
+
+    [Benchmark]
+    public int Write_WithPoints_Span()
+    {
+        var packet = new MonsterMove(_guid, _splineWithPoints);
+        return packet.WriteToSpan(_spanBuffer);
+    }
+}

--- a/HermesProxy.Benchmarks/ObjectUpdateBenchmarks.cs
+++ b/HermesProxy.Benchmarks/ObjectUpdateBenchmarks.cs
@@ -1,0 +1,119 @@
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using HermesProxy.World.Server.Packets;
+
+namespace HermesProxy.Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class ObjectUpdateConstructionBenchmarks
+{
+    private GlobalSessionData _session = null!;
+    private WowGuid128 _itemGuid;
+    private WowGuid128 _creatureGuid;
+    private WowGuid128 _playerGuid;
+    private WowGuid128 _gameObjectGuid;
+    private WowGuid128 _dynamicObjectGuid;
+    private WowGuid128 _corpseGuid;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _session = (GlobalSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GlobalSessionData));
+        _itemGuid = WowGuid128.Create(HighGuidType703.Item, 1);
+        _creatureGuid = WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
+        _playerGuid = WowGuid128.Create(HighGuidType703.Player, 1);
+        _gameObjectGuid = WowGuid128.Create(HighGuidType703.GameObject, 0, 5678, 1);
+        _dynamicObjectGuid = WowGuid128.Create(HighGuidType703.DynamicObject, 0, 100, 1);
+        _corpseGuid = WowGuid128.Create(HighGuidType703.Corpse, 0, 200, 1);
+    }
+
+    [Benchmark]
+    public ObjectUpdate CreateItem()
+    {
+        return new ObjectUpdate(_itemGuid, UpdateTypeModern.Values, _session);
+    }
+
+    [Benchmark]
+    public ObjectUpdate CreateUnit()
+    {
+        return new ObjectUpdate(_creatureGuid, UpdateTypeModern.Values, _session);
+    }
+
+    [Benchmark(Baseline = true)]
+    public ObjectUpdate CreatePlayer()
+    {
+        return new ObjectUpdate(_playerGuid, UpdateTypeModern.Values, _session);
+    }
+
+    [Benchmark]
+    public ObjectUpdate CreateGameObject()
+    {
+        return new ObjectUpdate(_gameObjectGuid, UpdateTypeModern.Values, _session);
+    }
+
+    [Benchmark]
+    public ObjectUpdate CreateDynamicObject()
+    {
+        return new ObjectUpdate(_dynamicObjectGuid, UpdateTypeModern.Values, _session);
+    }
+
+    [Benchmark]
+    public ObjectUpdate CreateCorpse()
+    {
+        return new ObjectUpdate(_corpseGuid, UpdateTypeModern.Values, _session);
+    }
+
+    [Benchmark]
+    public ObjectUpdate CreatePlayerWithCreateData()
+    {
+        return new ObjectUpdate(_playerGuid, UpdateTypeModern.CreateObject1, _session);
+    }
+}
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class ObjectUpdateBatchBenchmarks
+{
+    private GlobalSessionData _session = null!;
+    private WowGuid128[] _mixedGuids = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _session = (GlobalSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GlobalSessionData));
+
+        // Simulate a zone with mixed object types (100 objects)
+        _mixedGuids = new WowGuid128[100];
+        for (int i = 0; i < 100; i++)
+        {
+            _mixedGuids[i] = (i % 5) switch
+            {
+                0 => WowGuid128.Create(HighGuidType703.Creature, 0, (uint)(1000 + i), (ulong)i),
+                1 => WowGuid128.Create(HighGuidType703.Player, (ulong)i),
+                2 => WowGuid128.Create(HighGuidType703.GameObject, 0, (uint)(2000 + i), (ulong)i),
+                3 => WowGuid128.Create(HighGuidType703.Item, (ulong)i),
+                _ => WowGuid128.Create(HighGuidType703.DynamicObject, 0, (uint)(3000 + i), (ulong)i),
+            };
+        }
+    }
+
+    /// <summary>
+    /// Simulates zone load: create 100 ObjectUpdate instances of mixed types.
+    /// Measures total allocation pressure from the nullable field pattern.
+    /// </summary>
+    [Benchmark]
+    public int BatchCreate_100Mixed()
+    {
+        int count = 0;
+        for (int i = 0; i < _mixedGuids.Length; i++)
+        {
+            var update = new ObjectUpdate(_mixedGuids[i], UpdateTypeModern.CreateObject1, _session);
+            count += update.ObjectData != null ? 1 : 0; // Prevent dead code elimination
+        }
+        return count;
+    }
+}

--- a/HermesProxy.Benchmarks/UpdateFieldsArrayBenchmarks.cs
+++ b/HermesProxy.Benchmarks/UpdateFieldsArrayBenchmarks.cs
@@ -1,0 +1,166 @@
+using BenchmarkDotNet.Attributes;
+using Framework.IO;
+using HermesProxy.World;
+using HermesProxy.World.Objects;
+
+namespace HermesProxy.Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class UpdateFieldsArraySetBenchmarks
+{
+    private UpdateFieldsArray _fields = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _fields = new UpdateFieldsArray(128);
+    }
+
+    [Benchmark(Baseline = true)]
+    public void SetUpdateField_UInt32()
+    {
+        _fields.SetUpdateField<uint>(0, 0xDEADBEEFu);
+    }
+
+    [Benchmark]
+    public void SetUpdateField_Int32()
+    {
+        _fields.SetUpdateField<int>(1, -42);
+    }
+
+    [Benchmark]
+    public void SetUpdateField_Float()
+    {
+        _fields.SetUpdateField<float>(2, 3.14159f);
+    }
+
+    [Benchmark]
+    public void SetUpdateField_UInt64()
+    {
+        _fields.SetUpdateField<ulong>(4, 0x123456789ABCDEF0ul);
+    }
+
+    [Benchmark]
+    public void SetUpdateField_WowGuid128_Generic()
+    {
+        _fields.SetUpdateField<WowGuid128>(8, new WowGuid128(0x1122334455667788, 0xAABBCCDDEEFF0011));
+    }
+
+    [Benchmark]
+    public void SetUpdateField_WowGuid128_Direct()
+    {
+        _fields.SetUpdateField(8, new WowGuid128(0x1122334455667788, 0xAABBCCDDEEFF0011));
+    }
+
+    [Benchmark]
+    public void SetUpdateField_ByteWithOffset()
+    {
+        _fields.SetUpdateField<byte>(12, 0xAB, 2);
+    }
+
+    [Benchmark]
+    public void SetUpdateField_UShortWithOffset()
+    {
+        _fields.SetUpdateField<ushort>(13, 0xBEEF, 1);
+    }
+}
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class UpdateFieldsArrayGetBenchmarks
+{
+    private UpdateFieldsArray _fields = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _fields = new UpdateFieldsArray(128);
+        // Pre-populate with values
+        _fields.SetUpdateField<uint>(0, 0xDEADBEEFu);
+        _fields.SetUpdateField<int>(1, -42);
+        _fields.SetUpdateField<float>(2, 3.14159f);
+        _fields.SetUpdateField<ulong>(4, 0x123456789ABCDEF0ul);
+        _fields.SetUpdateField<WowGuid128>(8, new WowGuid128(0x1122334455667788, 0xAABBCCDDEEFF0011));
+    }
+
+    [Benchmark(Baseline = true)]
+    public uint GetUpdateField_UInt32()
+    {
+        return _fields.GetUpdateField<uint>(0);
+    }
+
+    [Benchmark]
+    public int GetUpdateField_Int32()
+    {
+        return _fields.GetUpdateField<int>(1);
+    }
+
+    [Benchmark]
+    public float GetUpdateField_Float()
+    {
+        return _fields.GetUpdateField<float>(2);
+    }
+
+    [Benchmark]
+    public ulong GetUpdateField_UInt64()
+    {
+        return _fields.GetUpdateField<ulong>(4);
+    }
+
+    [Benchmark]
+    public WowGuid128 GetUpdateField_WowGuid128_Generic()
+    {
+        return _fields.GetUpdateField<WowGuid128>(8);
+    }
+
+    [Benchmark]
+    public WowGuid128 GetUpdateField_WowGuid128_Direct()
+    {
+        return _fields.GetUpdateFieldGuid(8);
+    }
+}
+
+[MemoryDiagnoser]
+[ShortRunJob]
+public class UpdateFieldsArrayMixedBenchmarks
+{
+    private UpdateFieldsArray _fields = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _fields = new UpdateFieldsArray(256);
+    }
+
+    /// <summary>
+    /// Simulates a realistic object update: set ~20 fields of mixed types, then serialize.
+    /// This is the hot path for every object update packet.
+    /// </summary>
+    [Benchmark]
+    public byte[] RealisticObjectUpdate()
+    {
+        // Typical unit update fields
+        _fields.SetUpdateField<uint>(0, 1u);             // ObjectType
+        _fields.SetUpdateField<float>(1, 100.0f);        // ScaleX
+        _fields.SetUpdateField<ulong>(6, 0x12345678ul);  // Charm GUID low
+        _fields.SetUpdateField<uint>(20, 35u);            // Level
+        _fields.SetUpdateField<uint>(22, 1u);             // FactionTemplate
+        _fields.SetUpdateField<uint>(36, 100u);           // Health
+        _fields.SetUpdateField<uint>(37, 100u);           // MaxHealth
+        _fields.SetUpdateField<uint>(38, 50u);            // Power
+        _fields.SetUpdateField<uint>(39, 50u);            // MaxPower
+        _fields.SetUpdateField<float>(44, 1.0f);          // MinDamage
+        _fields.SetUpdateField<float>(45, 5.0f);          // MaxDamage
+        _fields.SetUpdateField<byte>(46, 1, 0);           // StandState
+        _fields.SetUpdateField<byte>(46, 0, 1);           // PetTalentPoints
+        _fields.SetUpdateField<byte>(46, 0, 2);           // VisFlags
+        _fields.SetUpdateField<byte>(46, 0, 3);           // AnimTier
+
+        var buffer = new ByteBuffer();
+        _fields.WriteToPacket(buffer);
+        var data = buffer.GetData();
+        buffer.Dispose();
+        return data;
+    }
+}

--- a/HermesProxy.Tests/World/MonsterMoveTests.cs
+++ b/HermesProxy.Tests/World/MonsterMoveTests.cs
@@ -15,7 +15,7 @@ public class MonsterMoveConstructorTests
     static MonsterMoveConstructorTests()
     {
         if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
-            global::Framework.Settings.ClientBuild = ClientVersionBuild.V9_0_1_36216;
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
     }
 
     private static WowGuid128 TestGuid => WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
@@ -96,7 +96,7 @@ public class MonsterMoveWriteTests
     static MonsterMoveWriteTests()
     {
         if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
-            global::Framework.Settings.ClientBuild = ClientVersionBuild.V9_0_1_36216;
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
     }
 
     private static WowGuid128 TestGuid => WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);

--- a/HermesProxy.Tests/World/MonsterMoveTests.cs
+++ b/HermesProxy.Tests/World/MonsterMoveTests.cs
@@ -1,0 +1,205 @@
+using System.Collections.Generic;
+using Framework.GameMath;
+using Framework.IO;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class MonsterMoveConstructorTests
+{
+    static MonsterMoveConstructorTests()
+    {
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V9_0_1_36216;
+    }
+
+    private static WowGuid128 TestGuid => WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
+
+    private static ServerSideMovement CreateBaseSpline(
+        SplineTypeModern splineType = SplineTypeModern.None,
+        SplineFlagModern flags = SplineFlagModern.None)
+    {
+        return new ServerSideMovement
+        {
+            SplineType = splineType,
+            SplineFlags = flags,
+            SplineId = 1,
+            SplineTimeFull = 1000,
+            SplineMode = 0,
+            StartPosition = new Vector3(100f, 200f, 300f),
+            EndPosition = new Vector3(110f, 210f, 310f),
+            TransportGuid = WowGuid128.Empty,
+            TransportSeat = 0,
+            FinalOrientation = 1.5f,
+            FinalFacingSpot = new Vector3(120f, 220f, 320f),
+            FinalFacingGuid = WowGuid128.Create(HighGuidType703.Player, 99),
+        };
+    }
+
+    [Fact]
+    public void Constructor_UncompressedPath_AddsPointsAndEndPosition()
+    {
+        var spline = CreateBaseSpline(flags: SplineFlagModern.UncompressedPath);
+        spline.SplinePoints = new List<Vector3>
+        {
+            new(101f, 201f, 301f),
+            new(102f, 202f, 302f),
+        };
+
+        var packet = new MonsterMove(TestGuid, spline);
+
+        // SplinePoints + EndPosition
+        Assert.Equal(3, packet.Points.Count);
+        Assert.Empty(packet.PackedDeltas);
+    }
+
+    [Fact]
+    public void Constructor_CompressedPath_CalculatesDeltas()
+    {
+        var spline = CreateBaseSpline(); // No UncompressedPath flag
+        spline.SplinePoints = new List<Vector3>
+        {
+            new(104f, 204f, 304f),
+            new(106f, 206f, 306f),
+        };
+
+        var packet = new MonsterMove(TestGuid, spline);
+
+        // EndPosition added as point
+        Assert.Single(packet.Points);
+        Assert.Equal(spline.EndPosition, packet.Points[0]);
+        // Deltas calculated from midpoint
+        Assert.Equal(2, packet.PackedDeltas.Count);
+    }
+
+    [Fact]
+    public void Constructor_NoEndPosition_NoPointsAdded()
+    {
+        var spline = CreateBaseSpline();
+        spline.EndPosition = Vector3.Zero;
+        spline.SplinePoints = new List<Vector3>();
+
+        var packet = new MonsterMove(TestGuid, spline);
+
+        Assert.Empty(packet.Points);
+        Assert.Empty(packet.PackedDeltas);
+    }
+}
+
+public class MonsterMoveWriteTests
+{
+    static MonsterMoveWriteTests()
+    {
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V9_0_1_36216;
+    }
+
+    private static WowGuid128 TestGuid => WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
+
+    private static ServerSideMovement CreateSpline(SplineTypeModern splineType)
+    {
+        return new ServerSideMovement
+        {
+            SplineType = splineType,
+            SplineFlags = SplineFlagModern.None,
+            SplineId = 1,
+            SplineTimeFull = 1000,
+            SplineMode = 0,
+            StartPosition = new Vector3(100f, 200f, 300f),
+            EndPosition = new Vector3(110f, 210f, 310f),
+            TransportGuid = WowGuid128.Empty,
+            TransportSeat = 0,
+            FinalOrientation = 1.5f,
+            FinalFacingSpot = new Vector3(120f, 220f, 320f),
+            FinalFacingGuid = WowGuid128.Create(HighGuidType703.Player, 99),
+            SplinePoints = new List<Vector3>(),
+        };
+    }
+
+    [Theory]
+    [InlineData(SplineTypeModern.FacingSpot)]
+    [InlineData(SplineTypeModern.FacingTarget)]
+    [InlineData(SplineTypeModern.FacingAngle)]
+    [InlineData(SplineTypeModern.None)]
+    public void WriteToSpan_MatchesWrite(SplineTypeModern splineType)
+    {
+        var spline = CreateSpline(splineType);
+        var packet1 = new MonsterMove(TestGuid, spline);
+        var packet2 = new MonsterMove(TestGuid, spline);
+
+        // Write via ByteBuffer path
+        packet1.Write();
+        packet1.WritePacketData();
+        byte[] byteBufferData = packet1.GetData()!;
+
+        // Write via Span path
+        byte[] spanBuffer = new byte[packet2.MaxSize];
+        int written = packet2.WriteToSpan(spanBuffer);
+
+        Assert.True(written > 0, $"WriteToSpan should succeed for {splineType}");
+        Assert.Equal(byteBufferData.Length, written);
+        Assert.Equal(byteBufferData, spanBuffer[..written]);
+    }
+
+    [Fact]
+    public void WriteToSpan_WithPoints_MatchesWrite()
+    {
+        var spline = CreateSpline(SplineTypeModern.None);
+        spline.SplineFlags = SplineFlagModern.UncompressedPath;
+        spline.SplinePoints = new List<Vector3>
+        {
+            new(101f, 201f, 301f),
+            new(102f, 202f, 302f),
+            new(103f, 203f, 303f),
+        };
+        var packet1 = new MonsterMove(TestGuid, spline);
+        var packet2 = new MonsterMove(TestGuid, spline);
+
+        packet1.Write();
+        packet1.WritePacketData();
+        byte[] byteBufferData = packet1.GetData()!;
+
+        byte[] spanBuffer = new byte[packet2.MaxSize];
+        int written = packet2.WriteToSpan(spanBuffer);
+
+        Assert.True(written > 0);
+        Assert.Equal(byteBufferData.Length, written);
+        Assert.Equal(byteBufferData, spanBuffer[..written]);
+    }
+
+    [Fact]
+    public void WriteToSpan_ExceedsMaxPoints_ReturnsMinus1()
+    {
+        var spline = CreateSpline(SplineTypeModern.None);
+        spline.SplineFlags = SplineFlagModern.UncompressedPath;
+        // Create more than MaxSplinePoints (16) points
+        spline.SplinePoints = new List<Vector3>();
+        for (int i = 0; i < 20; i++)
+            spline.SplinePoints.Add(new Vector3(i, i, i));
+
+        var packet = new MonsterMove(TestGuid, spline);
+
+        byte[] spanBuffer = new byte[2048];
+        int written = packet.WriteToSpan(spanBuffer);
+
+        Assert.Equal(-1, written);
+    }
+
+    [Fact]
+    public void WriteToSpan_ReturnsPositiveBytesWritten()
+    {
+        var spline = CreateSpline(SplineTypeModern.FacingSpot);
+        var packet = new MonsterMove(TestGuid, spline);
+
+        byte[] spanBuffer = new byte[packet.MaxSize];
+        int written = packet.WriteToSpan(spanBuffer);
+
+        Assert.True(written > 0);
+        Assert.True(written <= packet.MaxSize);
+    }
+}

--- a/HermesProxy.Tests/World/ObjectUpdateTests.cs
+++ b/HermesProxy.Tests/World/ObjectUpdateTests.cs
@@ -13,7 +13,7 @@ public class ObjectUpdateConstructorTests
     static ObjectUpdateConstructorTests()
     {
         if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
-            global::Framework.Settings.ClientBuild = ClientVersionBuild.V9_0_1_36216;
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
     }
 
     private static GlobalSessionData CreateGlobalSession()
@@ -130,7 +130,7 @@ public class ObjectUpdateFieldExclusivityTests
     static ObjectUpdateFieldExclusivityTests()
     {
         if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
-            global::Framework.Settings.ClientBuild = ClientVersionBuild.V9_0_1_36216;
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
     }
 
     private static GlobalSessionData CreateGlobalSession()

--- a/HermesProxy.Tests/World/ObjectUpdateTests.cs
+++ b/HermesProxy.Tests/World/ObjectUpdateTests.cs
@@ -1,0 +1,229 @@
+using System.Runtime.CompilerServices;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class ObjectUpdateConstructorTests
+{
+    static ObjectUpdateConstructorTests()
+    {
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V9_0_1_36216;
+    }
+
+    private static GlobalSessionData CreateGlobalSession()
+    {
+        return (GlobalSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GlobalSessionData));
+    }
+
+    [Fact]
+    public void Constructor_ItemGuid_InitializesItemAndContainerData()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Item, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        Assert.NotNull(update.ItemData);
+        Assert.NotNull(update.ContainerData);
+        Assert.NotNull(update.ObjectData);
+    }
+
+    [Fact]
+    public void Constructor_CreatureGuid_InitializesUnitData()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        Assert.NotNull(update.UnitData);
+    }
+
+    [Fact]
+    public void Constructor_PlayerGuid_InitializesUnitAndPlayerAndActivePlayerData()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Player, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        Assert.NotNull(update.UnitData);
+        Assert.NotNull(update.PlayerData);
+        Assert.NotNull(update.ActivePlayerData);
+    }
+
+    [Fact]
+    public void Constructor_GameObjectGuid_InitializesGameObjectData()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.GameObject, 0, 5678, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        Assert.NotNull(update.GameObjectData);
+    }
+
+    [Fact]
+    public void Constructor_DynamicObjectGuid_InitializesDynamicObjectData()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.DynamicObject, 0, 100, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        Assert.NotNull(update.DynamicObjectData);
+    }
+
+    [Fact]
+    public void Constructor_CorpseGuid_InitializesCorpseData()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Corpse, 0, 200, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        Assert.NotNull(update.CorpseData);
+    }
+
+    [Fact]
+    public void Constructor_CreateObject1_InitializesCreateData()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.CreateObject1, session);
+
+        Assert.NotNull(update.CreateData);
+    }
+
+    [Fact]
+    public void Constructor_CreateObject2_InitializesCreateData()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Player, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.CreateObject2, session);
+
+        Assert.NotNull(update.CreateData);
+    }
+
+    [Fact]
+    public void Constructor_ValuesType_DoesNotInitializeCreateData()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        Assert.Null(update.CreateData);
+    }
+}
+
+public class ObjectUpdateFieldExclusivityTests
+{
+    static ObjectUpdateFieldExclusivityTests()
+    {
+        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
+            global::Framework.Settings.ClientBuild = ClientVersionBuild.V9_0_1_36216;
+    }
+
+    private static GlobalSessionData CreateGlobalSession()
+    {
+        return (GlobalSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GlobalSessionData));
+    }
+
+    [Fact]
+    public void Constructor_ItemGuid_UnitDataIsNull()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Item, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        Assert.Null(update.UnitData);
+        Assert.Null(update.PlayerData);
+        Assert.Null(update.ActivePlayerData);
+        Assert.Null(update.GameObjectData);
+        Assert.Null(update.DynamicObjectData);
+        Assert.Null(update.CorpseData);
+    }
+
+    [Fact]
+    public void Constructor_UnitGuid_ItemDataIsNull()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        Assert.Null(update.ItemData);
+        Assert.Null(update.ContainerData);
+        Assert.Null(update.PlayerData);
+        Assert.Null(update.ActivePlayerData);
+        Assert.Null(update.GameObjectData);
+        Assert.Null(update.DynamicObjectData);
+        Assert.Null(update.CorpseData);
+    }
+
+    [Fact]
+    public void Constructor_PlayerGuid_ItemAndGameObjectDataAreNull()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Player, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        Assert.Null(update.ItemData);
+        Assert.Null(update.ContainerData);
+        Assert.Null(update.GameObjectData);
+        Assert.Null(update.DynamicObjectData);
+        Assert.Null(update.CorpseData);
+    }
+
+    [Fact]
+    public void Constructor_GameObjectGuid_UnitAndItemDataAreNull()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.GameObject, 0, 5678, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        Assert.Null(update.ItemData);
+        Assert.Null(update.ContainerData);
+        Assert.Null(update.UnitData);
+        Assert.Null(update.PlayerData);
+        Assert.Null(update.ActivePlayerData);
+        Assert.Null(update.DynamicObjectData);
+        Assert.Null(update.CorpseData);
+    }
+
+    [Fact]
+    public void Constructor_AlwaysInitializesObjectData()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Player, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        Assert.NotNull(update.ObjectData);
+    }
+
+    [Fact]
+    public void Constructor_StoresGuidAndType()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Player, 42);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.CreateObject1, session);
+
+        Assert.Equal(guid, update.Guid);
+        Assert.Equal(UpdateTypeModern.CreateObject1, update.Type);
+        Assert.Same(session, update.GlobalSession);
+    }
+}

--- a/HermesProxy.Tests/World/UpdateFieldsArrayTests.cs
+++ b/HermesProxy.Tests/World/UpdateFieldsArrayTests.cs
@@ -1,0 +1,490 @@
+using Framework.IO;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class UpdateFieldsArraySetGetTests
+{
+    [Fact]
+    public void SetGetUpdateField_UInt32_RoundTrips()
+    {
+        var fields = new UpdateFieldsArray(10);
+        uint expected = 0xDEADBEEF;
+
+        fields.SetUpdateField<uint>(0, expected);
+
+        Assert.Equal(expected, fields.GetUpdateField<uint>(0));
+    }
+
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(1u)]
+    [InlineData(uint.MaxValue)]
+    [InlineData(0x12345678u)]
+    public void SetGetUpdateField_UInt32_VariousValues(uint value)
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<uint>(0, value);
+
+        Assert.Equal(value, fields.GetUpdateField<uint>(0));
+    }
+
+    [Fact]
+    public void SetGetUpdateField_Int32_RoundTrips()
+    {
+        var fields = new UpdateFieldsArray(10);
+        int expected = -42;
+
+        fields.SetUpdateField<int>(0, expected);
+
+        Assert.Equal(expected, fields.GetUpdateField<int>(0));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    [InlineData(int.MaxValue)]
+    public void SetGetUpdateField_Int32_VariousValues(int value)
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<int>(0, value);
+
+        Assert.Equal(value, fields.GetUpdateField<int>(0));
+    }
+
+    [Fact]
+    public void SetGetUpdateField_Float_RoundTrips()
+    {
+        var fields = new UpdateFieldsArray(10);
+        float expected = 3.14159f;
+
+        fields.SetUpdateField<float>(0, expected);
+
+        Assert.Equal(expected, fields.GetUpdateField<float>(0));
+    }
+
+    [Theory]
+    [InlineData(0.0f)]
+    [InlineData(-1.0f)]
+    [InlineData(float.MaxValue)]
+    [InlineData(float.MinValue)]
+    [InlineData(float.Epsilon)]
+    public void SetGetUpdateField_Float_VariousValues(float value)
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<float>(0, value);
+
+        Assert.Equal(value, fields.GetUpdateField<float>(0));
+    }
+
+    [Fact]
+    public void SetGetUpdateField_UInt64_SpansTwoFields()
+    {
+        var fields = new UpdateFieldsArray(10);
+        ulong expected = 0x123456789ABCDEF0;
+
+        fields.SetUpdateField<ulong>(0, expected);
+
+        Assert.Equal(expected, fields.GetUpdateField<ulong>(0));
+    }
+
+    [Theory]
+    [InlineData(0UL)]
+    [InlineData(ulong.MaxValue)]
+    [InlineData(0x00000000FFFFFFFFul)]
+    [InlineData(0xFFFFFFFF00000000ul)]
+    public void SetGetUpdateField_UInt64_VariousValues(ulong value)
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<ulong>(0, value);
+
+        Assert.Equal(value, fields.GetUpdateField<ulong>(0));
+    }
+
+    [Fact]
+    public void SetGetUpdateField_WowGuid128_SpansFourFields()
+    {
+        var fields = new UpdateFieldsArray(10);
+        var expected = new WowGuid128(0x1122334455667788, 0xAABBCCDDEEFF0011);
+
+        fields.SetUpdateField<WowGuid128>(0, expected);
+
+        var result = fields.GetUpdateField<WowGuid128>(0);
+        Assert.Equal(expected.Low, result.Low);
+        Assert.Equal(expected.High, result.High);
+    }
+
+    [Fact]
+    public void SetUpdateField_WowGuid128_DirectOverload_RoundTrips()
+    {
+        var fields = new UpdateFieldsArray(10);
+        var expected = new WowGuid128(0x1122334455667788, 0xAABBCCDDEEFF0011);
+
+        // Use the direct (non-generic) overload
+        fields.SetUpdateField(0, expected);
+
+        var result = fields.GetUpdateField<WowGuid128>(0);
+        Assert.Equal(expected.Low, result.Low);
+        Assert.Equal(expected.High, result.High);
+    }
+
+    [Fact]
+    public void SetUpdateField_WowGuid128_DirectOverload_SetsMaskBits()
+    {
+        var fields = new UpdateFieldsArray(10);
+        var guid = new WowGuid128(0x1122334455667788, 0xAABBCCDDEEFF0011);
+
+        fields.SetUpdateField(0, guid);
+
+        Assert.True(fields.m_updateMask.GetBit(0));
+        Assert.True(fields.m_updateMask.GetBit(1));
+        Assert.True(fields.m_updateMask.GetBit(2));
+        Assert.True(fields.m_updateMask.GetBit(3));
+    }
+
+    [Fact]
+    public void SetUpdateField_WowGuid128_DirectOverload_SameValue_DoesNotSetMask()
+    {
+        var fields = new UpdateFieldsArray(10);
+        // Default WowGuid128 is all zeros, matching default UpdateValues
+        var empty = WowGuid128.Empty;
+
+        fields.SetUpdateField(0, empty);
+
+        Assert.False(fields.m_updateMask.GetBit(0));
+        Assert.False(fields.m_updateMask.GetBit(1));
+        Assert.False(fields.m_updateMask.GetBit(2));
+        Assert.False(fields.m_updateMask.GetBit(3));
+    }
+
+    [Fact]
+    public void GetUpdateFieldGuid_RoundTrips()
+    {
+        var fields = new UpdateFieldsArray(10);
+        var expected = new WowGuid128(0xDEADBEEFCAFEBABE, 0x1234567890ABCDEF);
+        fields.SetUpdateField(0, expected);
+
+        var result = fields.GetUpdateFieldGuid(0);
+
+        Assert.Equal(expected.Low, result.Low);
+        Assert.Equal(expected.High, result.High);
+    }
+
+    [Fact]
+    public void GetUpdateFieldGuid_MatchesGenericPath()
+    {
+        var fields = new UpdateFieldsArray(10);
+        var guid = new WowGuid128(0x1122334455667788, 0xAABBCCDDEEFF0011);
+        fields.SetUpdateField(0, guid);
+
+        var generic = fields.GetUpdateField<WowGuid128>(0);
+        var direct = fields.GetUpdateFieldGuid(0);
+
+        Assert.Equal(generic, direct);
+    }
+
+    [Fact]
+    public void SetUpdateField_WowGuid128_DirectAndGeneric_ProduceSameResult()
+    {
+        var fieldsA = new UpdateFieldsArray(10);
+        var fieldsB = new UpdateFieldsArray(10);
+        var guid = new WowGuid128(0xDEADBEEFCAFEBABE, 0x1234567890ABCDEF);
+
+        fieldsA.SetUpdateField<WowGuid128>(0, guid);
+        fieldsB.SetUpdateField(0, guid);
+
+        for (int i = 0; i < 4; i++)
+        {
+            Assert.Equal(fieldsA.m_updateValues[i].UnsignedValue, fieldsB.m_updateValues[i].UnsignedValue);
+            Assert.Equal(fieldsA.m_updateMask.GetBit(i), fieldsB.m_updateMask.GetBit(i));
+        }
+    }
+
+    [Fact]
+    public void SetGetUpdateField_Byte_WithOffset0_PacksCorrectly()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<byte>(0, 0xAB, 0);
+
+        Assert.Equal(0xAB, fields.GetUpdateField<byte>(0, 0));
+    }
+
+    [Fact]
+    public void SetGetUpdateField_Byte_WithOffset3_PacksCorrectly()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<byte>(0, 0xCD, 3);
+
+        Assert.Equal(0xCD, fields.GetUpdateField<byte>(0, 3));
+    }
+
+    [Fact]
+    public void SetGetUpdateField_Byte_MultipleOffsets_Independent()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<byte>(0, 0x11, 0);
+        fields.SetUpdateField<byte>(0, 0x22, 1);
+        fields.SetUpdateField<byte>(0, 0x33, 2);
+        fields.SetUpdateField<byte>(0, 0x44, 3);
+
+        Assert.Equal(0x11, fields.GetUpdateField<byte>(0, 0));
+        Assert.Equal(0x22, fields.GetUpdateField<byte>(0, 1));
+        Assert.Equal(0x33, fields.GetUpdateField<byte>(0, 2));
+        Assert.Equal(0x44, fields.GetUpdateField<byte>(0, 3));
+        // All four bytes packed into one uint32
+        Assert.Equal(0x44332211u, fields.GetUpdateField<uint>(0));
+    }
+
+    [Fact]
+    public void SetGetUpdateField_UShort_WithOffset0_PacksCorrectly()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<ushort>(0, 0xBEEF, 0);
+
+        Assert.Equal((ushort)0xBEEF, fields.GetUpdateField<ushort>(0, 0));
+    }
+
+    [Fact]
+    public void SetGetUpdateField_UShort_WithOffset1_PacksCorrectly()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<ushort>(0, 0xDEAD, 1);
+
+        Assert.Equal((ushort)0xDEAD, fields.GetUpdateField<ushort>(0, 1));
+    }
+
+    [Fact]
+    public void SetGetUpdateField_UShort_BothOffsets_Independent()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<ushort>(0, 0xBEEF, 0);
+        fields.SetUpdateField<ushort>(0, 0xDEAD, 1);
+
+        Assert.Equal((ushort)0xBEEF, fields.GetUpdateField<ushort>(0, 0));
+        Assert.Equal((ushort)0xDEAD, fields.GetUpdateField<ushort>(0, 1));
+        Assert.Equal(0xDEADBEEFu, fields.GetUpdateField<uint>(0));
+    }
+}
+
+public class UpdateFieldsArrayMaskTests
+{
+    [Fact]
+    public void SetUpdateField_SetsUpdateMaskBit()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<uint>(3, 42u);
+
+        Assert.True(fields.m_updateMask.GetBit(3));
+    }
+
+    [Fact]
+    public void SetUpdateField_UntouchedFields_MaskBitNotSet()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<uint>(3, 42u);
+
+        Assert.False(fields.m_updateMask.GetBit(0));
+        Assert.False(fields.m_updateMask.GetBit(1));
+        Assert.False(fields.m_updateMask.GetBit(2));
+    }
+
+    [Fact]
+    public void SetUpdateField_SameValue_DoesNotSetMaskBit()
+    {
+        var fields = new UpdateFieldsArray(10);
+        // Default value for uint is 0, so setting 0 should not dirty the field
+        fields.SetUpdateField<uint>(0, 0u);
+
+        Assert.False(fields.m_updateMask.GetBit(0));
+    }
+
+    [Fact]
+    public void SetUpdateField_DifferentValue_SetsMaskBit()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<uint>(0, 1u);
+
+        Assert.True(fields.m_updateMask.GetBit(0));
+    }
+
+    [Fact]
+    public void SetUpdateField_UInt64_SetsTwoMaskBits()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<ulong>(2, 0x0000000100000001ul);
+
+        Assert.True(fields.m_updateMask.GetBit(2));
+        Assert.True(fields.m_updateMask.GetBit(3));
+    }
+}
+
+public class UpdateFieldsArrayFlagTests
+{
+    [Fact]
+    public void AddFlag_SetsSpecificBits()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.AddFlag(0, 0x04u);
+
+        Assert.True(fields.HasFlag(0, 0x04u));
+        Assert.Equal(0x04u, fields.GetUpdateField<uint>(0));
+    }
+
+    [Fact]
+    public void AddFlag_MultipleBits_Accumulates()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.AddFlag(0, 0x01u);
+        fields.AddFlag(0, 0x04u);
+        fields.AddFlag(0, 0x10u);
+
+        Assert.True(fields.HasFlag(0, 0x01u));
+        Assert.True(fields.HasFlag(0, 0x04u));
+        Assert.True(fields.HasFlag(0, 0x10u));
+        Assert.Equal(0x15u, fields.GetUpdateField<uint>(0));
+    }
+
+    [Fact]
+    public void RemoveFlag_ClearsSpecificBits()
+    {
+        var fields = new UpdateFieldsArray(10);
+        fields.SetUpdateField<uint>(0, 0xFFu);
+
+        fields.RemoveFlag(0, 0x0Fu);
+
+        Assert.Equal(0xF0u, fields.GetUpdateField<uint>(0));
+        Assert.False(fields.HasFlag(0, 0x0Fu));
+        Assert.True(fields.HasFlag(0, 0xF0u));
+    }
+
+    [Fact]
+    public void HasFlag_ReturnsFalseForUnsetBits()
+    {
+        var fields = new UpdateFieldsArray(10);
+        fields.SetUpdateField<uint>(0, 0x0Fu);
+
+        Assert.False(fields.HasFlag(0, 0x10u));
+    }
+
+    [Fact]
+    public void HasFlag_OutOfBounds_ReturnsFalse()
+    {
+        var fields = new UpdateFieldsArray(5);
+
+        Assert.False(fields.HasFlag(10, 0x01u));
+    }
+
+    [Fact]
+    public void ApplyFlag_True_SetsFlag()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.ApplyFlag(0, 0x08u, true);
+
+        Assert.True(fields.HasFlag(0, 0x08u));
+    }
+
+    [Fact]
+    public void ApplyFlag_False_ClearsFlag()
+    {
+        var fields = new UpdateFieldsArray(10);
+        fields.SetUpdateField<uint>(0, 0xFFu);
+
+        fields.ApplyFlag(0, 0x08u, false);
+
+        Assert.False(fields.HasFlag(0, 0x08u));
+    }
+}
+
+public class UpdateFieldsArrayWriteTests
+{
+    [Fact]
+    public void WriteToPacket_WritesOnlyDirtyFields()
+    {
+        var fields = new UpdateFieldsArray(8);
+        fields.SetUpdateField<uint>(1, 0x11111111u);
+        fields.SetUpdateField<uint>(5, 0x55555555u);
+
+        var buffer = new ByteBuffer();
+        fields.WriteToPacket(buffer);
+
+        // Buffer should contain mask + only the 2 dirty field values
+        var data = buffer.GetData();
+        Assert.True(data.Length > 0);
+        buffer.Dispose();
+    }
+
+    [Fact]
+    public void WriteToPacket_NoDirtyFields_WritesOnlyMask()
+    {
+        var fields = new UpdateFieldsArray(8);
+
+        var buffer = new ByteBuffer();
+        fields.WriteToPacket(buffer);
+
+        var data = buffer.GetData();
+        // Should have mask data but no field data
+        Assert.True(data.Length > 0);
+        buffer.Dispose();
+    }
+}
+
+public class UpdateFieldsArrayMultiFieldTests
+{
+    [Fact]
+    public void SetUpdateField_MultipleIndices_Independent()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<uint>(0, 100u);
+        fields.SetUpdateField<uint>(1, 200u);
+        fields.SetUpdateField<uint>(2, 300u);
+
+        Assert.Equal(100u, fields.GetUpdateField<uint>(0));
+        Assert.Equal(200u, fields.GetUpdateField<uint>(1));
+        Assert.Equal(300u, fields.GetUpdateField<uint>(2));
+    }
+
+    [Fact]
+    public void SetUpdateField_OverwriteValue_UpdatesCorrectly()
+    {
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<uint>(0, 100u);
+        fields.SetUpdateField<uint>(0, 200u);
+
+        Assert.Equal(200u, fields.GetUpdateField<uint>(0));
+    }
+
+    [Fact]
+    public void SetUpdateField_MixedTypes_SameIndex_OverlappingUnion()
+    {
+        // The underlying UpdateValues is a StructLayout.Explicit union
+        // Setting float at index 0 should reinterpret the bits as uint
+        var fields = new UpdateFieldsArray(10);
+
+        fields.SetUpdateField<float>(0, 1.0f);
+        // 1.0f in IEEE 754 = 0x3F800000
+        Assert.Equal(0x3F800000u, fields.GetUpdateField<uint>(0));
+    }
+}

--- a/HermesProxy/World/Objects/UpdateFieldsArray.cs
+++ b/HermesProxy/World/Objects/UpdateFieldsArray.cs
@@ -117,11 +117,7 @@ public class UpdateFieldsArray
         }
         else if (value is WowGuid128 guid)
         {
-            //if (GetUpdateField<WowGuid128>(index) != guid)
-            //{
-            SetUpdateField<ulong>(index, guid.GetLowValue());
-            SetUpdateField<ulong>((int)index + 2, guid.GetHighValue());
-            //}
+            SetUpdateField(index, guid);
         }
         else
             throw new Exception($"Unhandled type {typeof(T).Name} in SetUpdateField!");
@@ -138,9 +134,48 @@ public class UpdateFieldsArray
             uint => (T)(object)m_updateValues[idx].UnsignedValue,
             float => (T)(object)m_updateValues[idx].FloatValue,
             ulong => (T)(object)((ulong)m_updateValues[idx + 1].UnsignedValue << 32 | m_updateValues[idx].UnsignedValue),
-            WowGuid128 => (T)(object)new WowGuid128(GetUpdateField<ulong>(index), GetUpdateField<ulong>(idx + 2)),
+            WowGuid128 => (T)(object)GetUpdateFieldGuid(idx),
             _ => throw new Exception($"{typeof(T).Name} is not implemented in GetUpdateField<T>"),
         };
+    }
+
+    public WowGuid128 GetUpdateFieldGuid(object index)
+    {
+        int idx = (int)index;
+        ulong low = (ulong)m_updateValues[idx + 1].UnsignedValue << 32 | m_updateValues[idx].UnsignedValue;
+        ulong high = (ulong)m_updateValues[idx + 3].UnsignedValue << 32 | m_updateValues[idx + 2].UnsignedValue;
+        return new WowGuid128(low, high);
+    }
+
+    public void SetUpdateField(object index, WowGuid128 guid)
+    {
+        int idx = (int)index;
+
+        // Low 8 bytes → indices [idx, idx+1]
+        ulong low = guid.GetLowValue();
+        uint loLo = MathFunctions.Pair64_LoPart(low);
+        uint loHi = MathFunctions.Pair64_HiPart(low);
+        if (m_updateValues[idx].UnsignedValue != loLo ||
+            m_updateValues[idx + 1].UnsignedValue != loHi)
+        {
+            m_updateValues[idx].UnsignedValue = loLo;
+            m_updateValues[idx + 1].UnsignedValue = loHi;
+            m_updateMask.SetBit(idx);
+            m_updateMask.SetBit(idx + 1);
+        }
+
+        // High 8 bytes → indices [idx+2, idx+3]
+        ulong high = guid.GetHighValue();
+        uint hiLo = MathFunctions.Pair64_LoPart(high);
+        uint hiHi = MathFunctions.Pair64_HiPart(high);
+        if (m_updateValues[idx + 2].UnsignedValue != hiLo ||
+            m_updateValues[idx + 3].UnsignedValue != hiHi)
+        {
+            m_updateValues[idx + 2].UnsignedValue = hiLo;
+            m_updateValues[idx + 3].UnsignedValue = hiHi;
+            m_updateMask.SetBit(idx + 2);
+            m_updateMask.SetBit(idx + 3);
+        }
     }
 
     public void _LoadIntoDataField(string data, uint startOffset, uint count)

--- a/HermesProxy/World/Objects/Version/V1_14_0_40237/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V1_14_0_40237/ObjectUpdateBuilder.cs
@@ -674,7 +674,7 @@ public class ObjectUpdateBuilder
 
         ObjectData objectData = m_updateData.ObjectData;
         if (objectData.Guid != default)
-            m_fields.SetUpdateField<WowGuid128>(ObjectField.OBJECT_FIELD_GUID, objectData.Guid);
+            m_fields.SetUpdateField(ObjectField.OBJECT_FIELD_GUID, objectData.Guid);
         if (objectData.EntryID != null)
             m_fields.SetUpdateField<int>(ObjectField.OBJECT_FIELD_ENTRY, (int)objectData.EntryID);
         if (objectData.DynamicFlags != null)
@@ -686,13 +686,13 @@ public class ObjectUpdateBuilder
         if (itemData != null)
         {
             if (itemData.Owner != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_OWNER, itemData.Owner.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_OWNER, itemData.Owner.Value);
             if (itemData.ContainedIn != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_CONTAINED, itemData.ContainedIn.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_CONTAINED, itemData.ContainedIn.Value);
             if (itemData.Creator != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_CREATOR, itemData.Creator.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_CREATOR, itemData.Creator.Value);
             if (itemData.GiftCreator != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_GIFTCREATOR, itemData.GiftCreator.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_GIFTCREATOR, itemData.GiftCreator.Value);
             if (itemData.StackCount != null)
                 m_fields.SetUpdateField<uint>(ItemField.ITEM_FIELD_STACK_COUNT, (uint)itemData.StackCount);
             if (itemData.Duration != null)
@@ -761,7 +761,7 @@ public class ObjectUpdateBuilder
                 int sizePerEntry = 4;
                 if (containerData.Slots[i] != null)
                 {
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, containerData.Slots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, containerData.Slots[i]!.Value);
                 }
             }
             if (containerData.NumSlots != null)
@@ -772,25 +772,25 @@ public class ObjectUpdateBuilder
         if (unitData != null)
         {
             if (unitData.Charm != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CHARM, unitData.Charm.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CHARM, unitData.Charm.Value);
             if (unitData.Summon != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_SUMMON, unitData.Summon.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_SUMMON, unitData.Summon.Value);
             if (unitData.Critter != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CRITTER, unitData.Critter.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CRITTER, unitData.Critter.Value);
             if (unitData.CharmedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CHARMEDBY, unitData.CharmedBy.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CHARMEDBY, unitData.CharmedBy.Value);
             if (unitData.SummonedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_SUMMONEDBY, unitData.SummonedBy.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_SUMMONEDBY, unitData.SummonedBy.Value);
             if (unitData.CreatedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CREATEDBY, unitData.CreatedBy.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CREATEDBY, unitData.CreatedBy.Value);
             if (unitData.DemonCreator != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_DEMON_CREATOR, unitData.DemonCreator.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_DEMON_CREATOR, unitData.DemonCreator.Value);
             if (unitData.LookAtControllerTarget != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_TARGET, unitData.LookAtControllerTarget.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_TARGET, unitData.LookAtControllerTarget.Value);
             if (unitData.Target != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_TARGET, unitData.Target.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_TARGET, unitData.Target.Value);
             if (unitData.BattlePetCompanionGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_BATTLE_PET_COMPANION_GUID, unitData.BattlePetCompanionGUID.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_BATTLE_PET_COMPANION_GUID, unitData.BattlePetCompanionGUID.Value);
             if (unitData.BattlePetDBID != null)
                 m_fields.SetUpdateField<ulong>(UnitField.UNIT_FIELD_BATTLE_PET_DB_ID, (ulong)unitData.BattlePetDBID);
             if (unitData.ChannelData != null)
@@ -1073,7 +1073,7 @@ public class ObjectUpdateBuilder
             if (unitData.LookAtControllerID != null)
                 m_fields.SetUpdateField<int>(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_ID, (int)unitData.LookAtControllerID);
             if (unitData.GuildGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_GUILD_GUID, unitData.GuildGUID.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_GUILD_GUID, unitData.GuildGUID.Value);
 
             // Dynamic Fields
             if (unitData.ChannelObject != null)
@@ -1084,11 +1084,11 @@ public class ObjectUpdateBuilder
         if (playerData != null)
         {
             if (playerData.DuelArbiter != null)
-                m_fields.SetUpdateField<WowGuid128>(PlayerField.PLAYER_DUEL_ARBITER, playerData.DuelArbiter.Value);
+                m_fields.SetUpdateField(PlayerField.PLAYER_DUEL_ARBITER, playerData.DuelArbiter.Value);
             if (playerData.WowAccount != null)
-                m_fields.SetUpdateField<WowGuid128>(PlayerField.PLAYER_WOW_ACCOUNT, playerData.WowAccount.Value);
+                m_fields.SetUpdateField(PlayerField.PLAYER_WOW_ACCOUNT, playerData.WowAccount.Value);
             if (playerData.LootTargetGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(PlayerField.PLAYER_LOOT_TARGET_GUID, playerData.LootTargetGUID.Value);
+                m_fields.SetUpdateField(PlayerField.PLAYER_LOOT_TARGET_GUID, playerData.LootTargetGUID.Value);
             if (playerData.PlayerFlags != null)
                 m_fields.SetUpdateField<uint>(PlayerField.PLAYER_FLAGS, (uint)playerData.PlayerFlags);
             if (playerData.PlayerFlagsEx != null)
@@ -1195,49 +1195,49 @@ public class ObjectUpdateBuilder
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD;
                 int sizePerEntry = 4;
                 if (activeData.InvSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.InvSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.InvSlots[i]!.Value);
             }
             for (int i = 0; i < 24; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.ItemStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.PackSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.PackSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.PackSlots[i]!.Value);
             }
             for (int i = 0; i < 28; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.BankItemStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.BankSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.BankSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.BankSlots[i]!.Value);
             }
             for (int i = 0; i < 7; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.BankBagStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.BankBagSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.BankBagSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.BankBagSlots[i]!.Value);
             }
             for (int i = 0; i < 12; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.BuyBackStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.BuyBackSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.BuyBackSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.BuyBackSlots[i]!.Value);
             }
             for (int i = 0; i < 32; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.KeyringStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.KeyringSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.KeyringSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.KeyringSlots[i]!.Value);
             }
             if (activeData.FarsightObject != null)
-                m_fields.SetUpdateField<WowGuid128>(ActivePlayerField.ACTIVE_PLAYER_FIELD_FARSIGHT, activeData.FarsightObject.Value);
+                m_fields.SetUpdateField(ActivePlayerField.ACTIVE_PLAYER_FIELD_FARSIGHT, activeData.FarsightObject.Value);
             if (activeData.ComboTarget != null)
-                m_fields.SetUpdateField<WowGuid128>(ActivePlayerField.ACTIVE_PLAYER_FIELD_COMBO_TARGET, activeData.ComboTarget.Value);
+                m_fields.SetUpdateField(ActivePlayerField.ACTIVE_PLAYER_FIELD_COMBO_TARGET, activeData.ComboTarget.Value);
             if (activeData.SummonedBattlePetGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(ActivePlayerField.ACTIVE_PLAYER_FIELD_SUMMONED_BATTLE_PET_ID, activeData.SummonedBattlePetGUID.Value);
+                m_fields.SetUpdateField(ActivePlayerField.ACTIVE_PLAYER_FIELD_SUMMONED_BATTLE_PET_ID, activeData.SummonedBattlePetGUID.Value);
             for (int i = 0; i < 12; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_KNOWN_TITLES;
@@ -1608,7 +1608,7 @@ public class ObjectUpdateBuilder
         if (goData != null)
         {
             if (goData.CreatedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(GameObjectField.GAMEOBJECT_FIELD_CREATED_BY, goData.CreatedBy.Value);
+                m_fields.SetUpdateField(GameObjectField.GAMEOBJECT_FIELD_CREATED_BY, goData.CreatedBy.Value);
             if (goData.DisplayID != null)
                 m_fields.SetUpdateField<int>(GameObjectField.GAMEOBJECT_DISPLAYID, (int)goData.DisplayID);
             if (goData.Flags != null)
@@ -1656,7 +1656,7 @@ public class ObjectUpdateBuilder
         if (dynData != null)
         {
             if (dynData.Caster != null)
-                m_fields.SetUpdateField<WowGuid128>(DynamicObjectField.DYNAMICOBJECT_CASTER, dynData.Caster.Value);
+                m_fields.SetUpdateField(DynamicObjectField.DYNAMICOBJECT_CASTER, dynData.Caster.Value);
             if (dynData.Type != null)
                 m_fields.SetUpdateField<uint>(DynamicObjectField.DYNAMICOBJECT_TYPE, (uint)dynData.Type);
             if (dynData.SpellXSpellVisualID != null)
@@ -1673,11 +1673,11 @@ public class ObjectUpdateBuilder
         if (corpseData != null)
         {
             if (corpseData.Owner != null)
-                m_fields.SetUpdateField<WowGuid128>(CorpseField.CORPSE_FIELD_OWNER, corpseData.Owner.Value);
+                m_fields.SetUpdateField(CorpseField.CORPSE_FIELD_OWNER, corpseData.Owner.Value);
             if (corpseData.PartyGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(CorpseField.CORPSE_FIELD_PARTY_GUID, corpseData.PartyGUID.Value);
+                m_fields.SetUpdateField(CorpseField.CORPSE_FIELD_PARTY_GUID, corpseData.PartyGUID.Value);
             if (corpseData.GuildGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(CorpseField.CORPSE_FIELD_GUILD_GUID, corpseData.GuildGUID.Value);
+                m_fields.SetUpdateField(CorpseField.CORPSE_FIELD_GUILD_GUID, corpseData.GuildGUID.Value);
             if (corpseData.DisplayID != null)
                 m_fields.SetUpdateField<uint>(CorpseField.CORPSE_FIELD_DISPLAY_ID, (uint)corpseData.DisplayID);
             for (int i = 0; i < 19; i++)

--- a/HermesProxy/World/Objects/Version/V1_14_1_40688/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V1_14_1_40688/ObjectUpdateBuilder.cs
@@ -674,7 +674,7 @@ public class ObjectUpdateBuilder
 
         ObjectData objectData = m_updateData.ObjectData;
         if (objectData.Guid != default)
-            m_fields.SetUpdateField<WowGuid128>(ObjectField.OBJECT_FIELD_GUID, objectData.Guid);
+            m_fields.SetUpdateField(ObjectField.OBJECT_FIELD_GUID, objectData.Guid);
         if (objectData.EntryID != null)
             m_fields.SetUpdateField<int>(ObjectField.OBJECT_FIELD_ENTRY, (int)objectData.EntryID);
         if (objectData.DynamicFlags != null)
@@ -686,13 +686,13 @@ public class ObjectUpdateBuilder
         if (itemData != null)
         {
             if (itemData.Owner != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_OWNER, itemData.Owner.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_OWNER, itemData.Owner.Value);
             if (itemData.ContainedIn != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_CONTAINED, itemData.ContainedIn.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_CONTAINED, itemData.ContainedIn.Value);
             if (itemData.Creator != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_CREATOR, itemData.Creator.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_CREATOR, itemData.Creator.Value);
             if (itemData.GiftCreator != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_GIFTCREATOR, itemData.GiftCreator.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_GIFTCREATOR, itemData.GiftCreator.Value);
             if (itemData.StackCount != null)
                 m_fields.SetUpdateField<uint>(ItemField.ITEM_FIELD_STACK_COUNT, (uint)itemData.StackCount);
             if (itemData.Duration != null)
@@ -761,7 +761,7 @@ public class ObjectUpdateBuilder
                 int sizePerEntry = 4;
                 if (containerData.Slots[i] != null)
                 {
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, containerData.Slots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, containerData.Slots[i]!.Value);
                 }
             }
             if (containerData.NumSlots != null)
@@ -772,25 +772,25 @@ public class ObjectUpdateBuilder
         if (unitData != null)
         {
             if (unitData.Charm != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CHARM, unitData.Charm.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CHARM, unitData.Charm.Value);
             if (unitData.Summon != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_SUMMON, unitData.Summon.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_SUMMON, unitData.Summon.Value);
             if (unitData.Critter != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CRITTER, unitData.Critter.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CRITTER, unitData.Critter.Value);
             if (unitData.CharmedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CHARMEDBY, unitData.CharmedBy.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CHARMEDBY, unitData.CharmedBy.Value);
             if (unitData.SummonedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_SUMMONEDBY, unitData.SummonedBy.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_SUMMONEDBY, unitData.SummonedBy.Value);
             if (unitData.CreatedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CREATEDBY, unitData.CreatedBy.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CREATEDBY, unitData.CreatedBy.Value);
             if (unitData.DemonCreator != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_DEMON_CREATOR, unitData.DemonCreator.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_DEMON_CREATOR, unitData.DemonCreator.Value);
             if (unitData.LookAtControllerTarget != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_TARGET, unitData.LookAtControllerTarget.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_TARGET, unitData.LookAtControllerTarget.Value);
             if (unitData.Target != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_TARGET, unitData.Target.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_TARGET, unitData.Target.Value);
             if (unitData.BattlePetCompanionGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_BATTLE_PET_COMPANION_GUID, unitData.BattlePetCompanionGUID.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_BATTLE_PET_COMPANION_GUID, unitData.BattlePetCompanionGUID.Value);
             if (unitData.BattlePetDBID != null)
                 m_fields.SetUpdateField<ulong>(UnitField.UNIT_FIELD_BATTLE_PET_DB_ID, (ulong)unitData.BattlePetDBID);
             if (unitData.ChannelData != null)
@@ -1073,7 +1073,7 @@ public class ObjectUpdateBuilder
             if (unitData.LookAtControllerID != null)
                 m_fields.SetUpdateField<int>(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_ID, (int)unitData.LookAtControllerID);
             if (unitData.GuildGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_GUILD_GUID, unitData.GuildGUID.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_GUILD_GUID, unitData.GuildGUID.Value);
 
             // Dynamic Fields
             if (unitData.ChannelObject != null)
@@ -1084,11 +1084,11 @@ public class ObjectUpdateBuilder
         if (playerData != null)
         {
             if (playerData.DuelArbiter != null)
-                m_fields.SetUpdateField<WowGuid128>(PlayerField.PLAYER_DUEL_ARBITER, playerData.DuelArbiter.Value);
+                m_fields.SetUpdateField(PlayerField.PLAYER_DUEL_ARBITER, playerData.DuelArbiter.Value);
             if (playerData.WowAccount != null)
-                m_fields.SetUpdateField<WowGuid128>(PlayerField.PLAYER_WOW_ACCOUNT, playerData.WowAccount.Value);
+                m_fields.SetUpdateField(PlayerField.PLAYER_WOW_ACCOUNT, playerData.WowAccount.Value);
             if (playerData.LootTargetGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(PlayerField.PLAYER_LOOT_TARGET_GUID, playerData.LootTargetGUID.Value);
+                m_fields.SetUpdateField(PlayerField.PLAYER_LOOT_TARGET_GUID, playerData.LootTargetGUID.Value);
             if (playerData.PlayerFlags != default)
                 m_fields.SetUpdateField<uint>(PlayerField.PLAYER_FLAGS, (uint)playerData.PlayerFlags!);
             if (playerData.PlayerFlagsEx != null)
@@ -1195,49 +1195,49 @@ public class ObjectUpdateBuilder
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD;
                 int sizePerEntry = 4;
                 if (activeData.InvSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.InvSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.InvSlots[i]!.Value);
             }
             for (int i = 0; i < 24; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.ItemStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.PackSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.PackSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.PackSlots[i]!.Value);
             }
             for (int i = 0; i < 28; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.BankItemStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.BankSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.BankSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.BankSlots[i]!.Value);
             }
             for (int i = 0; i < 7; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.BankBagStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.BankBagSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.BankBagSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.BankBagSlots[i]!.Value);
             }
             for (int i = 0; i < 12; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.BuyBackStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.BuyBackSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.BuyBackSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.BuyBackSlots[i]!.Value);
             }
             for (int i = 0; i < 32; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.KeyringStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.KeyringSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.KeyringSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.KeyringSlots[i]!.Value);
             }
             if (activeData.FarsightObject != null)
-                m_fields.SetUpdateField<WowGuid128>(ActivePlayerField.ACTIVE_PLAYER_FIELD_FARSIGHT, activeData.FarsightObject.Value);
+                m_fields.SetUpdateField(ActivePlayerField.ACTIVE_PLAYER_FIELD_FARSIGHT, activeData.FarsightObject.Value);
             if (activeData.ComboTarget != null)
-                m_fields.SetUpdateField<WowGuid128>(ActivePlayerField.ACTIVE_PLAYER_FIELD_COMBO_TARGET, activeData.ComboTarget.Value);
+                m_fields.SetUpdateField(ActivePlayerField.ACTIVE_PLAYER_FIELD_COMBO_TARGET, activeData.ComboTarget.Value);
             if (activeData.SummonedBattlePetGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(ActivePlayerField.ACTIVE_PLAYER_FIELD_SUMMONED_BATTLE_PET_ID, activeData.SummonedBattlePetGUID.Value);
+                m_fields.SetUpdateField(ActivePlayerField.ACTIVE_PLAYER_FIELD_SUMMONED_BATTLE_PET_ID, activeData.SummonedBattlePetGUID.Value);
             for (int i = 0; i < 12; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_KNOWN_TITLES;
@@ -1608,7 +1608,7 @@ public class ObjectUpdateBuilder
         if (goData != null)
         {
             if (goData.CreatedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(GameObjectField.GAMEOBJECT_FIELD_CREATED_BY, goData.CreatedBy.Value);
+                m_fields.SetUpdateField(GameObjectField.GAMEOBJECT_FIELD_CREATED_BY, goData.CreatedBy.Value);
             if (goData.DisplayID != null)
                 m_fields.SetUpdateField<int>(GameObjectField.GAMEOBJECT_DISPLAYID, (int)goData.DisplayID);
             if (goData.Flags != null)
@@ -1656,7 +1656,7 @@ public class ObjectUpdateBuilder
         if (dynData != null)
         {
             if (dynData.Caster != null)
-                m_fields.SetUpdateField<WowGuid128>(DynamicObjectField.DYNAMICOBJECT_CASTER, dynData.Caster.Value);
+                m_fields.SetUpdateField(DynamicObjectField.DYNAMICOBJECT_CASTER, dynData.Caster.Value);
             if (dynData.Type != null)
                 m_fields.SetUpdateField<uint>(DynamicObjectField.DYNAMICOBJECT_TYPE, (uint)dynData.Type);
             if (dynData.SpellXSpellVisualID != null)
@@ -1673,11 +1673,11 @@ public class ObjectUpdateBuilder
         if (corpseData != null)
         {
             if (corpseData.Owner != null)
-                m_fields.SetUpdateField<WowGuid128>(CorpseField.CORPSE_FIELD_OWNER, corpseData.Owner.Value);
+                m_fields.SetUpdateField(CorpseField.CORPSE_FIELD_OWNER, corpseData.Owner.Value);
             if (corpseData.PartyGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(CorpseField.CORPSE_FIELD_PARTY_GUID, corpseData.PartyGUID.Value);
+                m_fields.SetUpdateField(CorpseField.CORPSE_FIELD_PARTY_GUID, corpseData.PartyGUID.Value);
             if (corpseData.GuildGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(CorpseField.CORPSE_FIELD_GUILD_GUID, corpseData.GuildGUID.Value);
+                m_fields.SetUpdateField(CorpseField.CORPSE_FIELD_GUILD_GUID, corpseData.GuildGUID.Value);
             if (corpseData.DisplayID != null)
                 m_fields.SetUpdateField<uint>(CorpseField.CORPSE_FIELD_DISPLAY_ID, (uint)corpseData.DisplayID);
             for (int i = 0; i < 19; i++)

--- a/HermesProxy/World/Objects/Version/V2_5_2_39570/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V2_5_2_39570/ObjectUpdateBuilder.cs
@@ -674,7 +674,7 @@ public class ObjectUpdateBuilder
 
         ObjectData objectData = m_updateData.ObjectData;
         if (objectData.Guid != default)
-            m_fields.SetUpdateField<WowGuid128>(ObjectField.OBJECT_FIELD_GUID, objectData.Guid);
+            m_fields.SetUpdateField(ObjectField.OBJECT_FIELD_GUID, objectData.Guid);
         if (objectData.EntryID != null)
             m_fields.SetUpdateField<int>(ObjectField.OBJECT_FIELD_ENTRY, (int)objectData.EntryID);
         if (objectData.DynamicFlags != null)
@@ -686,13 +686,13 @@ public class ObjectUpdateBuilder
         if (itemData != null)
         {
             if (itemData.Owner != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_OWNER, itemData.Owner.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_OWNER, itemData.Owner.Value);
             if (itemData.ContainedIn != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_CONTAINED, itemData.ContainedIn.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_CONTAINED, itemData.ContainedIn.Value);
             if (itemData.Creator != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_CREATOR, itemData.Creator.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_CREATOR, itemData.Creator.Value);
             if (itemData.GiftCreator != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_GIFTCREATOR, itemData.GiftCreator.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_GIFTCREATOR, itemData.GiftCreator.Value);
             if (itemData.StackCount != null)
                 m_fields.SetUpdateField<uint>(ItemField.ITEM_FIELD_STACK_COUNT, (uint)itemData.StackCount);
             if (itemData.Duration != null)
@@ -761,7 +761,7 @@ public class ObjectUpdateBuilder
                 int sizePerEntry = 4;
                 if (containerData.Slots[i] != null)
                 {
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, containerData.Slots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, containerData.Slots[i]!.Value);
                 }
             }
             if (containerData.NumSlots != null)
@@ -772,25 +772,25 @@ public class ObjectUpdateBuilder
         if (unitData != null)
         {
             if (unitData.Charm != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CHARM, unitData.Charm.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CHARM, unitData.Charm.Value);
             if (unitData.Summon != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_SUMMON, unitData.Summon.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_SUMMON, unitData.Summon.Value);
             if (unitData.Critter != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CRITTER, unitData.Critter.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CRITTER, unitData.Critter.Value);
             if (unitData.CharmedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CHARMEDBY, unitData.CharmedBy.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CHARMEDBY, unitData.CharmedBy.Value);
             if (unitData.SummonedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_SUMMONEDBY, unitData.SummonedBy.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_SUMMONEDBY, unitData.SummonedBy.Value);
             if (unitData.CreatedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CREATEDBY, unitData.CreatedBy.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CREATEDBY, unitData.CreatedBy.Value);
             if (unitData.DemonCreator != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_DEMON_CREATOR, unitData.DemonCreator.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_DEMON_CREATOR, unitData.DemonCreator.Value);
             if (unitData.LookAtControllerTarget != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_TARGET, unitData.LookAtControllerTarget.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_TARGET, unitData.LookAtControllerTarget.Value);
             if (unitData.Target != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_TARGET, unitData.Target.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_TARGET, unitData.Target.Value);
             if (unitData.BattlePetCompanionGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_BATTLE_PET_COMPANION_GUID, unitData.BattlePetCompanionGUID.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_BATTLE_PET_COMPANION_GUID, unitData.BattlePetCompanionGUID.Value);
             if (unitData.BattlePetDBID != null)
                 m_fields.SetUpdateField<ulong>(UnitField.UNIT_FIELD_BATTLE_PET_DB_ID, (ulong)unitData.BattlePetDBID);
             if (unitData.ChannelData != null)
@@ -1073,7 +1073,7 @@ public class ObjectUpdateBuilder
             if (unitData.LookAtControllerID != null)
                 m_fields.SetUpdateField<int>(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_ID, (int)unitData.LookAtControllerID);
             if (unitData.GuildGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_GUILD_GUID, unitData.GuildGUID.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_GUILD_GUID, unitData.GuildGUID.Value);
 
             // Dynamic Fields
             if (unitData.ChannelObject != null)
@@ -1084,11 +1084,11 @@ public class ObjectUpdateBuilder
         if (playerData != null)
         {
             if (playerData.DuelArbiter != null)
-                m_fields.SetUpdateField<WowGuid128>(PlayerField.PLAYER_DUEL_ARBITER, playerData.DuelArbiter.Value);
+                m_fields.SetUpdateField(PlayerField.PLAYER_DUEL_ARBITER, playerData.DuelArbiter.Value);
             if (playerData.WowAccount != null)
-                m_fields.SetUpdateField<WowGuid128>(PlayerField.PLAYER_WOW_ACCOUNT, playerData.WowAccount.Value);
+                m_fields.SetUpdateField(PlayerField.PLAYER_WOW_ACCOUNT, playerData.WowAccount.Value);
             if (playerData.LootTargetGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(PlayerField.PLAYER_LOOT_TARGET_GUID, playerData.LootTargetGUID.Value);
+                m_fields.SetUpdateField(PlayerField.PLAYER_LOOT_TARGET_GUID, playerData.LootTargetGUID.Value);
             if (playerData.PlayerFlags != null)
                 m_fields.SetUpdateField<uint>(PlayerField.PLAYER_FLAGS, (uint)playerData.PlayerFlags);
             if (playerData.PlayerFlagsEx != null)
@@ -1195,49 +1195,49 @@ public class ObjectUpdateBuilder
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD;
                 int sizePerEntry = 4;
                 if (activeData.InvSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.InvSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.InvSlots[i]!.Value);
             }
             for (int i = 0; i < 24; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.ItemStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.PackSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.PackSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.PackSlots[i]!.Value);
             }
             for (int i = 0; i < 28; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.BankItemStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.BankSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.BankSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.BankSlots[i]!.Value);
             }
             for (int i = 0; i < 7; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.BankBagStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.BankBagSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.BankBagSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.BankBagSlots[i]!.Value);
             }
             for (int i = 0; i < 12; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.BuyBackStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.BuyBackSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.BuyBackSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.BuyBackSlots[i]!.Value);
             }
             for (int i = 0; i < 32; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.KeyringStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.KeyringSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.KeyringSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.KeyringSlots[i]!.Value);
             }
             if (activeData.FarsightObject != null)
-                m_fields.SetUpdateField<WowGuid128>(ActivePlayerField.ACTIVE_PLAYER_FIELD_FARSIGHT, activeData.FarsightObject.Value);
+                m_fields.SetUpdateField(ActivePlayerField.ACTIVE_PLAYER_FIELD_FARSIGHT, activeData.FarsightObject.Value);
             if (activeData.ComboTarget != null)
-                m_fields.SetUpdateField<WowGuid128>(ActivePlayerField.ACTIVE_PLAYER_FIELD_COMBO_TARGET, activeData.ComboTarget.Value);
+                m_fields.SetUpdateField(ActivePlayerField.ACTIVE_PLAYER_FIELD_COMBO_TARGET, activeData.ComboTarget.Value);
             if (activeData.SummonedBattlePetGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(ActivePlayerField.ACTIVE_PLAYER_FIELD_SUMMONED_BATTLE_PET_ID, activeData.SummonedBattlePetGUID.Value);
+                m_fields.SetUpdateField(ActivePlayerField.ACTIVE_PLAYER_FIELD_SUMMONED_BATTLE_PET_ID, activeData.SummonedBattlePetGUID.Value);
             for (int i = 0; i < 12; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_KNOWN_TITLES;
@@ -1596,7 +1596,7 @@ public class ObjectUpdateBuilder
         if (goData != null)
         {
             if (goData.CreatedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(GameObjectField.GAMEOBJECT_FIELD_CREATED_BY, goData.CreatedBy.Value);
+                m_fields.SetUpdateField(GameObjectField.GAMEOBJECT_FIELD_CREATED_BY, goData.CreatedBy.Value);
             if (goData.DisplayID != null)
                 m_fields.SetUpdateField<int>(GameObjectField.GAMEOBJECT_DISPLAYID, (int)goData.DisplayID);
             if (goData.Flags != null)
@@ -1644,7 +1644,7 @@ public class ObjectUpdateBuilder
         if (dynData != null)
         {
             if (dynData.Caster != null)
-                m_fields.SetUpdateField<WowGuid128>(DynamicObjectField.DYNAMICOBJECT_CASTER, dynData.Caster.Value);
+                m_fields.SetUpdateField(DynamicObjectField.DYNAMICOBJECT_CASTER, dynData.Caster.Value);
             if (dynData.Type != null)
                 m_fields.SetUpdateField<uint>(DynamicObjectField.DYNAMICOBJECT_TYPE, (uint)dynData.Type);
             if (dynData.SpellXSpellVisualID != null)
@@ -1661,11 +1661,11 @@ public class ObjectUpdateBuilder
         if (corpseData != null)
         {
             if (corpseData.Owner != null)
-                m_fields.SetUpdateField<WowGuid128>(CorpseField.CORPSE_FIELD_OWNER, corpseData.Owner.Value);
+                m_fields.SetUpdateField(CorpseField.CORPSE_FIELD_OWNER, corpseData.Owner.Value);
             if (corpseData.PartyGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(CorpseField.CORPSE_FIELD_PARTY_GUID, corpseData.PartyGUID.Value);
+                m_fields.SetUpdateField(CorpseField.CORPSE_FIELD_PARTY_GUID, corpseData.PartyGUID.Value);
             if (corpseData.GuildGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(CorpseField.CORPSE_FIELD_GUILD_GUID, corpseData.GuildGUID.Value);
+                m_fields.SetUpdateField(CorpseField.CORPSE_FIELD_GUILD_GUID, corpseData.GuildGUID.Value);
             if (corpseData.DisplayID != null)
                 m_fields.SetUpdateField<uint>(CorpseField.CORPSE_FIELD_DISPLAY_ID, (uint)corpseData.DisplayID);
             for (int i = 0; i < 19; i++)

--- a/HermesProxy/World/Objects/Version/V2_5_3_41750/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V2_5_3_41750/ObjectUpdateBuilder.cs
@@ -674,7 +674,7 @@ public class ObjectUpdateBuilder
 
         ObjectData objectData = m_updateData.ObjectData;
         if (objectData.Guid != default)
-            m_fields.SetUpdateField<WowGuid128>(ObjectField.OBJECT_FIELD_GUID, objectData.Guid);
+            m_fields.SetUpdateField(ObjectField.OBJECT_FIELD_GUID, objectData.Guid);
         if (objectData.EntryID != null)
             m_fields.SetUpdateField<int>(ObjectField.OBJECT_FIELD_ENTRY, (int)objectData.EntryID);
         if (objectData.DynamicFlags != null)
@@ -686,13 +686,13 @@ public class ObjectUpdateBuilder
         if (itemData != null)
         {
             if (itemData.Owner != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_OWNER, itemData.Owner.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_OWNER, itemData.Owner.Value);
             if (itemData.ContainedIn != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_CONTAINED, itemData.ContainedIn.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_CONTAINED, itemData.ContainedIn.Value);
             if (itemData.Creator != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_CREATOR, itemData.Creator.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_CREATOR, itemData.Creator.Value);
             if (itemData.GiftCreator != null)
-                m_fields.SetUpdateField<WowGuid128>(ItemField.ITEM_FIELD_GIFTCREATOR, itemData.GiftCreator.Value);
+                m_fields.SetUpdateField(ItemField.ITEM_FIELD_GIFTCREATOR, itemData.GiftCreator.Value);
             if (itemData.StackCount != null)
                 m_fields.SetUpdateField<uint>(ItemField.ITEM_FIELD_STACK_COUNT, (uint)itemData.StackCount);
             if (itemData.Duration != null)
@@ -761,7 +761,7 @@ public class ObjectUpdateBuilder
                 int sizePerEntry = 4;
                 if (containerData.Slots[i] != null)
                 {
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, containerData.Slots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, containerData.Slots[i]!.Value);
                 }
             }
             if (containerData.NumSlots != null)
@@ -772,25 +772,25 @@ public class ObjectUpdateBuilder
         if (unitData != null)
         {
             if (unitData.Charm != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CHARM, unitData.Charm.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CHARM, unitData.Charm.Value);
             if (unitData.Summon != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_SUMMON, unitData.Summon.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_SUMMON, unitData.Summon.Value);
             if (unitData.Critter != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CRITTER, unitData.Critter.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CRITTER, unitData.Critter.Value);
             if (unitData.CharmedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CHARMEDBY, unitData.CharmedBy.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CHARMEDBY, unitData.CharmedBy.Value);
             if (unitData.SummonedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_SUMMONEDBY, unitData.SummonedBy.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_SUMMONEDBY, unitData.SummonedBy.Value);
             if (unitData.CreatedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_CREATEDBY, unitData.CreatedBy.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_CREATEDBY, unitData.CreatedBy.Value);
             if (unitData.DemonCreator != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_DEMON_CREATOR, unitData.DemonCreator.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_DEMON_CREATOR, unitData.DemonCreator.Value);
             if (unitData.LookAtControllerTarget != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_TARGET, unitData.LookAtControllerTarget.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_TARGET, unitData.LookAtControllerTarget.Value);
             if (unitData.Target != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_TARGET, unitData.Target.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_TARGET, unitData.Target.Value);
             if (unitData.BattlePetCompanionGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_BATTLE_PET_COMPANION_GUID, unitData.BattlePetCompanionGUID.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_BATTLE_PET_COMPANION_GUID, unitData.BattlePetCompanionGUID.Value);
             if (unitData.BattlePetDBID != null)
                 m_fields.SetUpdateField<ulong>(UnitField.UNIT_FIELD_BATTLE_PET_DB_ID, (ulong)unitData.BattlePetDBID);
             if (unitData.ChannelData != null)
@@ -1073,7 +1073,7 @@ public class ObjectUpdateBuilder
             if (unitData.LookAtControllerID != null)
                 m_fields.SetUpdateField<int>(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_ID, (int)unitData.LookAtControllerID);
             if (unitData.GuildGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(UnitField.UNIT_FIELD_GUILD_GUID, unitData.GuildGUID.Value);
+                m_fields.SetUpdateField(UnitField.UNIT_FIELD_GUILD_GUID, unitData.GuildGUID.Value);
 
             // Dynamic Fields
             if (unitData.ChannelObject != null)
@@ -1084,11 +1084,11 @@ public class ObjectUpdateBuilder
         if (playerData != null)
         {
             if (playerData.DuelArbiter != null)
-                m_fields.SetUpdateField<WowGuid128>(PlayerField.PLAYER_DUEL_ARBITER, playerData.DuelArbiter.Value);
+                m_fields.SetUpdateField(PlayerField.PLAYER_DUEL_ARBITER, playerData.DuelArbiter.Value);
             if (playerData.WowAccount != null)
-                m_fields.SetUpdateField<WowGuid128>(PlayerField.PLAYER_WOW_ACCOUNT, playerData.WowAccount.Value);
+                m_fields.SetUpdateField(PlayerField.PLAYER_WOW_ACCOUNT, playerData.WowAccount.Value);
             if (playerData.LootTargetGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(PlayerField.PLAYER_LOOT_TARGET_GUID, playerData.LootTargetGUID.Value);
+                m_fields.SetUpdateField(PlayerField.PLAYER_LOOT_TARGET_GUID, playerData.LootTargetGUID.Value);
             if (playerData.PlayerFlags != null)
                 m_fields.SetUpdateField<uint>(PlayerField.PLAYER_FLAGS, (uint)playerData.PlayerFlags);
             if (playerData.PlayerFlagsEx != null)
@@ -1195,49 +1195,49 @@ public class ObjectUpdateBuilder
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD;
                 int sizePerEntry = 4;
                 if (activeData.InvSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.InvSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.InvSlots[i]!.Value);
             }
             for (int i = 0; i < 24; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.ItemStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.PackSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.PackSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.PackSlots[i]!.Value);
             }
             for (int i = 0; i < 28; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.BankItemStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.BankSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.BankSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.BankSlots[i]!.Value);
             }
             for (int i = 0; i < 7; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.BankBagStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.BankBagSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.BankBagSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.BankBagSlots[i]!.Value);
             }
             for (int i = 0; i < 12; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.BuyBackStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.BuyBackSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.BuyBackSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.BuyBackSlots[i]!.Value);
             }
             for (int i = 0; i < 32; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_INV_SLOT_HEAD + Enums.Classic.InventorySlots.KeyringStart * 4;
                 int sizePerEntry = 4;
                 if (activeData.KeyringSlots[i] != null)
-                    m_fields.SetUpdateField<WowGuid128>(startIndex + i * sizePerEntry, activeData.KeyringSlots[i]!.Value);
+                    m_fields.SetUpdateField(startIndex + i * sizePerEntry, activeData.KeyringSlots[i]!.Value);
             }
             if (activeData.FarsightObject != null)
-                m_fields.SetUpdateField<WowGuid128>(ActivePlayerField.ACTIVE_PLAYER_FIELD_FARSIGHT, activeData.FarsightObject.Value);
+                m_fields.SetUpdateField(ActivePlayerField.ACTIVE_PLAYER_FIELD_FARSIGHT, activeData.FarsightObject.Value);
             if (activeData.ComboTarget != null)
-                m_fields.SetUpdateField<WowGuid128>(ActivePlayerField.ACTIVE_PLAYER_FIELD_COMBO_TARGET, activeData.ComboTarget.Value);
+                m_fields.SetUpdateField(ActivePlayerField.ACTIVE_PLAYER_FIELD_COMBO_TARGET, activeData.ComboTarget.Value);
             if (activeData.SummonedBattlePetGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(ActivePlayerField.ACTIVE_PLAYER_FIELD_SUMMONED_BATTLE_PET_ID, activeData.SummonedBattlePetGUID.Value);
+                m_fields.SetUpdateField(ActivePlayerField.ACTIVE_PLAYER_FIELD_SUMMONED_BATTLE_PET_ID, activeData.SummonedBattlePetGUID.Value);
             for (int i = 0; i < 12; i++)
             {
                 int startIndex = (int)ActivePlayerField.ACTIVE_PLAYER_FIELD_KNOWN_TITLES;
@@ -1608,7 +1608,7 @@ public class ObjectUpdateBuilder
         if (goData != null)
         {
             if (goData.CreatedBy != null)
-                m_fields.SetUpdateField<WowGuid128>(GameObjectField.GAMEOBJECT_FIELD_CREATED_BY, goData.CreatedBy.Value);
+                m_fields.SetUpdateField(GameObjectField.GAMEOBJECT_FIELD_CREATED_BY, goData.CreatedBy.Value);
             if (goData.DisplayID != null)
                 m_fields.SetUpdateField<int>(GameObjectField.GAMEOBJECT_DISPLAYID, (int)goData.DisplayID);
             if (goData.Flags != null)
@@ -1656,7 +1656,7 @@ public class ObjectUpdateBuilder
         if (dynData != null)
         {
             if (dynData.Caster != null)
-                m_fields.SetUpdateField<WowGuid128>(DynamicObjectField.DYNAMICOBJECT_CASTER, dynData.Caster.Value);
+                m_fields.SetUpdateField(DynamicObjectField.DYNAMICOBJECT_CASTER, dynData.Caster.Value);
             if (dynData.Type != null)
                 m_fields.SetUpdateField<uint>(DynamicObjectField.DYNAMICOBJECT_TYPE, (uint)dynData.Type);
             if (dynData.SpellXSpellVisualID != null)
@@ -1673,11 +1673,11 @@ public class ObjectUpdateBuilder
         if (corpseData != null)
         {
             if (corpseData.Owner != null)
-                m_fields.SetUpdateField<WowGuid128>(CorpseField.CORPSE_FIELD_OWNER, corpseData.Owner.Value);
+                m_fields.SetUpdateField(CorpseField.CORPSE_FIELD_OWNER, corpseData.Owner.Value);
             if (corpseData.PartyGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(CorpseField.CORPSE_FIELD_PARTY_GUID, corpseData.PartyGUID.Value);
+                m_fields.SetUpdateField(CorpseField.CORPSE_FIELD_PARTY_GUID, corpseData.PartyGUID.Value);
             if (corpseData.GuildGUID != null)
-                m_fields.SetUpdateField<WowGuid128>(CorpseField.CORPSE_FIELD_GUILD_GUID, corpseData.GuildGUID.Value);
+                m_fields.SetUpdateField(CorpseField.CORPSE_FIELD_GUILD_GUID, corpseData.GuildGUID.Value);
             if (corpseData.DisplayID != null)
                 m_fields.SetUpdateField<uint>(CorpseField.CORPSE_FIELD_DISPLAY_ID, (uint)corpseData.DisplayID);
             for (int i = 0; i < 19; i++)


### PR DESCRIPTION
## Summary

This PR eliminates heap allocations caused by boxing `WowGuid128` in the generic `SetUpdateField<T>` / `GetUpdateField<T>` hot path, and establishes baseline benchmarks for future performance work.

### Background: C# 15 Union Research

This work started as research into whether C# 15 union types (shipping with .NET 11) could improve performance in HermesProxy's packet processing. Key finding: **unions box value types by default** (they store contents as `object?`), making them *slower* than our existing `StructLayout.Explicit`-based `UpdateValues` struct for value-type hot paths. Unions are primarily useful for reference-type hierarchies and compile-time exhaustiveness checking — not for the zero-allocation patterns we need.

However, the research revealed a real performance issue: the generic `SetUpdateField<T>` / `GetUpdateField<T>` methods box `WowGuid128` (a 16-byte struct) on every call through `(T)(object)` casts and recursive generic dispatch. This is called thousands of times per object update tick.

### The Fix

Added direct (non-generic) overloads that bypass the generic type dispatch entirely:

- **`SetUpdateField(object index, WowGuid128 guid)`** — writes 4 uint32 fields directly with inline dirty-checking
- **`GetUpdateFieldGuid(object index)`** — reads 4 uint32 fields and constructs WowGuid128 directly

The generic `SetUpdateField<WowGuid128>` case now delegates to the direct overload, so even callers that haven't migrated benefit. All ~30 `SetUpdateField<WowGuid128>` callsites across 4 ObjectUpdateBuilder versions were migrated to use the direct overload.

### Benchmark Results

**SetUpdateField (hot path — called thousands of times per update tick):**

| Method | Mean | Allocated | Change |
|--------|------|-----------|--------|
| `SetUpdateField<uint>` (baseline) | 0.32 ns | 0 B | — |
| `SetUpdateField<WowGuid128>` (before) | 13.2 ns | 48 B | — |
| `SetUpdateField<WowGuid128>` (generic, delegates to direct) | 6.7 ns | 24 B | 2x faster, 50% less alloc |
| **`SetUpdateField(WowGuid128)` (direct)** | **0.89 ns** | **0 B** | **15x faster, 100% alloc eliminated** |

**GetUpdateField:**

| Method | Mean | Allocated | Change |
|--------|------|-----------|--------|
| `GetUpdateField<WowGuid128>` (before) | 9.3 ns | 24 B | — |
| **`GetUpdateFieldGuid` (direct)** | **0.54 ns** | **0 B** | **17x faster, 100% alloc eliminated** |

> Note: `(T)(object)` casts for primitive types (uint, int, float) showed "ZeroMeasurement" — the JIT already optimizes these away. The boxing was only a real cost for `WowGuid128` (16-byte struct, too large for the JIT to elide).

**ObjectUpdate Construction (baseline for future work):**

| Type | Mean | Allocated |
|------|------|-----------|
| DynamicObject | 30 ns | 272 B |
| GameObject | 46 ns | 464 B |
| Corpse | 64 ns | 824 B |
| Item | 96 ns | 1,544 B |
| Unit | 183 ns | 2,248 B |
| Player | 1,556 ns | 34,152 B |
| Batch (100 mixed objects) | 41 us | 762 KB |

**MonsterMove Write vs WriteToSpan (baseline):**

| Path | ByteBuffer | Span | Speedup | Alloc Reduction |
|------|-----------|------|---------|-----------------|
| FacingSpot | 996 ns / 832 B | 553 ns / 301 B | 1.8x | 64% |
| FacingAngle | 1,000 ns / 824 B | 525 ns / 323 B | 1.9x | 61% |
| With 8 points | 1,216 ns / 1,264 B | 698 ns / 694 B | 1.7x | 45% |

### New Tests (51 + 11 + 10 = 72 tests)

- **UpdateFieldsArrayTests** — 51 tests covering Set/Get round-trips for all types (uint, int, float, ulong, WowGuid128, byte/ushort with offsets), update mask behavior, flag operations, write serialization, and direct-vs-generic equivalence
- **ObjectUpdateTests** — 11 tests verifying constructor initializes correct data fields per ObjectType and field exclusivity (Item doesn't init UnitData, etc.)
- **MonsterMoveTests** — 10 tests covering constructor point calculation, Write/WriteToSpan equivalence across all SplineTypes, and MaxPoints fallback

### New Benchmarks

- **UpdateFieldsArrayBenchmarks** — Set/Get per type, generic vs direct WowGuid128 comparison, realistic mixed-type object update scenario
- **ObjectUpdateBenchmarks** — Construction cost per object type, batch creation (100 mixed objects simulating zone load)
- **MonsterMoveBenchmarks** — ByteBuffer vs Span write path per SplineType, with varying point counts

## Test plan

- [x] `dotnet build` — all projects compile
- [x] `dotnet test` — all 296 tests pass (72 new + 224 existing)
- [x] Benchmarks run and produce valid results
- [x] Manual test: connect client (V1_14_2_42597) to legacy server, enter world, play

🤖 Generated with [Claude Code](https://claude.com/claude-code)