### PR TITLE
Fix #34: Defer player UpdateObject when item templates not yet cached

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -47,6 +47,13 @@ public sealed class TradeSession
     public uint ServerStateIndex = 1; // incremented by any trade action
 }
 
+public sealed class PendingObjectUpdate
+{
+    public required UpdateObject UpdateObject;
+    public required List<AuraUpdate> AuraUpdates;
+    public required HashSet<uint> WaitingForItemIds;
+}
+
 public sealed class GameSessionData
 {
     public bool HasWsgHordeFlagCarrier;
@@ -135,6 +142,13 @@ public sealed class GameSessionData
     public TradeSession? CurrentTrade = null;
     public HashSet<uint> RequestedItemHotfixes = [];
     public HashSet<uint> RequestedItemSparseHotfixes = [];
+
+    // SMSG_UPDATE_OBJECT batches that contain a player CreateObject whose
+    // VisibleItems reference item templates not yet cached. Held back until
+    // the matching ItemModifiedAppearance hotfixes are emitted, so the modern
+    // client renders the player dressed instead of naked. See issue #34.
+    public List<PendingObjectUpdate> DeferredObjectUpdates = [];
+    public Lock DeferredObjectUpdatesLock = new();
 
     private GameSessionData()
     {

--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -479,6 +479,9 @@ public partial class WorldClient
                 reply2.Timestamp = (uint)Time.UnixTime;
                 SendPacketToClient(reply2);
             }
+            // issue #34: even an "invalid" answer is an answer — drop this id
+            // from any pending waiting-set so the deferred batch can release.
+            FlushDeferredUpdatesFor((uint)entry.Key);
             return;
         }
 
@@ -487,6 +490,50 @@ public partial class WorldClient
 
         SendItemUpdatesIfNeeded(item);
         GameData.StoreItemTemplate((uint)entry.Key, item);
+
+        // issue #34: any UpdateObject batch that was held back waiting on this
+        // item template's hotfix can be released now that the DB2 row is in
+        // place on the modern client.
+        FlushDeferredUpdatesFor((uint)entry.Key);
+    }
+
+    private void FlushDeferredUpdatesFor(uint resolvedItemId)
+    {
+        var session = GetSession();
+        List<PendingObjectUpdate>? toFlush = null;
+        lock (session.GameState.DeferredObjectUpdatesLock)
+        {
+            var pending = session.GameState.DeferredObjectUpdates;
+            for (int i = 0; i < pending.Count; i++)
+            {
+                var entry = pending[i];
+                entry.WaitingForItemIds.Remove(resolvedItemId);
+                if (entry.WaitingForItemIds.Count == 0)
+                {
+                    toFlush ??= [];
+                    toFlush.Add(entry);
+                }
+            }
+            if (toFlush != null)
+            {
+                foreach (var entry in toFlush)
+                    pending.Remove(entry);
+            }
+        }
+
+        if (toFlush == null)
+            return;
+
+        foreach (var entry in toFlush)
+        {
+            if (entry.UpdateObject.ObjectUpdates.Count != 0 ||
+                entry.UpdateObject.DestroyedGuids.Count != 0 ||
+                entry.UpdateObject.OutOfRangeGuids.Count != 0)
+                SendPacketToClient(entry.UpdateObject);
+
+            foreach (var auraUpdate in entry.AuraUpdates)
+                SendPacketToClient(auraUpdate);
+        }
     }
 
     void SendItemUpdatesIfNeeded(ItemTemplate item)

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -276,6 +276,78 @@ public partial class WorldClient
             }
         }
 
+        // Issue #34: when the player CreateObject in this batch references item
+        // templates the modern client doesn't know (custom items, typically
+        // entry > 60000), the ItemModifiedAppearance hotfix has to land before
+        // the UpdateObject — otherwise the player renders naked because the
+        // client falls through the missing DB2 lookup. Hold the batch until
+        // the legacy server has answered every dependent CMSG_ITEM_QUERY_SINGLE
+        // and SendItemUpdatesIfNeeded has emitted the hotfixes.
+        //
+        // Vanilla 1.12 player CreateObjects don't reliably populate
+        // PlayerData.VisibleItems via the translator (the field block layout
+        // differs from later expansions), so the load-bearing signal is
+        // missingItemTemplates — items that came in the same batch as
+        // inventory CreateObject2 blocks. Scan PlayerData.VisibleItems
+        // additionally to cover partial-update reconnects where bag Creates
+        // aren't part of this batch.
+        HashSet<uint>? deferredFor = null;
+        if (activePlayerUpdateIndex >= 0)
+        {
+            if (missingItemTemplates.Count > 0)
+            {
+                deferredFor = new HashSet<uint>(missingItemTemplates);
+            }
+
+            var playerUpdate = updateObject.ObjectUpdates[activePlayerUpdateIndex];
+            if (playerUpdate.PlayerData != null)
+            {
+                foreach (var visible in playerUpdate.PlayerData.VisibleItems)
+                {
+                    if (visible.HasValue && visible.Value.ItemID > 0 &&
+                        !GameData.ItemTemplates.ContainsKey((uint)visible.Value.ItemID))
+                    {
+                        deferredFor ??= new HashSet<uint>();
+                        deferredFor.Add((uint)visible.Value.ItemID);
+                    }
+                }
+            }
+        }
+
+        if (deferredFor != null && deferredFor.Count > 0)
+        {
+            // Items only seen via PlayerData.VisibleItems still need their own
+            // CMSG_ITEM_QUERY_SINGLE — items already in missingItemTemplates
+            // were dispatched by the loop above.
+            foreach (uint itemId in deferredFor)
+            {
+                if (missingItemTemplates.Contains(itemId))
+                    continue;
+                WorldPacket reqPacket = new WorldPacket(Opcode.CMSG_ITEM_QUERY_SINGLE);
+                reqPacket.WriteUInt32(itemId);
+                if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
+                    reqPacket.WriteGuid(WowGuid64.Empty);
+                SendPacketToServer(reqPacket);
+            }
+
+            var pending = new PendingObjectUpdate
+            {
+                UpdateObject = updateObject,
+                AuraUpdates = auraUpdates,
+                WaitingForItemIds = deferredFor,
+            };
+            var session = GetSession();
+            lock (session.GameState.DeferredObjectUpdatesLock)
+                session.GameState.DeferredObjectUpdates.Add(pending);
+
+            // Release path: every SMSG_ITEM_QUERY_SINGLE_RESPONSE (valid or
+            // invalid) calls FlushDeferredUpdatesFor on its entry id. If the
+            // legacy server stops answering entirely, the connection-level
+            // TCP timeout tears the session down — the queue is per-session
+            // so it's GC'd along with the rest of the state.
+            return;
+        }
+
         if (updateObject.ObjectUpdates.Count != 0 ||
             updateObject.DestroyedGuids.Count != 0 ||
             updateObject.OutOfRangeGuids.Count != 0)


### PR DESCRIPTION
Closes #34. Also fixes the in-world-render variant of the long-standing upstream issue [WowLegacyCore/HermesProxy#74](https://github.com/WowLegacyCore/HermesProxy/issues/74) (open since 2022).

## Background

Reporter @worador2k1 hit this on vMaNGOS 1.12 (build 5875) with the 1.14.2 client (build 42597): equipping any custom item (entry id ≥ 60001) and relogging caused the character model to render *naked* on world enter. The character-select screen displayed the gear correctly. Re-equipping in-game restored the visual until the next relog.

## Root cause

The 1.14.2 client renders an equipped slot through the `ItemModifiedAppearance` DB2 row keyed on `VisibleItem.ItemID`. For stock item ids the client ships those rows; for custom ids HermesProxy synthesises the row at runtime and pushes it to the client as a hotfix.

The race condition that broke things on world enter:

```
legacy → proxy : SMSG_UPDATE_OBJECT  (player CreateObject + inventory items)
proxy         : scans inventory CreateObject2 entries, queues missing IDs
proxy → client : SMSG_UPDATE_OBJECT  ← client renders player NAKED here
                                       (no DB2 row for ID 60001 yet)
proxy → legacy : CMSG_ITEM_QUERY_SINGLE  for each missing ID  (async)
legacy → proxy : SMSG_ITEM_QUERY_SINGLE_RESPONSE   (later)
proxy → client : ItemModifiedAppearance hotfix     (too late — already rendered)
```

The character-select screen wasn't affected because `EnumCharactersResult.VisualItemInfo` carries `DisplayId` directly and bypasses the DB2 lookup path entirely.

Re-equipping in-game worked as a temporary fix because by then the template was cached and the second `VisibleItems` update made the client re-evaluate the appearance with the now-available row. The next relog blew that cache and the race returned.

## Fix

Defer the outgoing `UpdateObject` whenever it contains the player's `CreateObject` AND any item template referenced by the batch isn't already cached. The batch parks in a per-session queue and is released the moment the matching `SMSG_ITEM_QUERY_SINGLE_RESPONSE` lands and `SendItemUpdatesIfNeeded` has emitted the hotfixes.

Both **valid** and **invalid** responses release the waiting id, so a custom item that was deleted from `item_template` between sessions still won't hang the client at loading. If the legacy server stops answering entirely, connection-level TCP timeout tears the session down — the queue is per-session so it gets GC'd along with the rest of the state.

### What gets deferred

Only the specific `UpdateObject` that contains the player's own `CreateObject` *and* references uncached item templates. All other `UpdateObject` packets (Values updates for the player mid-session, other entities, etc.) flow through unchanged.

The deferral signal is `missingItemTemplates.Count > 0` plus a scan of `playerUpdate.PlayerData.VisibleItems` for entries the in-place translator already populated. Vanilla 1.12 player CreateObjects don't reliably populate `PlayerData.VisibleItems` via the translator (the field block layout differs from later expansions), so the load-bearing signal is the inventory `CreateObject2` scan that already exists.

## Changes

### `HermesProxy/GlobalSessionData.cs`
- New `PendingObjectUpdate` class (`UpdateObject` + `List<AuraUpdate>` + `HashSet<uint> WaitingForItemIds`).
- New `DeferredObjectUpdates` list and `DeferredObjectUpdatesLock` on `GameSessionData`.

### `HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs`
- After the existing player-create reorder logic, if `activePlayerUpdateIndex >= 0` and there are missing item templates, build the waiting set, send a `CMSG_ITEM_QUERY_SINGLE` for any visible-item entry the inventory loop didn't already queue, park the `UpdateObject` + `auraUpdates` on the queue, and return.

### `HermesProxy/World/Client/PacketHandlers/QueryHandler.cs`
- New `FlushDeferredUpdatesFor(uint resolvedItemId)` helper.
- Invoked from both branches of `HandleItemQueryResponse` (valid → after `StoreItemTemplate`; invalid → after the `DBReply` is sent).
- Each call removes the resolved id from every pending entry's `WaitingForItemIds`. Any entry whose set is now empty is sent to the client (`UpdateObject` + queued auras) and removed from the queue.

## Testing

- All 296 existing tests pass.
- Reproduced the bug locally on cMangos classic (commit `b6366f9654` from 2026-01-13, classic-db "Melting Pot v2") with a custom item entry 60001 reusing the Lionheart Helm display (22920). Bug present before, fixed after.
- Reporter @worador2k1 [confirmed the fix](https://github.com/Xian55/HermesProxy/issues/34#issuecomment-4275934686) on vMaNGOS 1.12 (5875) + Windows 11 IoT LTSC + client 1.14.2.42597 with custom items in the 60001-60008 range.

## Performance / safety notes

- Per *world-enter*: one `PendingObjectUpdate` allocation (~48 B) + one `HashSet<uint>` (copy of `missingItemTemplates`).
- Steady-state: zero allocations. The deferral path is gated by `!GameData.ItemTemplates.ContainsKey(...)` which becomes false after first cache hit.
- No new threading footprint — every flush call runs from the same `ReceiveLoop`-driven path that already exists. No `Task.Delay` or timer added.
- `+133` LOC, no public API changes, no behavioural changes for stock items.
