### PR TITLE
Fix: Preserve reflection-only types from PublishTrimmed (artifact follow-up)

### DIFF
--- a/Framework/Singleton/Singleton.cs
+++ b/Framework/Singleton/Singleton.cs
@@ -16,10 +16,11 @@
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading;
 
-public class Singleton<T> where T : class
+public class Singleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)] T> where T : class
 {
     private static volatile T? instance;
     private static readonly Lock _syncRoot = new();

--- a/HermesProxy/HermesProxy.csproj
+++ b/HermesProxy/HermesProxy.csproj
@@ -24,6 +24,14 @@
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(UsePublishBuildSettings)' == 'true'">
+    <!-- ConfigurationManager reflectively constructs ClientConfigurationHost,
+         which the trimmer can't see and otherwise strips. Without this the
+         published binary throws MissingMethodException on first config read.
+         See issue #34 follow-up. -->
+    <TrimmerRootAssembly Include="System.Configuration.ConfigurationManager" />
+  </ItemGroup>
+
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <DefineConstants>_WINDOWS</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
Follow-up to #35 (#34 fix). The CI artifacts produced for the `fix/34` branch failed to launch on @worador2k1's environment (Windows 11 IoT LTSC + .NET 10) with:

```
System.MissingMethodException: Cannot dynamically create an instance of type
'System.Configuration.ClientConfigurationHost'.
Reason: No parameterless constructor defined.
```

@worador2k1 worked around it by building from source (`dotnet build` doesn't apply `UsePublishBuildSettings=true`, so neither `PublishTrimmed` nor `PublishSingleFile` engage and the non-trimmed assemblies keep the constructor intact). This PR fixes the artifacts so the from-source workaround stops being necessary.

## Two trim failures, same family

Both failures are reflection paths that the IL trimmer can't statically see, so it strips members it should have kept.

### 1. `System.Configuration.ConfigurationManager` strips `ClientConfigurationHost`

`Framework/Configuration/ConfigurationParser.cs:27-28` calls `ConfigurationManager.OpenMappedExeConfiguration(...)`, which under the hood reflectively instantiates `System.Configuration.ClientConfigurationHost`. The trimmer can't see the call → strips a constructor → `MissingMethodException` at first config read.

**Fix:** add `<TrimmerRootAssembly Include="System.Configuration.ConfigurationManager" />` to `HermesProxy.csproj`. This tells the trimmer to preserve the entire assembly. Adds ~500 KB to the artifact.

### 2. `Singleton<T>` strips T's private constructor

`Framework/Singleton/Singleton.cs:37` reflectively constructs T via `typeof(T).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, ...)`. With trimming on, the trimmer doesn't know what concrete types T can be (`LoginServiceManager`, `RealmManager`, etc.), so it strips their private ctors. `Singleton<T>.Instance` then NRE's at runtime because `constructorInfo` comes back null.

I caught this one while smoke-testing the published binary locally — the published binary booted past config parsing (thanks to fix 1) but then crashed at `LoginServiceManager.Instance.Initialize()` in `Server.cs:109`. Reporter @worador2k1 didn't hit this one because their environment evidently stripped a different set of types, but it's the same class of latent bug and worth closing now.

**Fix:** annotate the type parameter on `Singleton<T>` with `[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]`. The annotation propagates to every closed generic the trimmer encounters, so each concrete `Singleton<X>` keeps `X`'s private ctor.

## Why not just disable `PublishTrimmed`?

That was option B in my analysis. Disabling trimming would also work and would be simpler, at the cost of ~5–10 MB per artifact. Rooting only the affected assemblies/types preserves trimming everywhere else and keeps the artifact lean. If we hit a *third* reflection-path failure later, we can revisit and either add another root or flip the global switch.

## Changes

### `HermesProxy/HermesProxy.csproj`
- Added an `<ItemGroup>` (gated on `'$(UsePublishBuildSettings)' == 'true'`) containing `<TrimmerRootAssembly Include="System.Configuration.ConfigurationManager" />`.
- Comment links back to issue #34 so the reasoning is discoverable from the file.

### `Framework/Singleton/Singleton.cs`
- Added `using System.Diagnostics.CodeAnalysis;`.
- Annotated `T` with `[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors)]`.

## Testing

- `dotnet test` — 296 / 296 pass.
- Local `dotnet publish HermesProxy --configuration Release --use-current-runtime -p:UsePublishBuildSettings=true` succeeds.
- Smoke test of the published Windows binary now boots through:
  - Config parsing (was throwing `MissingMethodException` before fix 1)
  - `GameData.LoadEverything()`
  - `LoginServiceManager.Instance.Initialize()` (was throwing NRE before fix 2)
  - All four socket listeners (`BnetTcpSession`, `BnetRestApiSession`, `RealmSocket`, `WorldSocket`)
  - Sits idle waiting for connections, no exceptions.

Pre-existing trim warnings from `VersionChecker.cs`, `WorldSocket.cs`, `GameData.cs` etc. are unchanged — they're potentially next-up to fix but are out of scope for this PR.

## Artifacts

CI built [run #24629683610](https://github.com/Xian55/HermesProxy/actions/runs/24629683610) — Windows / Linux / macOS artifacts available.

`+10 / -1` LOC. No behavioural change at runtime, only changes how the trimmer processes the publish output.
