### PR TITLE
Replace custom logger with Serilog + source-generated pipeline

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,13 @@
     <PackageVersion Include="Sep" Version="0.12.2" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.2" />
+    <!-- Logging -->
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     <!-- HermesProxy project packages -->
     <PackageVersion Include="GitVersion.MsBuild" Version="6.5.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />

--- a/Framework/Framework.csproj
+++ b/Framework/Framework.csproj
@@ -14,6 +14,12 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="System.Configuration.ConfigurationManager" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="Serilog.Sinks.Async" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/Framework/Logging/Log.cs
+++ b/Framework/Logging/Log.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Concurrent;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading;
-using ThreadingState = System.Threading.ThreadState;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Sinks.SystemConsole.Themes;
 
 namespace Framework.Logging;
 
@@ -30,104 +29,401 @@ public enum LogNetDir // Network direction
     P2C, // C<P S
 }
 
+public sealed record LogBootstrapOptions(
+    LogEventLevel MinimumLevel,
+    LogEventLevel ServerLevel,
+    LogEventLevel NetworkLevel,
+    LogEventLevel StorageLevel,
+    LogEventLevel PacketLevel,
+    LogEventLevel ConsoleLevel,
+    bool ToFile,
+    string Directory);
+
 public static class Log
 {
-    static Dictionary<LogType, (ConsoleColor Color, string Type)> LogToColorType = new()
-    {
-        { LogType.Debug,     (ConsoleColor.DarkBlue,  " Debug   ") },
-        { LogType.Server,    (ConsoleColor.Blue,      " Server  ") },
-        { LogType.Network,   (ConsoleColor.Green,     " Network ") },
-        { LogType.Error,     (ConsoleColor.Red,       " Error   ") },
-        { LogType.Warn,      (ConsoleColor.Yellow,    " Warning ") },
-        { LogType.Storage,   (ConsoleColor.Cyan,      " Storage ") },
-        { LogType.SpanMiss,  (ConsoleColor.Magenta,   " SpanMiss") },
-        { LogType.SpanStats, (ConsoleColor.DarkGreen, "SpanStats") },
-    }; 
+    public const string CategoryServer = "Server";
+    public const string CategoryNetwork = "Network";
+    public const string CategoryStorage = "Storage";
+    public const string CategoryPacket = "Packet";
 
-    static BlockingCollection<(LogType Type, string Message)> logQueue = new();
-    static readonly Lock _debugOutputLock = new();
-    private static Thread? _logOutputThread = null;
-    public static bool IsLogging => _logOutputThread != null && !logQueue.IsCompleted;
+    // Console template uses the ANSI-pre-colored category letter so each category keeps its own color
+    // (Server=Blue, Network=Green, Storage=Cyan, Packet=Magenta). The level letter is colored by the
+    // custom theme below. The message text stays the terminal's default color.
+    private const string ConsoleOutputTemplate =
+        "{Timestamp:HH:mm:ss} | {Level:u1} | {CategoryAnsi:l} | {SourceFile,-15} | {NetDir:l}{Message:lj}{NewLine}{Exception}";
 
-    public static bool DebugLogEnabled { get; set; }
-    public static bool SpanStatsEnabled { get; set; }
-    
-    /// <summary>
-    /// Start the logging Thread and take logs out of the <see cref="BlockingCollection{T}"/>
-    /// </summary>
-    public static void Start()
+    // File template uses the plain category letter so rolling log files never contain ANSI escape codes.
+    private const string FileOutputTemplate =
+        "{Timestamp:HH:mm:ss} | {Level:u1} | {Category} | {SourceFile,-15} | {NetDir:l}{Message:lj}{NewLine}{Exception}";
+
+    // Custom theme:
+    //   - Level letter colored per severity (V/D=gray, W=yellow, E/F=red, I=default)
+    //   - Literal text in messages stays default color
+    //   - Property values (substituted into the message by {Message:lj}) are colored by their
+    //     .NET type so e.g. "opcode CMSG_FOO (14053)" renders the string and number distinctly.
+    private static readonly AnsiConsoleTheme ConsoleTheme = new(new Dictionary<ConsoleThemeStyle, string>
     {
-        if (_logOutputThread == null)
+        [ConsoleThemeStyle.LevelVerbose]     = "\x1b[90m",          // bright black / gray
+        [ConsoleThemeStyle.LevelDebug]       = "\x1b[90m",          // bright black / gray
+        [ConsoleThemeStyle.LevelInformation] = string.Empty,        // default terminal color
+        [ConsoleThemeStyle.LevelWarning]     = "\x1b[33m",          // yellow
+        [ConsoleThemeStyle.LevelError]       = "\x1b[31m",          // red
+        [ConsoleThemeStyle.LevelFatal]       = "\x1b[1;31m",        // bold red
+
+        // Property value coloring inside {Message:lj}
+        [ConsoleThemeStyle.String]           = "\x1b[96m",          // bright cyan  (e.g. "CMSG_BATTLE_PAY_GET_PURCHASE_LIST")
+        [ConsoleThemeStyle.Number]           = "\x1b[93m",          // bright yellow (e.g. 14019)
+        [ConsoleThemeStyle.Boolean]          = "\x1b[35m",          // magenta       (true / false)
+        [ConsoleThemeStyle.Null]             = "\x1b[90m",          // gray          (null)
+        [ConsoleThemeStyle.Scalar]           = "\x1b[96m",          // bright cyan   (enum values like CMSG_PING)
+        [ConsoleThemeStyle.Name]             = "\x1b[38;5;117m",    // light blue    (@-prefixed property name, rarely used here)
+    });
+
+    private static readonly LoggingLevelSwitch _globalSwitch = new(LogEventLevel.Information);
+    private static readonly LoggingLevelSwitch _serverSwitch = new(LogEventLevel.Information);
+    private static readonly LoggingLevelSwitch _networkSwitch = new(LogEventLevel.Information);
+    private static readonly LoggingLevelSwitch _storageSwitch = new(LogEventLevel.Information);
+    private static readonly LoggingLevelSwitch _packetSwitch = new(LogEventLevel.Warning);
+
+    // Additional floor applied ONLY to the console sink. The file sink sees everything that passes
+    // the per-category switches, which is typically more verbose. This lets users keep the console
+    // tidy while the file captures enough detail to be useful in a bug report.
+    private static readonly LoggingLevelSwitch _consoleSwitch = new(LogEventLevel.Information);
+
+    private static Logger _root = null!;
+    // volatile: reassigned in BuildPipeline; SwappableMelLogger reads on every call.
+    private static volatile Serilog.Extensions.Logging.SerilogLoggerFactory _melFactory = null!;
+    private static readonly Dictionary<string, ILogger> _callerToCategory =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public static ILogger Server { get; private set; } = null!;
+    public static ILogger Network { get; private set; } = null!;
+    public static ILogger Storage { get; private set; } = null!;
+    public static ILogger Packet { get; private set; } = null!;
+
+    static Log()
+    {
+        BuildPipeline(toFile: false, directory: "Logs");
+    }
+
+    public static bool IsLogging => _root is not null;
+
+    /// <summary>Back-compat. When set to true, bumps the global minimum level to Debug.</summary>
+    public static bool DebugLogEnabled
+    {
+        get => _globalSwitch.MinimumLevel <= LogEventLevel.Debug;
+        set
         {
-            _logOutputThread = new Thread(() =>
+            if (value && _globalSwitch.MinimumLevel > LogEventLevel.Debug)
+                _globalSwitch.MinimumLevel = LogEventLevel.Debug;
+        }
+    }
+
+    /// <summary>Back-compat. When set to true, bumps the Packet category to Verbose.</summary>
+    public static bool SpanStatsEnabled
+    {
+        get => _packetSwitch.MinimumLevel <= LogEventLevel.Verbose;
+        set
+        {
+            if (value && _packetSwitch.MinimumLevel > LogEventLevel.Verbose)
+                _packetSwitch.MinimumLevel = LogEventLevel.Verbose;
+        }
+    }
+
+    /// <summary>No-op retained for API compatibility. The pipeline is built eagerly in the static ctor.</summary>
+    public static void Start() { }
+
+    public static void Configure(LogBootstrapOptions options)
+    {
+        _globalSwitch.MinimumLevel = options.MinimumLevel;
+        _serverSwitch.MinimumLevel = options.ServerLevel;
+        _networkSwitch.MinimumLevel = options.NetworkLevel;
+        _storageSwitch.MinimumLevel = options.StorageLevel;
+        _packetSwitch.MinimumLevel = options.PacketLevel;
+        _consoleSwitch.MinimumLevel = options.ConsoleLevel;
+
+        BuildPipeline(options.ToFile, options.Directory);
+    }
+
+    public static void Shutdown()
+    {
+        _root?.Dispose();
+    }
+
+    private static void BuildPipeline(bool toFile, string directory)
+    {
+        var config = new LoggerConfiguration()
+            .MinimumLevel.ControlledBy(_globalSwitch)
+            .MinimumLevel.Override(CategoryServer, _serverSwitch)
+            .MinimumLevel.Override(CategoryNetwork, _networkSwitch)
+            .MinimumLevel.Override(CategoryStorage, _storageSwitch)
+            .MinimumLevel.Override(CategoryPacket, _packetSwitch)
+            .Enrich.With<CategoryLetterEnricher>()
+            .Enrich.With<NetDirEnricher>()
+            .Enrich.With<SourceFileEnricher>()
+            .WriteTo.Async(a =>
             {
-                foreach (var msg in logQueue.GetConsumingEnumerable())
+                // Console sub-logger has its own level switch so users can keep console tidy
+                // (e.g. Information) while per-category switches allow more verbose events that
+                // flow to the file sink only.
+                a.Logger(sub => sub
+                    .MinimumLevel.ControlledBy(_consoleSwitch)
+                    .WriteTo.Console(
+                        outputTemplate: ConsoleOutputTemplate,
+                        theme: ConsoleTheme));
+
+                if (toFile)
                 {
-                    PrintInternalDirectly(msg.Type, msg.Message);
+                    try
+                    {
+                        System.IO.Directory.CreateDirectory(directory);
+                    }
+                    catch
+                    {
+                        // If the directory can't be created we still want console logging to work.
+                    }
+                    // File sink has no additional filter — it captures whatever passes the
+                    // per-category switches, which is typically the more verbose view.
+                    a.File(
+                        path: Path.Combine(directory, "hermes-.log"),
+                        rollingInterval: RollingInterval.Day,
+                        retainedFileCountLimit: 30,
+                        outputTemplate: FileOutputTemplate,
+                        shared: false);
                 }
             });
 
-            _logOutputThread.IsBackground = true;
-            _logOutputThread.Start();
-        }
+        var newRoot = config.CreateLogger();
+        var oldRoot = _root;
+        var oldFactory = _melFactory;
+        _root = newRoot;
+        _melFactory = new Serilog.Extensions.Logging.SerilogLoggerFactory(newRoot, dispose: false);
+
+        Server = newRoot.ForContext(Serilog.Core.Constants.SourceContextPropertyName, CategoryServer);
+        Network = newRoot.ForContext(Serilog.Core.Constants.SourceContextPropertyName, CategoryNetwork);
+        Storage = newRoot.ForContext(Serilog.Core.Constants.SourceContextPropertyName, CategoryStorage);
+        Packet = newRoot.ForContext(Serilog.Core.Constants.SourceContextPropertyName, CategoryPacket);
+
+        oldFactory?.Dispose();
+        oldRoot?.Dispose();
     }
 
-    private static void PrintInternalDirectly(LogType type, string text)
-    {
-        if (type == LogType.Debug && !DebugLogEnabled)
-            return;
-        if (type == LogType.SpanStats && !SpanStatsEnabled)
-            return;
-#if DEBUG
-        Console.Write($"{DateTime.Now:HH:mm:ss.ff} | "); // This function is directly called in DEBUG, so our timesstamps can also be a more precise
-#else
-        Console.Write($"{DateTime.Now:HH:mm:ss} | ");
-#endif
-        Console.ForegroundColor = LogToColorType[type].Color;
-        Console.Write($"{LogToColorType[type].Type}");
-        Console.ResetColor();
+    /// <summary>
+    /// Create a <see cref="Microsoft.Extensions.Logging.ILogger"/> routed to this Serilog pipeline.
+    /// Use this as the first parameter of source-generated <c>[LoggerMessage]</c> methods.
+    /// The <paramref name="categoryName"/> should be one of <c>"Server"</c>, <c>"Network"</c>,
+    /// <c>"Storage"</c>, <c>"Packet"</c> so that the per-category <c>MinimumLevel.Override</c> applies.
+    /// <para>
+    /// The returned logger is a thin wrapper that re-resolves through the current MEL factory on
+    /// every call. This makes static-field captures of the logger safe across
+    /// <see cref="Configure"/> rebuilds: classes that initialize BEFORE <c>Log.Configure</c> runs
+    /// (e.g. <see cref="HermesProxy.Server"/>) still route their writes through the live pipeline
+    /// after it's rebuilt. Overhead per call is one dictionary lookup in the SerilogLoggerFactory's
+    /// internal name-&gt;logger cache.
+    /// </para>
+    /// </summary>
+    public static Microsoft.Extensions.Logging.ILogger CreateMelLogger(string categoryName)
+        => new SwappableMelLogger(categoryName);
 
-        Console.WriteLine($"| {text}");
-    }
-
-    public static void Print(LogType type, object text, [CallerMemberName] string method = "", [CallerFilePath] string path = "")
+    private sealed class SwappableMelLogger : Microsoft.Extensions.Logging.ILogger
     {
-        string formattedText = $"{FormatCaller(method, path)} | {text}";
-#if DEBUG
-        // Fastpath when using breakpoints we want to see the log results immediately
-        if (Debugger.IsAttached)
+        private readonly string _name;
+        // Per-instance cache: resolve the MEL logger once per factory. SerilogLoggerProvider
+        // does NOT cache CreateLogger results internally, so without this layer every log call
+        // would allocate a fresh SerilogLogger (~150 B / call). We compare factory identities
+        // and only re-resolve after Log.Configure swaps _melFactory.
+        private Microsoft.Extensions.Logging.ILoggerFactory? _cachedFactory;
+        private Microsoft.Extensions.Logging.ILogger? _cachedLogger;
+
+        public SwappableMelLogger(string name) => _name = name;
+
+        private Microsoft.Extensions.Logging.ILogger Current
         {
-            lock (_debugOutputLock)
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
             {
-                PrintInternalDirectly(type, formattedText);
+                var factory = _melFactory;
+                if (!ReferenceEquals(factory, _cachedFactory))
+                {
+                    _cachedFactory = factory;
+                    _cachedLogger = factory.CreateLogger(_name);
+                }
+                return _cachedLogger!;
             }
-            return;
         }
-#endif
-        logQueue.Add((type, formattedText));
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+            => Current.BeginScope(state);
+
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel)
+            => Current.IsEnabled(logLevel);
+
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Current.Log(logLevel, eventId, state, exception, formatter);
     }
 
-    public static void PrintNet(LogType type, LogNetDir netDirection, object text, [CallerMemberName] string method = "", [CallerFilePath] string path = "")
+    /// <summary>
+    /// Associate a caller file name (from <c>[CallerFilePath]</c>) with a category logger so that
+    /// legacy <see cref="LogType.Warn"/> and <see cref="LogType.Error"/> calls are routed appropriately.
+    /// Unregistered callers default to <see cref="Server"/>.
+    /// </summary>
+    public static void RegisterCallerMapping(string callerFileName, ILogger category)
     {
-        string directionText = netDirection switch
-        {
-            LogNetDir.C2P => "C>P S",
-            LogNetDir.P2S => "C P>S",
-            LogNetDir.S2P => "C P<S",
-            LogNetDir.P2C => "C<P S",
-            _ => "?   ?",
-        };
-        Print(type, $"{directionText} | {text}", method, path);
+        _callerToCategory[callerFileName] = category;
     }
 
-    public static void outException(Exception err, [CallerMemberName] string method = "", [CallerFilePath] string path = "")
+    public static void Print(LogType type, object text,
+        [CallerMemberName] string method = "",
+        [CallerFilePath] string path = "")
+    {
+        var (logger, level) = Route(type, path);
+        if (!logger.IsEnabled(level))
+            return;
+
+        var sourceFile = FormatCaller(path);
+        // Pass the already-formatted text AS the message template (with {/} escaped). This makes
+        // Serilog's themed renderer treat it as literal Text, not as a String-typed property
+        // value — so the ConsoleThemeStyle.String color does not bleed over the whole message.
+        // Structured hot-path calls that actually have placeholders still get per-property coloring.
+        logger
+            .ForContext("SourceFile", sourceFile)
+            .Write(level, EscapeAsLiteralTemplate(text));
+    }
+
+    public static void PrintNet(LogType type, LogNetDir netDirection, object text,
+        [CallerMemberName] string method = "",
+        [CallerFilePath] string path = "")
+    {
+        var (logger, level) = Route(type, path);
+        if (!logger.IsEnabled(level))
+            return;
+
+        var sourceFile = FormatCaller(path);
+        var dir = FormatDir(netDirection);
+        logger
+            .ForContext("SourceFile", sourceFile)
+            .ForContext("NetDir", dir)
+            .Write(level, EscapeAsLiteralTemplate(text));
+    }
+
+    // Serilog parses message templates at call time. Any unescaped '{' or '}' in the adapter text
+    // would be interpreted as placeholders and produce warnings. Double them so the template is
+    // purely literal. For typical log text this allocates only when '{' / '}' actually appear.
+    private static string EscapeAsLiteralTemplate(object text)
+    {
+        var s = text as string ?? text?.ToString() ?? string.Empty;
+        if (s.IndexOfAny(['{', '}']) < 0)
+            return s;
+        return s.Replace("{", "{{").Replace("}", "}}");
+    }
+
+    public static void outException(Exception err,
+        [CallerMemberName] string method = "",
+        [CallerFilePath] string path = "")
     {
         Print(LogType.Error, err.ToString(), method, path);
     }
 
-    private static string FormatCaller(string method, string path)
+    private static (ILogger logger, LogEventLevel level) Route(LogType type, string path)
     {
-        var fileName = Path.GetFileNameWithoutExtension(path);
-        return fileName.PadRight(15, ' ');
+        return type switch
+        {
+            LogType.Server => (Server, LogEventLevel.Information),
+            LogType.Network => (Network, LogEventLevel.Information),
+            LogType.Storage => (Storage, LogEventLevel.Information),
+            LogType.Debug => (Server, LogEventLevel.Debug),
+            LogType.Warn => (ResolveCategoryFromPath(path), LogEventLevel.Warning),
+            LogType.Error => (ResolveCategoryFromPath(path), LogEventLevel.Error),
+            LogType.SpanMiss => (Packet, LogEventLevel.Warning),
+            LogType.SpanStats => (Packet, LogEventLevel.Verbose),
+            _ => (Server, LogEventLevel.Information)
+        };
+    }
+
+    private static ILogger ResolveCategoryFromPath(string path)
+    {
+        var file = Path.GetFileNameWithoutExtension(path);
+        return _callerToCategory.TryGetValue(file, out var logger) ? logger : Server;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string FormatCaller(string path)
+        => Path.GetFileNameWithoutExtension(path).PadRight(15, ' ');
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string FormatDir(LogNetDir dir) => dir switch
+    {
+        LogNetDir.C2P => "C>P S | ",
+        LogNetDir.P2S => "C P>S | ",
+        LogNetDir.S2P => "C P<S | ",
+        LogNetDir.P2C => "C<P S | ",
+        _ => "?   ? | "
+    };
+
+}
+
+internal sealed class CategoryLetterEnricher : ILogEventEnricher
+{
+    private const string AnsiReset = "\x1b[0m";
+
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        string letter = "?";
+        string ansi = "?";
+        if (logEvent.Properties.TryGetValue(Serilog.Core.Constants.SourceContextPropertyName, out var value) &&
+            value is ScalarValue { Value: string name })
+        {
+            (letter, ansi) = name switch
+            {
+                Log.CategoryServer  => ("S", "\x1b[34mS" + AnsiReset),  // blue
+                Log.CategoryNetwork => ("N", "\x1b[32mN" + AnsiReset),  // green
+                Log.CategoryStorage => ("T", "\x1b[36mT" + AnsiReset),  // cyan
+                Log.CategoryPacket  => ("P", "\x1b[35mP" + AnsiReset),  // magenta
+                _ => ("?", "?")
+            };
+        }
+        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("Category", letter));
+        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("CategoryAnsi", ansi));
+    }
+}
+
+internal sealed class NetDirEnricher : ILogEventEnricher
+{
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        // Ensure NetDir is always present so the output template never emits {NetDir}.
+        if (!logEvent.Properties.ContainsKey("NetDir"))
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("NetDir", string.Empty));
+    }
+}
+
+internal sealed class SourceFileEnricher : ILogEventEnricher
+{
+    private const int Width = 15;
+    private static readonly string _emptyPadded = new(' ', Width);
+
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        if (logEvent.Properties.ContainsKey("SourceFile"))
+            return;
+
+        if (logEvent.Properties.TryGetValue(Serilog.Core.Constants.SourceContextPropertyName, out var value) &&
+            value is ScalarValue { Value: string name })
+        {
+            var shortName = name.Length > 0 && name.LastIndexOf('.') is int dot && dot >= 0
+                ? name[(dot + 1)..]
+                : name;
+            logEvent.AddPropertyIfAbsent(
+                propertyFactory.CreateProperty("SourceFile", shortName.PadRight(Width)));
+        }
+        else
+        {
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("SourceFile", _emptyPadded));
+        }
     }
 }

--- a/Framework/Networking/NetworkThread.cs
+++ b/Framework/Networking/NetworkThread.cs
@@ -24,6 +24,10 @@ namespace Framework.Networking;
 
 public class NetworkThread<TSocketType> where TSocketType : ISocket
 {
+    private static readonly Microsoft.Extensions.Logging.ILogger _melNet = Log.CreateMelLogger(Log.CategoryNetwork);
+    private static readonly string _sourceFile = "NetworkThread".PadRight(15);
+    private const string _netDirNone = "";
+
     int _connections;
     volatile bool _stopped;
 
@@ -88,7 +92,7 @@ public class NetworkThread<TSocketType> where TSocketType : ISocket
 
     void Run()
     {
-        Log.Print(LogType.Network, "Network Thread Starting");
+        NetworkThreadLogMessages.NetworkThreadStarting(_melNet, _sourceFile, _netDirNone);
 
         int sleepTime = 10;
         while (!_stopped)

--- a/Framework/Networking/NetworkThreadLogMessages.cs
+++ b/Framework/Networking/NetworkThreadLogMessages.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Logging;
+
+namespace Framework.Networking;
+
+#pragma warning disable SYSLIB1015
+internal static partial class NetworkThreadLogMessages
+{
+    // EventId 900 range is reserved for NetworkThread.
+
+    [LoggerMessage(EventId = 900, Level = LogLevel.Information, Message = "Network Thread Starting")]
+    public static partial void NetworkThreadStarting(
+        ILogger logger, string SourceFile, string NetDir);
+}

--- a/HermesProxy.Benchmarks/LoggingBenchmarks.cs
+++ b/HermesProxy.Benchmarks/LoggingBenchmarks.cs
@@ -1,0 +1,180 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using Framework.Logging;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace HermesProxy.Benchmarks;
+
+/// <summary>
+/// Four equivalent "received opcode" calls benchmarked side-by-side:
+///   1. Interpolated string through Serilog (old pattern, pre-migration)
+///   2. Manual structured template through Serilog (current migration Phase B pattern)
+///   3. Source-generated [LoggerMessage] through the MEL -> Serilog bridge (Phase C pattern)
+/// Each is measured in both the enabled and disabled state. The key column is
+/// <c>Allocated</c> on the <c>*_Disabled</c> rows — zero there is the whole point of
+/// migrating a hot path.
+/// </summary>
+[MemoryDiagnoser]
+[ShortRunJob]
+public class LoggingBenchmarks
+{
+    private Serilog.ILogger _sinkSerilog = null!;
+    private Serilog.ILogger _disabledSinkSerilog = null!;
+    private Microsoft.Extensions.Logging.ILogger _sinkMel = null!;
+    private Microsoft.Extensions.Logging.ILogger _disabledSinkMel = null!;
+    // Mirrors Log.CreateMelLogger's production behavior: a SwappableMelLogger-equivalent wrapper
+    // that re-resolves through the current factory on every call. Adds one extra virtual dispatch
+    // plus one dictionary lookup (the factory's name->logger cache).
+    private Microsoft.Extensions.Logging.ILogger _sinkSwappable = null!;
+    private Microsoft.Extensions.Logging.ILogger _disabledSinkSwappable = null!;
+
+    private const string Opcode = "CMSG_BATTLE_PAY_GET_PURCHASE_LIST";
+    private const int OpcodeId = 14019;
+    private const string SourceFile = "WorldSocket    ";
+    private const string NetDir = "C>P S | ";
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var enabledRoot = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .WriteTo.Sink(new NullSink())
+            .CreateLogger();
+        _sinkSerilog = enabledRoot;
+        var enabledFactory = new Serilog.Extensions.Logging.SerilogLoggerFactory(enabledRoot, dispose: false);
+        _sinkMel = enabledFactory.CreateLogger("Packet");
+        _sinkSwappable = new TestSwappableMelLogger(enabledFactory, "Packet");
+
+        var disabledRoot = new LoggerConfiguration()
+            .MinimumLevel.Error()
+            .WriteTo.Sink(new NullSink())
+            .CreateLogger();
+        _disabledSinkSerilog = disabledRoot;
+        var disabledFactory = new Serilog.Extensions.Logging.SerilogLoggerFactory(disabledRoot, dispose: false);
+        _disabledSinkMel = disabledFactory.CreateLogger("Packet");
+        _disabledSinkSwappable = new TestSwappableMelLogger(disabledFactory, "Packet");
+    }
+
+    // --- Interpolated (old pattern, always allocates) ---
+
+    [Benchmark(Baseline = true, Description = "1a. Interpolated, disabled")]
+    public void Interpolated_Disabled()
+    {
+        _disabledSinkSerilog.Debug($"Received opcode {Opcode} ({OpcodeId}).");
+    }
+
+    [Benchmark(Description = "1b. Interpolated, enabled")]
+    public void Interpolated_Enabled()
+    {
+        _sinkSerilog.Debug($"Received opcode {Opcode} ({OpcodeId}).");
+    }
+
+    // --- Manual structured template (current Phase B pattern) ---
+
+    [Benchmark(Description = "2a. Structured, disabled")]
+    public void Structured_Disabled()
+    {
+        if (_disabledSinkSerilog.IsEnabled(LogEventLevel.Debug))
+            _disabledSinkSerilog.Debug("Received opcode {Opcode} ({OpcodeId}).", Opcode, OpcodeId);
+    }
+
+    [Benchmark(Description = "2b. Structured, enabled")]
+    public void Structured_Enabled()
+    {
+        if (_sinkSerilog.IsEnabled(LogEventLevel.Debug))
+            _sinkSerilog.Debug("Received opcode {Opcode} ({OpcodeId}).", Opcode, OpcodeId);
+    }
+
+    // --- Source-generated [LoggerMessage] through MEL -> Serilog (Phase C pattern) ---
+
+    [Benchmark(Description = "3a. SourceGen, disabled")]
+    public void SourceGen_Disabled()
+    {
+        BenchmarkLogMessages.PacketReceivedStr(_disabledSinkMel, SourceFile, NetDir, Opcode, OpcodeId);
+    }
+
+    [Benchmark(Description = "3b. SourceGen, enabled")]
+    public void SourceGen_Enabled()
+    {
+        BenchmarkLogMessages.PacketReceivedStr(_sinkMel, SourceFile, NetDir, Opcode, OpcodeId);
+    }
+
+    // --- Source-generated [LoggerMessage] via SwappableMelLogger (actual production path) ---
+
+    [Benchmark(Description = "4a. SourceGen+Swappable, disabled")]
+    public void SourceGenSwappable_Disabled()
+    {
+        BenchmarkLogMessages.PacketReceivedStr(_disabledSinkSwappable, SourceFile, NetDir, Opcode, OpcodeId);
+    }
+
+    [Benchmark(Description = "4b. SourceGen+Swappable, enabled")]
+    public void SourceGenSwappable_Enabled()
+    {
+        BenchmarkLogMessages.PacketReceivedStr(_sinkSwappable, SourceFile, NetDir, Opcode, OpcodeId);
+    }
+
+    private sealed class NullSink : ILogEventSink
+    {
+        public void Emit(LogEvent logEvent) { }
+    }
+
+    /// <summary>
+    /// Local mirror of <c>Framework.Logging.Log.SwappableMelLogger</c>. Caches the inner MEL
+    /// logger per-instance and only re-resolves when the underlying factory changes reference.
+    /// </summary>
+    private sealed class TestSwappableMelLogger : Microsoft.Extensions.Logging.ILogger
+    {
+        private readonly Microsoft.Extensions.Logging.ILoggerFactory _factory;
+        private readonly string _name;
+        private Microsoft.Extensions.Logging.ILoggerFactory? _cachedFactory;
+        private Microsoft.Extensions.Logging.ILogger? _cachedLogger;
+
+        public TestSwappableMelLogger(Microsoft.Extensions.Logging.ILoggerFactory factory, string name)
+        { _factory = factory; _name = name; }
+
+        private Microsoft.Extensions.Logging.ILogger Current
+        {
+            get
+            {
+                if (!ReferenceEquals(_factory, _cachedFactory))
+                {
+                    _cachedFactory = _factory;
+                    _cachedLogger = _factory.CreateLogger(_name);
+                }
+                return _cachedLogger!;
+            }
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+            => Current.BeginScope(state);
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel)
+            => Current.IsEnabled(logLevel);
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Current.Log(logLevel, eventId, state, exception, formatter);
+    }
+}
+
+#pragma warning disable SYSLIB1015
+internal static partial class BenchmarkLogMessages
+{
+    // Mirrors WorldSocketLogMessages.PacketReceived but uses a string for Opcode
+    // so we can feed it constants in the benchmark. Shape and generated code are identical.
+    [LoggerMessage(
+        EventId = 9999,
+        Level = LogLevel.Debug,
+        Message = "Received opcode {Opcode} ({OpcodeId}).")]
+    public static partial void PacketReceivedStr(
+        Microsoft.Extensions.Logging.ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string Opcode,
+        int OpcodeId);
+}

--- a/HermesProxy/Auth/AuthClient.cs
+++ b/HermesProxy/Auth/AuthClient.cs
@@ -14,11 +14,21 @@ using Framework;
 using Framework.IO;
 using Framework.Logging;
 using Framework.Networking;
+using HermesProxy.Auth.Logging;
 
 namespace HermesProxy.Auth;
 
 public partial class AuthClient
 {
+    // Source-generated logging: one MEL logger per target category so per-category
+    // MinimumLevel.Override still applies. SourceFile + NetDir strings are cached constants.
+    private static readonly Microsoft.Extensions.Logging.ILogger _melNet = Log.CreateMelLogger(Log.CategoryNetwork);
+    private static readonly Microsoft.Extensions.Logging.ILogger _melServer = Log.CreateMelLogger(Log.CategoryServer);
+    private static readonly string _sourceFile = nameof(AuthClient).PadRight(15);
+    private static readonly string _netDirP2S = Log.FormatDir(LogNetDir.P2S);
+    private static readonly string _netDirS2P = Log.FormatDir(LogNetDir.S2P);
+    private const string _netDirNone = "";
+
     // For ez debugging: Call this function wherever you want
     private static readonly Action<ByteBuffer> _debugTraceBreakpointHandler = (b) =>
     {
@@ -62,8 +72,8 @@ public partial class AuthClient
 
         try
         {
-            var serverIpAddress = NetworkUtils.ResolveOrDirectIPv4(Settings.ServerAddress); 
-            Log.PrintNet(LogType.Network, LogNetDir.P2S, $"Connecting to auth server... (realmlist addr: {Settings.ServerAddress}:{Settings.ServerPort}) (resolved as: {serverIpAddress}:{Settings.ServerPort})");
+            var serverIpAddress = NetworkUtils.ResolveOrDirectIPv4(Settings.ServerAddress);
+            AuthClientLogMessages.ConnectingToAuthServer(_melNet, _sourceFile, _netDirP2S, Settings.ServerAddress, Settings.ServerPort, serverIpAddress.ToString());
             _clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             // Connect to the specified host.
             var endPoint = new IPEndPoint(serverIpAddress, Settings.ServerPort);
@@ -71,7 +81,7 @@ public partial class AuthClient
         }
         catch (Exception ex)
         {
-            Log.PrintNet(LogType.Error, LogNetDir.P2S, $"Socket Error: {ex.Message}");
+            AuthClientLogMessages.SocketError(_melNet, ex, _sourceFile, _netDirP2S, ex.Message);
             _response.SetResult(AuthResult.FAIL_INTERNAL_ERROR);
         }
 
@@ -88,8 +98,8 @@ public partial class AuthClient
 
         try
         {
-            var serverIpAddress = NetworkUtils.ResolveOrDirectIPv4(Settings.ServerAddress); 
-            Log.PrintNet(LogType.Network, LogNetDir.P2S, $"Reconnecting to auth server... (realmlist addr: {Settings.ServerAddress}:{Settings.ServerPort}) (resolved as: {serverIpAddress}:{Settings.ServerPort})");
+            var serverIpAddress = NetworkUtils.ResolveOrDirectIPv4(Settings.ServerAddress);
+            AuthClientLogMessages.ReconnectingToAuthServer(_melNet, _sourceFile, _netDirP2S, Settings.ServerAddress, Settings.ServerPort, serverIpAddress.ToString());
             _clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             // Connect to the specified host.
             var endPoint = new IPEndPoint(serverIpAddress, Settings.ServerPort);
@@ -97,7 +107,7 @@ public partial class AuthClient
         }
         catch (Exception ex)
         {
-            Log.PrintNet(LogType.Error, LogNetDir.P2S, $"Socket Error: {ex.Message}");
+            AuthClientLogMessages.SocketError(_melNet, ex, _sourceFile, _netDirP2S, ex.Message);
             _response.SetResult(AuthResult.FAIL_INTERNAL_ERROR);
         }
 
@@ -142,7 +152,7 @@ public partial class AuthClient
         }
         catch (Exception ex)
         {
-            Log.Print(LogType.Error, $"Connect Error: {ex.Message}");
+            AuthClientLogMessages.ConnectError(_melNet, ex, _sourceFile, _netDirNone, ex.Message);
             SetAuthResponse(AuthResult.FAIL_INTERNAL_ERROR);
         }
     }
@@ -159,7 +169,7 @@ public partial class AuthClient
         }
         catch (Exception ex)
         {
-            Log.PrintNet(LogType.Error, LogNetDir.P2S, $"Connect Error: {ex.Message}");
+            AuthClientLogMessages.ConnectError(_melNet, ex, _sourceFile, _netDirP2S, ex.Message);
             SetAuthResponse(AuthResult.FAIL_INTERNAL_ERROR);
         }
     }
@@ -174,7 +184,7 @@ public partial class AuthClient
             {
                 SetAuthResponse(AuthResult.FAIL_INTERNAL_ERROR);
 
-                Log.PrintNet(LogType.Error, LogNetDir.S2P, "Socket Closed By Server");
+                AuthClientLogMessages.SocketClosedByServer(_melNet, _sourceFile, _netDirS2P);
                 return;
             }
 
@@ -191,7 +201,7 @@ public partial class AuthClient
         }
         catch (Exception ex)
         {
-            Log.Print(LogType.Error, $"Packet Read Error: {ex.Message}");
+            AuthClientLogMessages.PacketReadError(_melNet, ex, _sourceFile, _netDirNone, ex.Message);
             SetAuthResponse(AuthResult.FAIL_INTERNAL_ERROR);
         }
     }
@@ -204,7 +214,7 @@ public partial class AuthClient
         }
         catch (Exception ex)
         {
-            Log.PrintNet(LogType.Error, LogNetDir.P2S, $"Packet Send Error: {ex.Message}");
+            AuthClientLogMessages.PacketSendError(_melNet, ex, _sourceFile, _netDirP2S, ex.Message);
             SetAuthResponse(AuthResult.FAIL_INTERNAL_ERROR);
         }
     }
@@ -218,7 +228,7 @@ public partial class AuthClient
         }
         catch (Exception ex)
         {
-            Log.PrintNet(LogType.Error, LogNetDir.P2S, $"Packet Write Error: {ex.Message}");
+            AuthClientLogMessages.PacketWriteError(_melNet, ex, _sourceFile, _netDirP2S, ex.Message);
             SetAuthResponse(AuthResult.FAIL_INTERNAL_ERROR);
         }
     }
@@ -227,7 +237,7 @@ public partial class AuthClient
     {
         ByteBuffer packet = new ByteBuffer(buffer);
         AuthCommand opcode = (AuthCommand)packet.ReadUInt8();
-        Log.PrintNet(LogType.Debug, LogNetDir.S2P, $"Received opcode {opcode} size {size}.");
+        AuthClientLogMessages.PacketReceived(_melNet, _sourceFile, _netDirS2P, opcode, size);
 
         switch (opcode)
         {
@@ -247,7 +257,7 @@ public partial class AuthClient
                 HandleRealmList(packet);
                 break;
             default:
-                Log.PrintNet(LogType.Error, LogNetDir.S2P, $"No handler for opcode {opcode}!");
+                AuthClientLogMessages.NoHandlerForOpcode(_melNet, _sourceFile, _netDirS2P, opcode);
                 SetAuthResponse(AuthResult.FAIL_INTERNAL_ERROR);
                 break;
         }
@@ -283,7 +293,7 @@ public partial class AuthClient
         AuthResult error = (AuthResult)packet.ReadUInt8();
         if (error != AuthResult.SUCCESS)
         {
-            Log.Print(LogType.Error, $"Login failed. Reason: {error}");
+            AuthClientLogMessages.LoginFailed(_melNet, _sourceFile, _netDirNone, error);
             SetAuthResponse(error);
             return;
         }
@@ -454,7 +464,7 @@ public partial class AuthClient
         AuthResult error = (AuthResult)packet.ReadUInt8();
         if (error != AuthResult.SUCCESS)
         {
-            Log.Print(LogType.Error, $"Login failed. Reason: {error}");
+            AuthClientLogMessages.LoginFailed(_melNet, _sourceFile, _netDirNone, error);
             SetAuthResponse(error);
             return;
         }
@@ -487,12 +497,12 @@ public partial class AuthClient
 
         if (!equal)
         {
-            Log.Print(LogType.Error, "Authentication failed!");
+            AuthClientLogMessages.AuthenticationFailed(_melNet, _sourceFile, _netDirNone);
             SetAuthResponse(AuthResult.FAIL_INTERNAL_ERROR);
         }
         else
         {
-            Log.Print(LogType.Network, "Authentication succeeded!");
+            AuthClientLogMessages.AuthenticationSucceeded(_melNet, _sourceFile, _netDirNone);
             SetAuthResponse(AuthResult.SUCCESS);
         }
     }
@@ -528,7 +538,7 @@ public partial class AuthClient
         AuthResult error = (AuthResult)packet.ReadUInt8();
         if (error != AuthResult.SUCCESS)
         {
-            Log.Print(LogType.Error, $"Reconnect failed. Reason: {error}");
+            AuthClientLogMessages.ReconnectFailed(_melNet, _sourceFile, _netDirNone, error);
             SetAuthResponse(error);
             return;
         }
@@ -538,7 +548,7 @@ public partial class AuthClient
 
     public void SendRealmListUpdateRequest()
     {
-        Log.Print(LogType.Server, $"Requesting RealmList update for {_username}");
+        AuthClientLogMessages.RequestingRealmListUpdate(_melServer, _sourceFile, _netDirNone, _username);
         ByteBuffer buffer = new ByteBuffer();
         buffer.WriteUInt8((byte)AuthCommand.REALM_LIST);
         for (int i = 0; i < 4; i++)
@@ -562,7 +572,7 @@ public partial class AuthClient
             realmsCount = packet.ReadUInt16();
         }
 
-        Log.Print(LogType.Network, $"Received {realmsCount} realms.");
+        AuthClientLogMessages.ReceivedRealms(_melNet, _sourceFile, _netDirNone, realmsCount);
         List<RealmInfo> realmList = new List<RealmInfo>();
 
         for (ushort i = 0; i < realmsCount; i++)

--- a/HermesProxy/Auth/Logging/AuthClientLogMessages.cs
+++ b/HermesProxy/Auth/Logging/AuthClientLogMessages.cs
@@ -1,0 +1,141 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace HermesProxy.Auth.Logging;
+
+/// <summary>
+/// Source-generated logging methods for <see cref="AuthClient"/>. Covers the SRP6 login flow,
+/// realmlist request, and the auth socket's receive/send callbacks. <c>SourceFile</c> and
+/// <c>NetDir</c> are intentional overflow properties — the Serilog output template renders them
+/// in their own columns.
+/// </summary>
+#pragma warning disable SYSLIB1015
+internal static partial class AuthClientLogMessages
+{
+    // EventId 300-399 range is reserved for AuthClient.
+
+    [LoggerMessage(
+        EventId = 300,
+        Level = LogLevel.Information,
+        Message = "Connecting to auth server... (realmlist addr: {Address}:{Port}) (resolved as: {ResolvedAddress}:{Port})")]
+    public static partial void ConnectingToAuthServer(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string Address,
+        int Port,
+        string ResolvedAddress);
+
+    [LoggerMessage(
+        EventId = 301,
+        Level = LogLevel.Information,
+        Message = "Reconnecting to auth server... (realmlist addr: {Address}:{Port}) (resolved as: {ResolvedAddress}:{Port})")]
+    public static partial void ReconnectingToAuthServer(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string Address,
+        int Port,
+        string ResolvedAddress);
+
+    [LoggerMessage(EventId = 302, Level = LogLevel.Error, Message = "Socket Error: {Message}")]
+    public static partial void SocketError(
+        ILogger logger,
+        Exception ex,
+        string SourceFile,
+        string NetDir,
+        string Message);
+
+    [LoggerMessage(EventId = 303, Level = LogLevel.Error, Message = "Connect Error: {Message}")]
+    public static partial void ConnectError(
+        ILogger logger,
+        Exception ex,
+        string SourceFile,
+        string NetDir,
+        string Message);
+
+    [LoggerMessage(EventId = 304, Level = LogLevel.Error, Message = "Socket Closed By Server")]
+    public static partial void SocketClosedByServer(
+        ILogger logger,
+        string SourceFile,
+        string NetDir);
+
+    [LoggerMessage(EventId = 305, Level = LogLevel.Error, Message = "Packet Read Error: {Message}")]
+    public static partial void PacketReadError(
+        ILogger logger,
+        Exception ex,
+        string SourceFile,
+        string NetDir,
+        string Message);
+
+    [LoggerMessage(EventId = 306, Level = LogLevel.Error, Message = "Packet Send Error: {Message}")]
+    public static partial void PacketSendError(
+        ILogger logger,
+        Exception ex,
+        string SourceFile,
+        string NetDir,
+        string Message);
+
+    [LoggerMessage(EventId = 307, Level = LogLevel.Error, Message = "Packet Write Error: {Message}")]
+    public static partial void PacketWriteError(
+        ILogger logger,
+        Exception ex,
+        string SourceFile,
+        string NetDir,
+        string Message);
+
+    [LoggerMessage(EventId = 308, Level = LogLevel.Debug, Message = "Received opcode {Opcode} size {Size}.")]
+    public static partial void PacketReceived(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        AuthCommand Opcode,
+        int Size);
+
+    [LoggerMessage(EventId = 309, Level = LogLevel.Error, Message = "No handler for opcode {Opcode}!")]
+    public static partial void NoHandlerForOpcode(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        AuthCommand Opcode);
+
+    [LoggerMessage(EventId = 310, Level = LogLevel.Error, Message = "Login failed. Reason: {Reason}")]
+    public static partial void LoginFailed(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        AuthResult Reason);
+
+    [LoggerMessage(EventId = 311, Level = LogLevel.Error, Message = "Authentication failed!")]
+    public static partial void AuthenticationFailed(
+        ILogger logger,
+        string SourceFile,
+        string NetDir);
+
+    [LoggerMessage(EventId = 312, Level = LogLevel.Information, Message = "Authentication succeeded!")]
+    public static partial void AuthenticationSucceeded(
+        ILogger logger,
+        string SourceFile,
+        string NetDir);
+
+    [LoggerMessage(EventId = 313, Level = LogLevel.Error, Message = "Reconnect failed. Reason: {Reason}")]
+    public static partial void ReconnectFailed(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        AuthResult Reason);
+
+    [LoggerMessage(EventId = 314, Level = LogLevel.Information, Message = "Requesting RealmList update for {Username}")]
+    public static partial void RequestingRealmListUpdate(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string Username);
+
+    [LoggerMessage(EventId = 315, Level = LogLevel.Information, Message = "Received {Count} realms.")]
+    public static partial void ReceivedRealms(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        ushort Count);
+}

--- a/HermesProxy/BnetServer/Networking/BnetTcpSession.cs
+++ b/HermesProxy/BnetServer/Networking/BnetTcpSession.cs
@@ -346,6 +346,10 @@ internal readonly struct BnetPacketParseResultPooled
 
 public class BnetTcpSession : SSLSocket, BnetServices.INetwork
 {
+    private static readonly Microsoft.Extensions.Logging.ILogger _melServer = Log.CreateMelLogger(Log.CategoryServer);
+    private static readonly string _sourceFile = nameof(BnetTcpSession).PadRight(15);
+    private const string _netDirNone = "";
+
     private readonly BnetServices.ServiceManager _handlerManager;
 
     public BnetTcpSession(Socket socket) : base(socket)
@@ -356,7 +360,7 @@ public class BnetTcpSession : SSLSocket, BnetServices.INetwork
     public override void Accept()
     {
         string ipAddress = GetRemoteIpEndPoint()!.ToString();
-        Log.Print(LogType.Server, $"Accepting connection from {ipAddress}.");
+        BnetTcpSessionLogMessages.AcceptingConnection(_melServer, _sourceFile, _netDirNone, ipAddress);
         AsyncHandshake(BnetServerCertificate.Certificate);
     }
 

--- a/HermesProxy/BnetServer/Networking/BnetTcpSessionLogMessages.cs
+++ b/HermesProxy/BnetServer/Networking/BnetTcpSessionLogMessages.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Logging;
+
+namespace BNetServer.Networking;
+
+#pragma warning disable SYSLIB1015
+internal static partial class BnetTcpSessionLogMessages
+{
+    // EventId 800-899 range is reserved for BnetTcpSession.
+
+    [LoggerMessage(EventId = 800, Level = LogLevel.Information, Message = "Accepting connection from {Endpoint}.")]
+    public static partial void AcceptingConnection(
+        ILogger logger, string SourceFile, string NetDir, string Endpoint);
+}

--- a/HermesProxy/BnetServer/Services/BnetServices.ServiceManager.cs
+++ b/HermesProxy/BnetServer/Services/BnetServices.ServiceManager.cs
@@ -28,14 +28,19 @@ public partial class BnetServices
                         var key = (serviceAttr.ServiceHash, serviceAttr.MethodId);
                         if (_serviceHandlers.ContainsKey(key))
                         {
-                            Log.Print(LogType.Error, $"Tried to override ServiceHandler: {_serviceHandlers[key]} with {methodInfo.Name} (ServiceHash: {serviceAttr.ServiceHash} MethodId: {serviceAttr.MethodId})");
+                            BnetServicesLogMessages.ServiceHandlerOverrideAttempt(
+                                BnetServices._melNet, BnetServices._sourceFile, BnetServices._netDirNone,
+                                _serviceHandlers[key].ToString() ?? "", methodInfo.Name,
+                                serviceAttr.ServiceHash, serviceAttr.MethodId);
                             continue;
                         }
 
                         var parameters = methodInfo.GetParameters();
                         if (parameters.Length == 0)
                         {
-                            Log.Print(LogType.Error, $"Method: {methodInfo.Name} needs atleast one parameter");
+                            BnetServicesLogMessages.ServiceHandlerMissingParameters(
+                                BnetServices._melNet, BnetServices._sourceFile, BnetServices._netDirNone,
+                                methodInfo.Name);
                             continue;
                         }
 
@@ -83,19 +88,26 @@ public partial class BnetServices
 
             if (!_serviceHandlers.TryGetValue((serviceHash, methodId), out var handler))
             {
-                _serviceHolder.ServiceLog(LogType.Warn, $"Client requested service {serviceHash}/m:{methodId} but this service is not implemented?");
+                BnetServicesLogMessages.ServiceNotImplemented(
+                    BnetServices._melNet, BnetServices._sourceFile, BnetServices._netDirNone,
+                    _serviceHolder.BuildSessionPrefix(), serviceHash, methodId);
                 SendErrorResponse(BattlenetRpcErrorCode.RpcNotImplemented);
                 return;
             }
 
             if (handler.Requirement != ServiceRequirement.Always && handler.Requirement != _serviceHolder.CurrentMatchingRequirement())
             {
-                _serviceHolder.ServiceLog(LogType.Warn, $"Client requested service {serviceHash}/m:{methodId} but with invalid state, required: {handler.Requirement} but only has {_serviceHolder.CurrentMatchingRequirement()}!");
+                BnetServicesLogMessages.ServiceInvalidState(
+                    BnetServices._melNet, BnetServices._sourceFile, BnetServices._netDirNone,
+                    _serviceHolder.BuildSessionPrefix(), serviceHash, methodId,
+                    handler.Requirement, _serviceHolder.CurrentMatchingRequirement());
                 SendErrorResponse(BattlenetRpcErrorCode.Denied);
                 return;
             }
 
-            _serviceHolder.ServiceLog(LogType.Debug, $"Client requested service {serviceHash}/m:{methodId}");
+            BnetServicesLogMessages.ServiceRequested(
+                BnetServices._melNet, BnetServices._sourceFile, BnetServices._netDirNone,
+                _serviceHolder.BuildSessionPrefix(), serviceHash, methodId);
 
             var request = (IMessage)Activator.CreateInstance(handler.RequestType)!;
             request.MergeFrom(stream);

--- a/HermesProxy/BnetServer/Services/BnetServices.cs
+++ b/HermesProxy/BnetServer/Services/BnetServices.cs
@@ -15,6 +15,10 @@ namespace BNetServer.Services;
 
 public partial class BnetServices
 {
+    internal static readonly Microsoft.Extensions.Logging.ILogger _melNet = Log.CreateMelLogger(Log.CategoryNetwork);
+    internal static readonly string _sourceFile = nameof(BnetServices).PadRight(15);
+    internal const string _netDirNone = "";
+
     private static uint _serverInvokedRequestToken = 0;
     private Dictionary<uint /*requestId*/, Action<CodedInputStream> /*callbackHandler*/> _callbackHandlers = new();
 
@@ -60,10 +64,19 @@ public partial class BnetServices
 
     private void ServiceLog(LogType type, string message)
     {
+        Log.Print(type, $"{BuildSessionPrefix()} {message}");
+    }
+
+    /// <summary>
+    /// Compose the per-session prefix like <c>[WorldSocket][127.0.0.1:1234, Account: X, Game account: Y]</c>
+    /// used as a structured property by source-generated BnetServices log messages.
+    /// </summary>
+    internal string BuildSessionPrefix()
+    {
         StringBuilder prefix = new StringBuilder();
         prefix.Append($"[{_connectionPath}]");
         prefix.Append($"[{GetRemoteIpEndPoint()}");
-        
+
         if (GetSession() != null)
         {
             if (GetSession().AccountInfo != null && !GetSession().AccountInfo.Login.IsEmpty())
@@ -72,10 +85,9 @@ public partial class BnetServices
             if (GetSession().GameAccountInfo != null)
                 prefix.Append(", Game account: " + GetSession().GameAccountInfo.Name);
         }
-        
-        prefix.Append(']');
 
-        Log.Print(type, $"{prefix} {message}");
+        prefix.Append(']');
+        return prefix.ToString();
     }
 
     public ServiceRequirement CurrentMatchingRequirement()

--- a/HermesProxy/BnetServer/Services/BnetServicesLogMessages.cs
+++ b/HermesProxy/BnetServer/Services/BnetServicesLogMessages.cs
@@ -1,0 +1,76 @@
+using Framework.Constants;
+using Microsoft.Extensions.Logging;
+
+namespace BNetServer.Services;
+
+/// <summary>
+/// Source-generated logging methods for the BnetServices RPC dispatch. Covers the highest-volume
+/// call sites in <see cref="BnetServices.ServiceManager"/>; other <c>ServiceLog</c> callers can be
+/// migrated incrementally.
+/// </summary>
+#pragma warning disable SYSLIB1015
+internal static partial class BnetServicesLogMessages
+{
+    // EventId 500-599 range is reserved for BnetServices.
+
+    [LoggerMessage(
+        EventId = 500,
+        Level = LogLevel.Warning,
+        Message = "{Prefix} Client requested service {ServiceHash}/m:{MethodId} but this service is not implemented?")]
+    public static partial void ServiceNotImplemented(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string Prefix,
+        OriginalHash ServiceHash,
+        uint MethodId);
+
+    [LoggerMessage(
+        EventId = 501,
+        Level = LogLevel.Warning,
+        Message = "{Prefix} Client requested service {ServiceHash}/m:{MethodId} but with invalid state, required: {Required} but only has {Current}!")]
+    public static partial void ServiceInvalidState(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string Prefix,
+        OriginalHash ServiceHash,
+        uint MethodId,
+        ServiceRequirement Required,
+        ServiceRequirement Current);
+
+    [LoggerMessage(
+        EventId = 502,
+        Level = LogLevel.Debug,
+        Message = "{Prefix} Client requested service {ServiceHash}/m:{MethodId}")]
+    public static partial void ServiceRequested(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string Prefix,
+        OriginalHash ServiceHash,
+        uint MethodId);
+
+    [LoggerMessage(
+        EventId = 503,
+        Level = LogLevel.Error,
+        Message = "Tried to override ServiceHandler: {Existing} with {MethodName} (ServiceHash: {ServiceHash} MethodId: {MethodId})")]
+    public static partial void ServiceHandlerOverrideAttempt(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string Existing,
+        string MethodName,
+        OriginalHash ServiceHash,
+        uint MethodId);
+
+    [LoggerMessage(
+        EventId = 504,
+        Level = LogLevel.Error,
+        Message = "Method: {MethodName} needs atleast one parameter")]
+    public static partial void ServiceHandlerMissingParameters(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string MethodName);
+}

--- a/HermesProxy/Configuration/Settings.cs
+++ b/HermesProxy/Configuration/Settings.cs
@@ -8,6 +8,7 @@ using Framework.Logging;
 using Framework.Networking;
 using HermesProxy;
 using HermesProxy.Configuration;
+using Serilog.Events;
 
 namespace Framework;
 
@@ -28,6 +29,15 @@ public static class Settings
     public static bool DebugOutput;
     public static bool PacketsLog;
     public static bool SpanStatsLog;
+
+    public static LogEventLevel LogMinimumLevel;
+    public static LogEventLevel LogServerLevel;
+    public static LogEventLevel LogNetworkLevel;
+    public static LogEventLevel LogStorageLevel;
+    public static LogEventLevel LogPacketLevel;
+    public static LogEventLevel LogConsoleLevel;
+    public static bool LogToFile;
+    public static string LogDirectory = "Logs";
 
     public static bool LoadAndVerifyFrom(ConfigurationParser config)
     {
@@ -51,8 +61,35 @@ public static class Settings
         PacketsLog = config.GetBoolean("PacketsLog", true);
         SpanStatsLog = config.GetBoolean("SpanStatsLog", false);
 
+        LogMinimumLevel = ParseLogLevel(config.GetString("Log.MinimumLevel", "Information"), LogEventLevel.Information);
+        LogServerLevel = ParseLogLevel(config.GetString("Log.Server.MinimumLevel", "Information"), LogEventLevel.Information);
+        LogNetworkLevel = ParseLogLevel(config.GetString("Log.Network.MinimumLevel", "Information"), LogEventLevel.Information);
+        LogStorageLevel = ParseLogLevel(config.GetString("Log.Storage.MinimumLevel", "Information"), LogEventLevel.Information);
+        LogPacketLevel = ParseLogLevel(config.GetString("Log.Packet.MinimumLevel", "Warning"), LogEventLevel.Warning);
+        LogConsoleLevel = ParseLogLevel(config.GetString("Log.Console.MinimumLevel", "Information"), LogEventLevel.Information);
+        LogToFile = config.GetBoolean("Log.ToFile", true);
+        LogDirectory = config.GetString("Log.Directory", "Logs");
+
+        // Back-compat: translate legacy DebugOutput / SpanStatsLog into the new per-category min-levels.
+        if (DebugOutput && LogMinimumLevel > LogEventLevel.Debug)
+            LogMinimumLevel = LogEventLevel.Debug;
+        if (DebugOutput && LogConsoleLevel > LogEventLevel.Debug)
+            LogConsoleLevel = LogEventLevel.Debug;
+        if (SpanStatsLog && LogPacketLevel > LogEventLevel.Verbose)
+            LogPacketLevel = LogEventLevel.Verbose;
+
         return VerifyConfig();
     }
+
+    private static LogEventLevel ParseLogLevel(string raw, LogEventLevel defaultValue)
+    {
+        if (Enum.TryParse<LogEventLevel>(raw, ignoreCase: true, out var parsed))
+            return parsed;
+        return defaultValue;
+    }
+
+    public static LogBootstrapOptions ToLogBootstrapOptions()
+        => new(LogMinimumLevel, LogServerLevel, LogNetworkLevel, LogStorageLevel, LogPacketLevel, LogConsoleLevel, LogToFile, LogDirectory);
     
     private static bool VerifyConfig()
     {

--- a/HermesProxy/HermesProxy.config
+++ b/HermesProxy/HermesProxy.config
@@ -93,5 +93,61 @@
             Default:     "true"
     -->
     <add key="PacketsLog" value="true" />
+    <!--
+            Option:      Log.MinimumLevel
+            Description: Global minimum log level. One of: Verbose, Debug, Information, Warning, Error, Fatal.
+                         Rendered in the output as a single letter: V, D, I, W, E, F.
+            Default:     "Information"
+    -->
+    <add key="Log.MinimumLevel" value="Information" />
+    <!--
+            Option:      Log.Server.MinimumLevel
+            Description: Per-category override for the Server category (lifecycle, config, startup). Letter: S.
+            Default:     "Information"
+    -->
+    <add key="Log.Server.MinimumLevel" value="Information" />
+    <!--
+            Option:      Log.Network.MinimumLevel
+            Description: Per-category override for the Network category (auth/world socket connect/disconnect, handshake). Letter: N.
+            Default:     "Information"
+    -->
+    <add key="Log.Network.MinimumLevel" value="Information" />
+    <!--
+            Option:      Log.Storage.MinimumLevel
+            Description: Per-category override for the Storage category (GameData, CSV/DB2 load, hotfixes). Letter: T.
+            Default:     "Information"
+    -->
+    <add key="Log.Storage.MinimumLevel" value="Information" />
+    <!--
+            Option:      Log.Packet.MinimumLevel
+            Description: Per-category override for the Packet category (opcode dispatch, span fallback/stats). Letter: P.
+                         Warning shows SpanMiss; Verbose also shows per-packet SpanStats.
+            Default:     "Warning"
+    -->
+    <add key="Log.Packet.MinimumLevel" value="Warning" />
+    <!--
+            Option:      Log.Console.MinimumLevel
+            Description: Additional floor applied ONLY to the console sink. The file sink captures
+                         whatever passes the per-category switches (Log.Server.MinimumLevel etc.),
+                         so you can keep the console tidy while the file stays verbose for bug reports.
+                         Example for a support-friendly setup:
+                           Log.Packet.MinimumLevel  = Debug       (packet debug goes to file)
+                           Log.Console.MinimumLevel = Information (console stays at Info, hiding those debugs)
+            Default:     "Information"
+    -->
+    <add key="Log.Console.MinimumLevel" value="Information" />
+    <!--
+            Option:      Log.ToFile
+            Description: When true, also write logs to a daily rolling file at Log.Directory/hermes-YYYY-MM-DD.log.
+                         Files roll daily; the most recent 30 days are kept automatically.
+            Default:     "true"
+    -->
+    <add key="Log.ToFile" value="true" />
+    <!--
+            Option:      Log.Directory
+            Description: Directory for rolling log files (relative to working directory).
+            Default:     "Logs"
+    -->
+    <add key="Log.Directory" value="Logs" />
   </appSettings>
 </configuration>

--- a/HermesProxy/Realm/RealmManager.cs
+++ b/HermesProxy/Realm/RealmManager.cs
@@ -34,6 +34,10 @@ using HermesProxy.World;
 
 public sealed class RealmManager
 {
+    private static readonly Microsoft.Extensions.Logging.ILogger _melServer = Log.CreateMelLogger(Log.CategoryServer);
+    private static readonly string _sourceFile = nameof(RealmManager).PadRight(15);
+    private const string _netDirNone = "";
+
     const int placeholderRegion = 1;
     const int placeholderBattlegroup = 1;
 
@@ -102,9 +106,9 @@ public sealed class RealmManager
         UpdateRealm(realm);
 
         if (!existingRealms.ContainsKey(realm.Id))
-            Log.Print(LogType.Server, $"Added realm \"{realm.Name}\" at {realm.ExternalAddress}:{realm.Port}");
+            RealmManagerLogMessages.AddedRealm(_melServer, _sourceFile, _netDirNone, realm.Name, realm.ExternalAddress, realm.Port);
         else
-            Log.Print(LogType.Server, $"Updating realm \"{realm.Name}\" at { realm.ExternalAddress}:{realm.Port}");
+            RealmManagerLogMessages.UpdatingRealm(_melServer, _sourceFile, _netDirNone, realm.Name, realm.ExternalAddress, realm.Port);
 
         existingRealms.Remove(realm.Id);
     }
@@ -131,13 +135,14 @@ public sealed class RealmManager
         if (_realms.Count == 0)
             return;
 
-        Log.Print(LogType.Debug, "");
-        Log.Print(LogType.Debug, $"{"Type",-5} {"Type",-5} {"Locked",-8} {"Flags",-10} {"Name",-15} {"Address",-15} {"Port",-10} {"Build",-10}");
+        RealmManagerLogMessages.RealmListLine(_melServer, _sourceFile, _netDirNone, string.Empty);
+        RealmManagerLogMessages.RealmListLine(_melServer, _sourceFile, _netDirNone,
+            $"{"Type",-5} {"Type",-5} {"Locked",-8} {"Flags",-10} {"Name",-15} {"Address",-15} {"Port",-10} {"Build",-10}");
 
         foreach (var realm in _realms)
-            Log.Print(LogType.Debug, realm.ToString());
+            RealmManagerLogMessages.RealmListLine(_melServer, _sourceFile, _netDirNone, realm.ToString());
 
-        Log.Print(LogType.Debug,"");
+        RealmManagerLogMessages.RealmListLine(_melServer, _sourceFile, _netDirNone, string.Empty);
     }
 
     public Realm? GetRealm(RealmId id)

--- a/HermesProxy/Realm/RealmManagerLogMessages.cs
+++ b/HermesProxy/Realm/RealmManagerLogMessages.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Logging;
+
+// Kept in the global namespace to match RealmManager/Realm which also live there —
+// introducing a HermesProxy.Realm.* namespace would shadow the Realm type for callers.
+
+/// <summary>
+/// Source-generated logging methods for <see cref="RealmManager"/>.
+/// </summary>
+#pragma warning disable SYSLIB1015
+internal static partial class RealmManagerLogMessages
+{
+    // EventId 400-499 range is reserved for RealmManager.
+
+    [LoggerMessage(
+        EventId = 400,
+        Level = LogLevel.Information,
+        Message = "Added realm \"{Name}\" at {Address}:{Port}")]
+    public static partial void AddedRealm(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string Name,
+        string Address,
+        int Port);
+
+    [LoggerMessage(
+        EventId = 401,
+        Level = LogLevel.Information,
+        Message = "Updating realm \"{Name}\" at {Address}:{Port}")]
+    public static partial void UpdatingRealm(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string Name,
+        string Address,
+        int Port);
+
+    [LoggerMessage(
+        EventId = 402,
+        Level = LogLevel.Debug,
+        Message = "{Line}")]
+    public static partial void RealmListLine(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string Line);
+}

--- a/HermesProxy/Server.cs
+++ b/HermesProxy/Server.cs
@@ -1,8 +1,11 @@
 ﻿using BNetServer.Networking;
+using BNetServer.Services;
 using Framework.Logging;
 using Framework.Metrics;
 using Framework.Networking;
+using HermesProxy.Auth;
 using HermesProxy.World;
+using HermesProxy.World.Client;
 using HermesProxy.World.Server;
 using System;
 using System.Collections.Generic;
@@ -79,9 +82,9 @@ partial class Server
             Log.Print(LogType.Error, "The verification of the config failed");
             return;
         }
-        Log.DebugLogEnabled = Settings.DebugOutput;
+        Log.Configure(Settings.ToLogBootstrapOptions());
+        RegisterLogCallerMappings();
         Log.Print(LogType.Debug, "Debug logging enabled");
-        Log.SpanStatsEnabled = Settings.SpanStatsLog;
 
         if (!AesGcm.IsSupported)
         {
@@ -154,6 +157,22 @@ partial class Server
         Console.WriteLine($"(bnetSocketServer.IsListening: {bnetSocketServer.IsListening}");
         Console.WriteLine($"(realmSocketServer.IsListening: {realmSocketServer.IsListening}");
         Console.WriteLine($"(worldSocketServer.IsListening: {worldSocketServer.IsListening}");
+    }
+
+    private static void RegisterLogCallerMappings()
+    {
+        // Route legacy Log.Print(LogType.Warn|Error, ...) calls to the appropriate Serilog category
+        // based on the caller file that the [CallerFilePath] attribute resolves to.
+        Log.RegisterCallerMapping(nameof(AuthClient), Log.Network);
+        Log.RegisterCallerMapping(nameof(BnetTcpSession), Log.Network);
+        Log.RegisterCallerMapping(nameof(BnetServices), Log.Network);
+        Log.RegisterCallerMapping(nameof(LoginServiceManager), Log.Network);
+        Log.RegisterCallerMapping(nameof(RealmSocket), Log.Network);
+        Log.RegisterCallerMapping("NetworkThread", Log.Network); // generic type, no clean nameof form
+        Log.RegisterCallerMapping(nameof(WorldClient), Log.Packet);
+        Log.RegisterCallerMapping(nameof(WorldSocket), Log.Packet);
+        Log.RegisterCallerMapping(nameof(WorldSocketManager), Log.Packet);
+        Log.RegisterCallerMapping(nameof(GameData), Log.Storage);
     }
 
     private static SocketManager<TSocketType> StartServer<TSocketType>(IPEndPoint bindIp) where TSocketType : ISocket

--- a/HermesProxy/Server.cs
+++ b/HermesProxy/Server.cs
@@ -28,6 +28,15 @@ namespace HermesProxy;
 
 partial class Server
 {
+    // These MEL loggers are captured during Server's static init, which runs BEFORE
+    // Log.Configure rebuilds the Serilog pipeline. Log.CreateMelLogger returns a SwappableMelLogger
+    // that re-resolves through the current MEL factory on every call — so captures made here
+    // remain valid after Log.Configure without any runtime reinitialisation.
+    private static readonly Microsoft.Extensions.Logging.ILogger _melServer = Log.CreateMelLogger(Log.CategoryServer);
+    private static readonly Microsoft.Extensions.Logging.ILogger _melNetwork = Log.CreateMelLogger(Log.CategoryNetwork);
+    private static readonly string _sourceFile = nameof(Server).PadRight(15);
+    private const string _netDirNone = "";
+
     /// <summary>
     /// Global metrics collector for packet statistics.
     /// Only active when --metrics command line argument is passed.
@@ -53,7 +62,7 @@ partial class Server
         MetricsEnabled = args.EnableMetrics;
 
         Log.Print(LogType.Server, "Starting Hermes Proxy...");
-        Log.Print(LogType.Server, $"Version {GetVersionInformation()}");
+        ServerLogMessages.Version(_melServer, _sourceFile, _netDirNone, GetVersionInformation());
         if (MetricsEnabled)
             Log.Print(LogType.Server, "Latency metrics collection enabled");
         Log.Start();
@@ -98,8 +107,8 @@ partial class Server
             return;
         }
 
-        Log.Print(LogType.Server, $"Modern (Client) Build: {Settings.ClientBuild}");
-        Log.Print(LogType.Server, $"Legacy (Server) Build: {Settings.ServerBuild}");
+        ServerLogMessages.ModernClientBuild(_melServer, _sourceFile, _netDirNone, Settings.ClientBuild);
+        ServerLogMessages.LegacyServerBuild(_melServer, _sourceFile, _netDirNone, Settings.ServerBuild);
 
         GameData.LoadEverything();
 
@@ -107,7 +116,7 @@ partial class Server
         if (!IPAddress.IsLoopback(bindIp))
             bindIp = IPAddress.Any; // If we are not listening on localhost we have to expose our services
 
-        Log.Print(LogType.Network, $"External IP: {Settings.ExternalAddress}");
+        ServerLogMessages.ExternalIp(_melNetwork, _sourceFile, _netDirNone, Settings.ExternalAddress);
         // LoginServiceManager holds our external IPs so that other player can connect to our Hermes instance
         LoginServiceManager.Instance.Initialize();
 
@@ -179,7 +188,7 @@ partial class Server
     {
         var socketManager = new SocketManager<TSocketType>();
 
-        Log.Print(LogType.Server, $"Starting {typeof(TSocketType).Name} service on {bindIp}...");
+        ServerLogMessages.StartingService(_melServer, _sourceFile, _netDirNone, typeof(TSocketType).Name, bindIp.ToString());
         if (!socketManager.StartNetwork(bindIp.Address.ToString(), bindIp.Port))
         {
             throw new Exception($"Failed to start {typeof(TSocketType).Name} service");

--- a/HermesProxy/ServerLogMessages.cs
+++ b/HermesProxy/ServerLogMessages.cs
@@ -1,0 +1,42 @@
+using HermesProxy.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace HermesProxy;
+
+/// <summary>
+/// Source-generated logging methods for the top-level server lifecycle
+/// (<see cref="Server"/> and <see cref="VersionChecker"/> startup lines).
+/// </summary>
+#pragma warning disable SYSLIB1015
+internal static partial class ServerLogMessages
+{
+    // EventId 600-699 range is reserved for server startup / lifecycle.
+
+    [LoggerMessage(EventId = 600, Level = LogLevel.Information, Message = "Version {Version}")]
+    public static partial void Version(
+        ILogger logger, string SourceFile, string NetDir, string Version);
+
+    [LoggerMessage(EventId = 601, Level = LogLevel.Information, Message = "Modern (Client) Build: {Build}")]
+    public static partial void ModernClientBuild(
+        ILogger logger, string SourceFile, string NetDir, ClientVersionBuild Build);
+
+    [LoggerMessage(EventId = 602, Level = LogLevel.Information, Message = "Legacy (Server) Build: {Build}")]
+    public static partial void LegacyServerBuild(
+        ILogger logger, string SourceFile, string NetDir, ClientVersionBuild Build);
+
+    [LoggerMessage(EventId = 603, Level = LogLevel.Information, Message = "External IP: {Address}")]
+    public static partial void ExternalIp(
+        ILogger logger, string SourceFile, string NetDir, string Address);
+
+    [LoggerMessage(EventId = 604, Level = LogLevel.Information, Message = "Starting {ServiceName} service on {Endpoint}...")]
+    public static partial void StartingService(
+        ILogger logger, string SourceFile, string NetDir, string ServiceName, string Endpoint);
+
+    [LoggerMessage(EventId = 605, Level = LogLevel.Information, Message = "Loaded {Count} modern opcodes.")]
+    public static partial void LoadedModernOpcodes(
+        ILogger logger, string SourceFile, string NetDir, int Count);
+
+    [LoggerMessage(EventId = 606, Level = LogLevel.Information, Message = "Loaded {Count} legacy opcodes.")]
+    public static partial void LoadedLegacyOpcodes(
+        ILogger logger, string SourceFile, string NetDir, int Count);
+}

--- a/HermesProxy/VersionChecker.cs
+++ b/HermesProxy/VersionChecker.cs
@@ -19,6 +19,11 @@ namespace HermesProxy;
 // This is class is a plain copy of ModernVersion/LegacyVersion/Opcodes but without static constructor
 public static class VersionChecker
 {
+    // Shared with sibling classes LegacyVersion / ModernVersion in this file.
+    internal static readonly Microsoft.Extensions.Logging.ILogger _melServer = Log.CreateMelLogger(Log.CategoryServer);
+    internal static readonly string _sourceFile = nameof(VersionChecker).PadRight(15);
+    internal const string _netDirNone = "";
+
     public static bool IsSupportedLegacyVersion(ClientVersionBuild legacyVersion)
     {
         switch (legacyVersion)
@@ -166,7 +171,7 @@ public static class LegacyVersion
         CurrentToUniversalOpcodeDictionary = dict1.ToFrozenDictionary();
         UniversalToCurrentOpcodeDictionary = dict1.ToFrozenDictionary(kvp => kvp.Value, kvp => kvp.Key);
 
-        Log.Print(LogType.Server, $"Loaded {CurrentToUniversalOpcodeDictionary.Count} legacy opcodes.");
+        ServerLogMessages.LoadedLegacyOpcodes(VersionChecker._melServer, VersionChecker._sourceFile, VersionChecker._netDirNone, CurrentToUniversalOpcodeDictionary.Count);
     }
 
     private static readonly FrozenDictionary<uint, Opcode> CurrentToUniversalOpcodeDictionary = FrozenDictionary<uint, Opcode>.Empty;
@@ -501,7 +506,7 @@ public static class ModernVersion
         if (dict.Count < 1)
             return (FrozenDictionary<uint, Opcode>.Empty, FrozenDictionary<Opcode, uint>.Empty);
 
-        Log.Print(LogType.Server, $"Loaded {dict.Count} modern opcodes.");
+        ServerLogMessages.LoadedModernOpcodes(VersionChecker._melServer, VersionChecker._sourceFile, VersionChecker._netDirNone, dict.Count);
         return (dict.ToFrozenDictionary(), dict.ToFrozenDictionary(kvp => kvp.Value, kvp => kvp.Key));
     }
 

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -18,11 +18,19 @@ using Framework.Networking;
 using HermesProxy.World.Server;
 using System.Collections.Frozen;
 using System.Diagnostics;
+using HermesProxy.World.Logging;
 
 namespace HermesProxy.World.Client;
 
 public partial class WorldClient
 {
+    private static readonly Microsoft.Extensions.Logging.ILogger _melLog = Log.CreateMelLogger(Log.CategoryPacket);
+    private static readonly Microsoft.Extensions.Logging.ILogger _melNet = Log.CreateMelLogger(Log.CategoryNetwork);
+    private static readonly string _sourceFile = nameof(WorldClient).PadRight(15);
+    private static readonly string _netDirRecv = Log.FormatDir(LogNetDir.S2P);
+    private static readonly string _netDirSend = Log.FormatDir(LogNetDir.P2S);
+    private const string _netDirNone = "";
+
     Socket _clientSocket = null!;
     bool? _isSuccessful;
     uint _queuePosition;
@@ -62,11 +70,11 @@ public partial class WorldClient
         _delayedPacketsToServer = new Dictionary<Opcode, List<WorldPacket>>();
         _delayedPacketsToClient = new Dictionary<Opcode, List<ServerPacket>>();
 
-        Log.Print(LogType.Network, "Connecting to world server...");
+        WorldClientLogMessages.ConnectingToWorldServer(_melNet, _sourceFile, _netDirNone);
         try
         {
             var ip = NetworkUtils.ResolveOrDirectIPv4(realm.ExternalAddress);
-            Log.Print(LogType.Network, $"World Server address {realm.ExternalAddress}:{realm.Port} resolved as {ip}:{realm.Port}");
+            WorldClientLogMessages.WorldServerResolved(_melNet, _sourceFile, _netDirNone, realm.ExternalAddress, realm.Port, ip.ToString());
             _clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             // Connect to the specified host.
             var endPoint = new IPEndPoint(ip, realm.Port);
@@ -142,7 +150,7 @@ public partial class WorldClient
     {
         try
         {
-            Log.Print(LogType.Network, "Connection established!");
+            WorldClientLogMessages.ConnectionEstablished(_melNet, _sourceFile, _netDirNone);
 
             _clientSocket.EndConnect(AR);
             _clientSocket.ReceiveBufferSize = 65535;
@@ -237,7 +245,7 @@ public partial class WorldClient
         }
         catch(Exception e)
         {
-            Log.PrintNet(LogType.Error, LogNetDir.S2P, $"Packet Read Error: {e.Message}{Environment.NewLine}{e.StackTrace}");
+            WorldClientLogMessages.PacketReadError(_melLog, e, _sourceFile, _netDirRecv, e.Message);
             if (_isSuccessful == null)
                 _isSuccessful = false;
             else
@@ -262,7 +270,7 @@ public partial class WorldClient
                 header.Opcode = packet.GetOpcode();
                 header.Write(buffer);
 
-                Log.PrintNet(LogType.Debug, LogNetDir.P2S, $"Sending opcode {LegacyVersion.GetUniversalOpcode(header.Opcode)} ({header.Opcode}) with size {header.Size}.");
+                WorldClientLogMessages.PacketSent(_melLog, _sourceFile, _netDirSend, LegacyVersion.GetUniversalOpcode(header.Opcode), header.Opcode, header.Size);
 
                 byte[] headerArray = buffer.GetData();
                 if (_worldCrypt != null)
@@ -401,7 +409,7 @@ public partial class WorldClient
     private void HandlePacket(WorldPacket packet)
     {
         Opcode universalOpcode = packet.GetUniversalOpcode(false);
-        Log.PrintNet(LogType.Debug, LogNetDir.S2P, $"Received opcode {universalOpcode} ({packet.GetOpcode()}).");
+        WorldClientLogMessages.PacketReceived(_melLog, _sourceFile, _netDirRecv, universalOpcode, packet.GetOpcode());
 
         long startTimestamp = HermesProxy.Server.MetricsEnabled ? System.Diagnostics.Stopwatch.GetTimestamp() : 0;
 
@@ -422,7 +430,7 @@ public partial class WorldClient
                 }
                 else
                 {
-                    Log.PrintNet(LogType.Warn, LogNetDir.S2P, $"No handler for opcode {universalOpcode} ({packet.GetOpcode()}) (Got unknown packet from WorldServer)");
+                    WorldClientLogMessages.NoHandlerForOpcode(_melLog, _sourceFile, _netDirRecv, universalOpcode, packet.GetOpcode());
                     if (_isSuccessful == null)
                         _isSuccessful = false;
                 }
@@ -522,7 +530,7 @@ public partial class WorldClient
 
         if (result == AuthResult.AUTH_OK)
         {
-            Log.Print(LogType.Network, "Authentication succeeded!");
+            WorldClientLogMessages.AuthenticationSucceeded(_melNet, _sourceFile, _netDirNone);
             if (_queuePosition != 0 && GetSession().RealmSocket != null)
             {
                 _queuePosition = 0;

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -20,6 +20,10 @@ namespace HermesProxy.World;
 
 public static partial class GameData
 {
+    private static readonly Microsoft.Extensions.Logging.ILogger _melStorage = Log.CreateMelLogger(Log.CategoryStorage);
+    private static readonly string _sourceFile = nameof(GameData).PadRight(15);
+    private const string _netDirNone = "";
+
     // From CSV
     public static Dictionary<uint/*Build*/, Dictionary<string /*Platform*/, byte[] /*seed*/>> BuildAuthSeeds = [];
     public static SortedDictionary<uint, BroadcastText> BroadcastTextStore = [];
@@ -544,7 +548,7 @@ public static partial class GameData
     public static void LoadEverything()
     {
         long startTime = Stopwatch.GetTimestamp();
-        Log.Print(LogType.Storage, "Loading data files...");
+        GameDataLogMessages.LoadingDataFiles(_melStorage, _sourceFile, _netDirNone);
 
         Parallel.Invoke(
             LoadBuildAuthSeeds,
@@ -583,7 +587,7 @@ public static partial class GameData
             LoadHotfixes
         );
 
-        Log.Print(LogType.Storage, $"Finished loading data. Time taken: {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds} ms");
+        GameDataLogMessages.FinishedLoadingData(_melStorage, _sourceFile, _netDirNone, Stopwatch.GetElapsedTime(startTime).TotalMilliseconds);
     }
 
     public static void LoadBuildAuthSeeds()

--- a/HermesProxy/World/GameDataLogMessages.cs
+++ b/HermesProxy/World/GameDataLogMessages.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Logging;
+
+namespace HermesProxy.World;
+
+#pragma warning disable SYSLIB1015
+internal static partial class GameDataLogMessages
+{
+    // EventId 700-799 range is reserved for GameData.
+
+    [LoggerMessage(EventId = 700, Level = LogLevel.Information, Message = "Loading data files...")]
+    public static partial void LoadingDataFiles(ILogger logger, string SourceFile, string NetDir);
+
+    [LoggerMessage(EventId = 701, Level = LogLevel.Information, Message = "Finished loading data. Time taken: {Milliseconds} ms")]
+    public static partial void FinishedLoadingData(
+        ILogger logger, string SourceFile, string NetDir, double Milliseconds);
+}

--- a/HermesProxy/World/Logging/PacketLogMessages.cs
+++ b/HermesProxy/World/Logging/PacketLogMessages.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Logging;
+
+namespace HermesProxy.World.Logging;
+
+/// <summary>
+/// Source-generated logging methods for <see cref="ServerPacket"/> hot paths.
+/// The generator produces a static partial method body that:
+///   - calls <c>logger.IsEnabled(level)</c> before building the event
+///   - captures arguments into a struct state (no params array, no boxing for value types)
+///   - uses the message template verbatim at compile time (no runtime parsing)
+/// Template placeholders must match parameter names (case-insensitive for Serilog output lookup).
+///
+/// SYSLIB1015 is suppressed: <c>SourceFile</c> and <c>NetDir</c> are intentionally
+/// emitted as overflow properties so the Serilog output template can render them
+/// in their own columns rather than inlining them into the message.
+/// </summary>
+#pragma warning disable SYSLIB1015
+internal static partial class PacketLogMessages
+{
+    // EventId 1-2 range is reserved for ServerPacket span-path logs.
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Warning,
+        Message = "{Name} exceeded MaxSize ({Max}), using fallback")]
+    public static partial void SpanMissExceededMaxSize(
+        ILogger logger,
+        string SourceFile,
+        string Name,
+        int Max);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Trace, // MEL Trace maps to Serilog Verbose
+        Message = "{Name}: {Bytes}/{Max} bytes")]
+    public static partial void SpanStats(
+        ILogger logger,
+        string SourceFile,
+        string Name,
+        int Bytes,
+        int Max);
+}

--- a/HermesProxy/World/Logging/WorldClientLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldClientLogMessages.cs
@@ -1,0 +1,82 @@
+using HermesProxy.World.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace HermesProxy.World.Logging;
+
+/// <summary>
+/// Source-generated logging methods for <see cref="Client.WorldClient"/> hot paths.
+/// </summary>
+#pragma warning disable SYSLIB1015
+internal static partial class WorldClientLogMessages
+{
+    // EventId 200-299 range is reserved for WorldClient packet dispatch.
+
+    [LoggerMessage(
+        EventId = 200,
+        Level = LogLevel.Debug,
+        Message = "Received opcode {Opcode} ({OpcodeId}).")]
+    public static partial void PacketReceived(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        Opcode Opcode,
+        uint OpcodeId);
+
+    [LoggerMessage(
+        EventId = 201,
+        Level = LogLevel.Debug,
+        Message = "Sending opcode {Opcode} ({OpcodeId}) with size {Size}.")]
+    public static partial void PacketSent(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        Opcode Opcode,
+        uint OpcodeId,
+        ushort Size);
+
+    [LoggerMessage(
+        EventId = 202,
+        Level = LogLevel.Warning,
+        Message = "No handler for opcode {Opcode} ({OpcodeId}) (Got unknown packet from WorldServer)")]
+    public static partial void NoHandlerForOpcode(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        Opcode Opcode,
+        uint OpcodeId);
+
+    [LoggerMessage(
+        EventId = 203,
+        Level = LogLevel.Error,
+        Message = "Packet Read Error: {Message}")]
+    public static partial void PacketReadError(
+        ILogger logger,
+        System.Exception ex,
+        string SourceFile,
+        string NetDir,
+        string Message);
+
+    [LoggerMessage(EventId = 204, Level = LogLevel.Information, Message = "Connecting to world server...")]
+    public static partial void ConnectingToWorldServer(
+        ILogger logger, string SourceFile, string NetDir);
+
+    [LoggerMessage(
+        EventId = 205,
+        Level = LogLevel.Information,
+        Message = "World Server address {Address}:{Port} resolved as {ResolvedAddress}:{Port}")]
+    public static partial void WorldServerResolved(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string Address,
+        int Port,
+        string ResolvedAddress);
+
+    [LoggerMessage(EventId = 206, Level = LogLevel.Information, Message = "Connection established!")]
+    public static partial void ConnectionEstablished(
+        ILogger logger, string SourceFile, string NetDir);
+
+    [LoggerMessage(EventId = 207, Level = LogLevel.Information, Message = "Authentication succeeded!")]
+    public static partial void AuthenticationSucceeded(
+        ILogger logger, string SourceFile, string NetDir);
+}

--- a/HermesProxy/World/Logging/WorldSocketLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldSocketLogMessages.cs
@@ -1,0 +1,48 @@
+using HermesProxy.World.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace HermesProxy.World.Logging;
+
+/// <summary>
+/// Source-generated logging methods for <see cref="Server.WorldSocket"/> hot paths.
+/// <c>NetDir</c> and <c>SourceFile</c> are intentional overflow properties so the
+/// Serilog output template can render them in their own columns.
+/// </summary>
+#pragma warning disable SYSLIB1015
+internal static partial class WorldSocketLogMessages
+{
+    // EventId 100-199 range is reserved for WorldSocket packet dispatch.
+
+    [LoggerMessage(
+        EventId = 100,
+        Level = LogLevel.Debug,
+        Message = "Received opcode {Opcode} ({OpcodeId}).")]
+    public static partial void PacketReceived(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        Opcode Opcode,
+        uint OpcodeId);
+
+    [LoggerMessage(
+        EventId = 101,
+        Level = LogLevel.Debug,
+        Message = "Sending opcode {Opcode} ({OpcodeId}).")]
+    public static partial void PacketSent(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        Opcode Opcode,
+        uint OpcodeId);
+
+    [LoggerMessage(
+        EventId = 102,
+        Level = LogLevel.Warning,
+        Message = "No handler for opcode {Opcode} ({OpcodeId}) (Got unknown packet from ModernClient)")]
+    public static partial void NoHandlerForOpcode(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        Opcode Opcode,
+        uint OpcodeId);
+}

--- a/HermesProxy/World/Packet.cs
+++ b/HermesProxy/World/Packet.cs
@@ -23,6 +23,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Client;
+using HermesProxy.World.Logging;
 using System.Collections.Generic;
 
 namespace HermesProxy.World;
@@ -65,6 +66,12 @@ public abstract class ClientPacket : IDisposable
 
 public abstract class ServerPacket
 {
+    // Source-generated [LoggerMessage] methods use the MEL logger below.
+    // MinimumLevel.Override("Packet", _packetSwitch) still applies because we create the MEL logger
+    // with the "Packet" category name, which becomes SourceContext on the Serilog side.
+    private static readonly Microsoft.Extensions.Logging.ILogger _melLog = Log.CreateMelLogger(Log.CategoryPacket);
+    private static readonly string _sourceFile = nameof(ServerPacket).PadRight(15);
+
     protected ServerPacket(Opcode universalOpcode)
     {
         connectionType = ConnectionType.Realm;
@@ -134,13 +141,13 @@ public abstract class ServerPacket
                 // Negative return means packet exceeded MaxSize cap, fall back to standard Write()
                 if (bytesWritten < 0)
                 {
-                    Log.Print(LogType.SpanMiss, $"{GetType().Name} exceeded MaxSize ({spanWritable.MaxSize}), using fallback");
+                    PacketLogMessages.SpanMissExceededMaxSize(_melLog, _sourceFile, GetType().Name, spanWritable.MaxSize);
                     Write();
                     buffer = _worldPacket.GetData();
                 }
                 else
                 {
-                    Log.Print(LogType.SpanStats, $"{GetType().Name}: {bytesWritten}/{spanWritable.MaxSize} bytes");
+                    PacketLogMessages.SpanStats(_melLog, _sourceFile, GetType().Name, bytesWritten, spanWritable.MaxSize);
                     buffer = new byte[bytesWritten];
                     pooledBuffer.AsSpan(0, bytesWritten).CopyTo(buffer);
                 }

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -37,11 +37,19 @@ using System.Net;
 using BNetServer;
 using BNetServer.Services;
 using Google.Protobuf;
+using HermesProxy.World.Logging;
 
 namespace HermesProxy.World.Server;
 
 public partial class WorldSocket : SocketBase, BnetServices.INetwork
 {
+    // Source-generated [LoggerMessage] methods use this MEL logger. SourceFile and NetDir are
+    // passed per-call but resolve to the same cached strings, so they compile to const loads.
+    private static readonly Microsoft.Extensions.Logging.ILogger _melLog = Log.CreateMelLogger(Log.CategoryPacket);
+    private static readonly string _sourceFile = nameof(WorldSocket).PadRight(15);
+    private static readonly string _netDirRecv = Log.FormatDir(LogNetDir.C2P);
+    private static readonly string _netDirSend = Log.FormatDir(LogNetDir.P2C);
+
     static readonly string ClientConnectionInitialize = "WORLD OF WARCRAFT CONNECTION - CLIENT TO SERVER - V2";
     static readonly string ServerConnectionInitialize = "WORLD OF WARCRAFT CONNECTION - SERVER TO CLIENT - V2";
 
@@ -253,7 +261,7 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
         Opcode opcode = packet.GetUniversalOpcode(true);
 
-        Log.PrintNet(LogType.Debug, LogNetDir.C2P, $"Received opcode {opcode.ToString()} ({packet.GetOpcode()}).");
+        WorldSocketLogMessages.PacketReceived(_melLog, _sourceFile, _netDirRecv, opcode, packet.GetOpcode());
 
         if (opcode != Opcode.CMSG_HOTFIX_REQUEST && !header.IsValidSize())
         {
@@ -341,7 +349,7 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
             }
         }
         else
-            Log.PrintNet(LogType.Warn, LogNetDir.C2P, $"No handler for opcode {universalOpcode} ({packet.GetOpcode()}) (Got unknown packet from ModernClient)");
+            WorldSocketLogMessages.NoHandlerForOpcode(_melLog, _sourceFile, _netDirRecv, universalOpcode, packet.GetOpcode());
     }
 
     private void SendPacketToServer(WorldPacket packet, Opcode delayUntilOpcode = Opcode.MSG_NULL_ACTION)
@@ -384,7 +392,7 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
             Opcode universalOpcode = packet.GetUniversalOpcode();
             ushort opcode = (ushort)packet.GetOpcode();
 
-            Log.PrintNet(LogType.Debug, LogNetDir.P2C, $"Sending opcode {universalOpcode} ({(uint)opcode}).");
+            WorldSocketLogMessages.PacketSent(_melLog, _sourceFile, _netDirSend, universalOpcode, (uint)opcode);
 
             ByteBuffer buffer = new();
 

--- a/HermesProxy/World/SniffFile.cs
+++ b/HermesProxy/World/SniffFile.cs
@@ -10,16 +10,33 @@ namespace HermesProxy.World;
 
 public sealed class SniffFile
 {
+    // Monotonic counter suffixed to filenames so simultaneous sessions can't collide on the
+    // one-second-granular Unix timestamp (two logins in the same second previously raced for
+    // the same path).
+    private static int _sessionCounter = 0;
+
+    // 64 KB FileStream buffer — packet logging is bursty sequential writes; the default 4 KB
+    // buffer means more frequent syscalls. Larger buffer reduces kernel transitions.
+    private const int FileBufferSize = 64 * 1024;
+
     public SniffFile(string fileName, ushort build)
     {
         string dir = "PacketsLog";
         if (!Directory.Exists(dir))
             Directory.CreateDirectory(dir);
 
-        string file = fileName + "_" + build + "_" + Time.UnixTime + ".pkt";
+        int seq = Interlocked.Increment(ref _sessionCounter);
+        string file = fileName + "_" + build + "_" + Time.UnixTime + "_" + seq + ".pkt";
         string path = Path.Combine(dir, file);
 
-        _fileWriter = new BinaryWriter(File.Open(path, FileMode.Create));
+        var stream = new FileStream(
+            path,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.Read,
+            FileBufferSize,
+            FileOptions.SequentialScan);
+        _fileWriter = new BinaryWriter(stream);
         _gameVersion = build;
     }
     BinaryWriter _fileWriter;
@@ -42,7 +59,7 @@ public sealed class SniffFile
         }
     }
 
-    public void WritePacket(uint opcode, bool isFromClient, byte[] data)
+    public void WritePacket(uint opcode, bool isFromClient, ReadOnlySpan<byte> data)
     {
         lock (_lock)
         {
@@ -59,8 +76,8 @@ public sealed class SniffFile
                 _fileWriter.Write(packetSize);
                 _fileWriter.Write(opcode);
 
-                for (int i = 2; i < data.Length; i++)
-                    _fileWriter.Write(data[i]);
+                // Skip the 2-byte opcode prefix; single bulk write of the payload.
+                _fileWriter.Write(data[2..]);
             }
             else
             {
@@ -75,6 +92,15 @@ public sealed class SniffFile
 
     public void CloseFile()
     {
-        _fileWriter.Close();
+        // Guard against races with an in-flight WritePacket on another thread — session teardown
+        // can run concurrently with the last packets being flushed.
+        // Flush() is redundant here (BinaryWriter.Close -> FileStream.Dispose flushes the 64 KB
+        // buffer before closing the handle) but makes the intent explicit, and keeps the invariant
+        // that "CloseFile returned cleanly => all previously-written bytes are in the OS page cache".
+        lock (_lock)
+        {
+            _fileWriter.Flush();
+            _fileWriter.Close();
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ HermesProxy provides some internal chat commands:
 
 ## Command Line Arguments
 
-| Argument                   | Description                                                  |
-|----------------------------|--------------------------------------------------------------|
-| `--config <filename>`      | Specify a config file (default: `HermesProxy.config`)        |
-| `--set <key>=<value>`      | Override a specific config value at runtime                  |
-| `--no-version-check`       | Disable the check for newer versions on startup              |
+| Argument                   | Description                                                                                     |
+|----------------------------|-------------------------------------------------------------------------------------------------|
+| `--config <filename>`      | Specify a config file (default: `HermesProxy.config`)                                           |
+| `--set <key>=<value>`      | Override a specific config value at runtime (repeatable)                                        |
+| `--no-version-check`       | Disable the check for newer versions on startup                                                 |
+| `--metrics`                | Enable per-opcode latency metrics collection. A top-20 summary is logged every 60 s (see below) |
 
 **Examples:**
 ```bash
@@ -86,7 +87,24 @@ HermesProxy --set ServerAddress=logon.example.com --set ServerPort=3725
 
 # Combine config file with overrides
 HermesProxy --config Production.config --set DebugOutput=true
+
+# Run with latency metrics enabled (a summary is written to the log every 60 seconds)
+HermesProxy --metrics
+
+# Metrics + verbose packet capture, handy when profiling a suspicious opcode
+HermesProxy --metrics --set Log.Packet.MinimumLevel=Debug
 ```
+
+### `--metrics` Details
+
+When enabled, HermesProxy tracks per-opcode round-trip latency for both directions (Client → Server and Server → Client) and emits a summary line every minute through the `Server` logging category. Nothing is printed when no traffic has been observed, so idle proxies stay quiet.
+
+```
+17:42:14 | I | S | Server          | Latency Metrics: 842 C->S opcodes, 1203 S->C opcodes tracked
+17:42:14 | I | S | Server          | <top 20 opcodes with min / max / avg / p99 latency>
+```
+
+Useful for: identifying slow-dispatching opcodes, spotting regressions after a packet-handler change, and validating that hot-path migrations didn't shift the latency profile. Leave it off in normal play — it has a small per-packet timestamp overhead.
 
 ## Configuration Reference
 
@@ -126,13 +144,144 @@ All ports must be in the range `1-65535`.
 | `ReportedOS`       | `OSX`   | `OSX`, `Win`, etc.              | OS identifier sent to the legacy server  |
 | `ReportedPlatform` | `x86`   | `x86`, `x64`                    | Platform identifier sent to legacy server|
 
-### Logging Settings
+### Logging
 
-| Setting        | Default | Description                                                          |
-|----------------|---------|----------------------------------------------------------------------|
-| `DebugOutput`  | `false` | Print additional debug information to console                        |
-| `PacketsLog`   | `true`  | Save each session's packets to files in `PacketsLog` directory       |
-| `SpanStatsLog` | `false` | Log statistics about Span-based packet serialization (for profiling) |
+HermesProxy ships with a Serilog-backed logger that splits **severity** (single letter: `V`, `D`, `I`, `W`, `E`, `F`) from **category** (single letter: `S` = Server, `N` = Network, `T` = Storage, `P` = Packet) and colors property values in the console output (strings in cyan, numbers in yellow) so the interesting bits stand out at a glance.
+
+```
+17:00:33 | I | S | Server          | Starting WorldSocket service on 127.0.0.1:8086...
+17:00:34 | I | S | BnetTcpSession  | Accepting connection from 127.0.0.1:49695.
+17:09:19 | W | P | WorldSocket     | C>P S | No handler for opcode CMSG_BATTLE_PAY_GET_PURCHASE_LIST (14019) (Got unknown packet from ModernClient)
+```
+
+Each category has its own minimum level so you can dial verbosity in independently — the console has an additional floor applied on top, which lets you keep the console tidy while the file captures enough detail for a bug report.
+
+#### Reading a Log Line
+
+Every line has the same pipe-delimited shape so it's easy to scan vertically:
+
+```
+HH:mm:ss | L | C | SourceFile      | [NetDir | ] message
+```
+
+Worked example:
+
+```
+17:09:19 | W | P | WorldSocket     | C>P S | No handler for opcode CMSG_BATTLE_PAY_GET_PURCHASE_LIST (14019)
+   ▲       ▲   ▲        ▲              ▲                       ▲                                      ▲
+   │       │   │        │              │                       │                                      └── number, yellow
+   │       │   │        │              │                       └── string, bright cyan
+   │       │   │        │              └── optional network-direction tag (only on packet-flow events)
+   │       │   │        └── caller file (class name, padded to 15 chars) — always default color
+   │       │   └── category letter — blue(S) / green(N) / cyan(T) / magenta(P)
+   │       └── severity letter — yellow(W) / red(E,F) / gray(V,D) / default(I)
+   └── local clock (24h)
+```
+
+**Severity letter — `L`**
+
+The first letter encodes the severity so you can grep / filter without remembering words:
+
+| Letter | Level         | Console color | When you see it                                                     |
+|--------|---------------|---------------|---------------------------------------------------------------------|
+| `V`    | `Verbose`     | gray          | Per-packet `SpanStats` — only when `Log.Packet.MinimumLevel=Verbose` |
+| `D`    | `Debug`       | gray          | Opcode send/receive traces when debug is enabled                    |
+| `I`    | `Information` | default       | Normal lifecycle events — the default minimum                       |
+| `W`    | `Warning`     | yellow        | Recoverable issues: unknown opcode, unimplemented service, SpanMiss |
+| `E`    | `Error`       | red           | Socket errors, auth failures, decrypt failures                      |
+| `F`    | `Fatal`       | bold red      | Reserved for unrecoverable conditions                               |
+
+**Category letter — `C`**
+
+The second letter tells you *which subsystem* is talking, independent of severity:
+
+| Letter | Category  | Console color | Covers                                                                |
+|--------|-----------|---------------|-----------------------------------------------------------------------|
+| `S`    | `Server`  | blue          | Lifecycle, config, startup, version checks, service managers         |
+| `N`    | `Network` | green         | Auth/world-socket connect/disconnect, handshake, network thread      |
+| `T`    | `Storage` | cyan          | GameData load, CSV/DB2 readers, hotfix files                          |
+| `P`    | `Packet`  | magenta       | Opcode dispatch, per-packet traces, Span-based serialization fallback |
+
+This is also the selector for per-category verbosity: `Log.Packet.MinimumLevel=Debug` affects only lines where the category letter is `P`.
+
+**Network direction tag — `NetDir`** *(optional)*
+
+When a line represents packet flow between client, proxy, and server, the message is prefixed with a 5-character flow diagram. `C` = game client, `P` = HermesProxy, `S` = legacy server; the `>` or `<` marks the direction:
+
+| Tag     | Meaning                                       |
+|---------|-----------------------------------------------|
+| `C>P S` | Client → Proxy — packet received from client  |
+| `C<P S` | Proxy → Client — packet sent to client        |
+| `C P>S` | Proxy → Server — packet forwarded to server   |
+| `C P<S` | Server → Proxy — packet received from server  |
+
+Lines without this tag are not packet-flow events (startup, config, etc.).
+
+**Message and property values**
+
+Everything after the final `|` is the human-readable message. The literal text stays at the terminal default color; property values substituted into the message are colored by type — strings go bright cyan (`CMSG_BATTLE_PAY_GET_PURCHASE_LIST`, `PROTONOX`, `192.168.88.55`), numbers go bright yellow (`14019`, `8085`, `42597`). When you're scanning for a specific opcode or account, you can spot it on color alone.
+
+In the rolling file (`Logs/hermes-YYYYMMDD.log`) the same layout is used but without ANSI codes, so it stays grep-friendly and safe to paste into a bug report.
+
+#### Logging Settings
+
+| Setting                       | Default       | Description                                                                                                          |
+|-------------------------------|---------------|----------------------------------------------------------------------------------------------------------------------|
+| `Log.MinimumLevel`            | `Information` | Absolute floor across all sinks. Events below this level are dropped before categories/sinks are checked.            |
+| `Log.Server.MinimumLevel`     | `Information` | Category override for `Server` (lifecycle, config, startup). Rendered as `S`.                                        |
+| `Log.Network.MinimumLevel`    | `Information` | Category override for `Network` (auth/world socket connect, handshake). Rendered as `N`.                             |
+| `Log.Storage.MinimumLevel`    | `Information` | Category override for `Storage` (GameData, CSV/DB2, hotfixes). Rendered as `T`.                                      |
+| `Log.Packet.MinimumLevel`     | `Warning`     | Category override for `Packet` (opcode dispatch, span fallback/stats). Rendered as `P`. `Verbose` enables SpanStats. |
+| `Log.Console.MinimumLevel`    | `Information` | Additional floor applied ONLY to the console. File sink captures everything the categories allow.                    |
+| `Log.ToFile`                  | `true`        | Write a daily rolling log file to `Log.Directory/hermes-YYYY-MM-DD.log`. Last 30 days are retained automatically.    |
+| `Log.Directory`               | `Logs`        | Directory (relative to the working directory) where rolling log files are placed.                                    |
+| `PacketsLog`                  | `true`        | Dump each session's raw packets to a `.pkt` file in `PacketsLog/` for replay / inspection (unrelated to text logs).  |
+| `DebugOutput` *(legacy)*      | `false`       | Back-compat shortcut — lowers `Log.MinimumLevel` and `Log.Console.MinimumLevel` to `Debug`.                          |
+| `SpanStatsLog` *(legacy)*     | `false`       | Back-compat shortcut — lowers `Log.Packet.MinimumLevel` to `Verbose`.                                                |
+
+Valid level values (case-insensitive): `Verbose`, `Debug`, `Information`, `Warning`, `Error`, `Fatal`.
+
+#### CLI Examples
+
+All logging settings can be overridden at runtime with `--set key=value` (repeat the flag for multiple overrides).
+
+```bash
+# Capture packet-level debug detail in the log file while keeping the console quiet.
+# Ideal default for "always-on" logging — when a user reports an issue, ask for
+# Logs/hermes-YYYYMMDD.log and you already have the Debug-level context.
+HermesProxy --set Log.Packet.MinimumLevel=Debug --set Log.Console.MinimumLevel=Information
+
+# Crank everything to maximum verbosity (console included) for interactive debugging.
+HermesProxy --set Log.MinimumLevel=Verbose --set Log.Console.MinimumLevel=Verbose --set Log.Packet.MinimumLevel=Verbose
+
+# Enable per-packet SpanStats output to the file only (useful for profiling packet serialization).
+HermesProxy --set Log.Packet.MinimumLevel=Verbose --set Log.Console.MinimumLevel=Information
+
+# Reduce noise on a long-running proxy — warnings and above only, even in the file.
+HermesProxy --set Log.MinimumLevel=Warning --set Log.Console.MinimumLevel=Warning
+
+# Silence the Packet category entirely (e.g. when you're debugging auth and don't care about
+# "No handler for opcode" warnings), while leaving Server/Network/Storage at defaults.
+HermesProxy --set Log.Packet.MinimumLevel=Error
+
+# Opt out of the rolling file sink if disk writes are undesirable (headless containers, etc.).
+HermesProxy --set Log.ToFile=false
+
+# Point the file sink at a different location.
+HermesProxy --set Log.Directory=D:/HermesLogs
+
+# Legacy flags still work via the back-compat shortcuts.
+HermesProxy --set DebugOutput=true          # == Log.MinimumLevel=Debug + Log.Console.MinimumLevel=Debug
+HermesProxy --set SpanStatsLog=true         # == Log.Packet.MinimumLevel=Verbose
+```
+
+#### Bug-Report Workflow
+
+With the defaults (`Log.ToFile=true`, file captures per-category levels, console filtered by `Log.Console.MinimumLevel`), a typical error triage goes:
+
+1. User reports the issue and shares `Logs/hermes-<date>.log` for the day it happened.
+2. The file contains all startup context (version, client/server build, bound ports, resolved realms) and the per-session flow (auth, realm-list, world-socket handshake, opcode handler warnings, etc.).
+3. If you need even more detail for a particular subsystem, ask the user to rerun with for example `--set Log.Packet.MinimumLevel=Debug` and resend the log.
 
 ### Example Configuration
 
@@ -145,8 +294,11 @@ All ports must be in the range `1-65535`.
     <add key="ServerAddress" value="logon.example.com" />
     <add key="ServerPort" value="3724" />
     <add key="BNetPort" value="1119" />
-    <add key="DebugOutput" value="false" />
     <add key="PacketsLog" value="true" />
+    <add key="Log.MinimumLevel" value="Information" />
+    <add key="Log.Packet.MinimumLevel" value="Debug" />
+    <add key="Log.Console.MinimumLevel" value="Information" />
+    <add key="Log.ToFile" value="true" />
   </appSettings>
 </configuration>
 ```


### PR DESCRIPTION
## Summary

- Replaces `Framework/Logging/Log.cs` with a Serilog-backed pipeline that preserves the original line shape and the `C>P S` / `C<P S` / `C P>S` / `C P<S` network-direction annotation, while adding per-category + per-sink level control, a rolling daily file sink, and per-property console coloring.
- Converts 47 hot-path / high-visibility log call sites to Microsoft.Extensions.Logging `[LoggerMessage]` source-generated partial methods bridged to Serilog, giving **zero-allocation disabled paths** and compile-time template/argument safety.
- Fixes a concurrent-session filename collision in `SniffFile` and cuts per-packet write CPU by replacing a byte-by-byte loop with a single bulk write.
- Adds `LoggingBenchmarks` with before/after numbers, documents everything in the README, and adds the missing `--metrics` CLI flag docs.

## Commits

| Hash | Title |
|---|---|
| `72e8fd6` | Replace custom logger with Serilog-backed pipeline |
| `e0a9e2c` | Migrate hot-path and high-visibility log call sites to source-gen |
| `c502d67` | SniffFile: fix concurrent-session filename collision and cut write overhead |
| `baf35e8` | Add LoggingBenchmarks to prove allocation / latency claims |
| `515e9d2` | docs(README): document the new logging system and --metrics CLI flag |

Each commit stands on its own: compiles, test suite passes (296/296), runtime behavior consistent at every point. Bisectable.

## Log line format — before / after

**Before** — single 9-char severity/category column:

```
14:45:00 |  SpanMiss| Packet          | MonsterMove exceeded MaxSize (366), using fallback
14:45:00 |  Warning | WorldSocket     | C>P S | No handler for opcode CMSG_BATTLE_PAY_GET_PURCHASE_LIST (14019) ...
```

**After** — two single-letter columns, property values type-colored:

```
14:45:00 | W | P | Packet          | MonsterMove exceeded MaxSize (366), using fallback
14:45:00 | W | P | WorldSocket     | C>P S | No handler for opcode CMSG_BATTLE_PAY_GET_PURCHASE_LIST (14019) ...
```

- `L` (severity): `V` `D` `I` `W` `E` `F` — colored yellow / red / bold red / gray per level
- `C` (category): `S` Server (blue) / `N` Network (green) / `T` Storage (cyan) / `P` Packet (magenta)
- Property values inside messages: strings **bright cyan** (`CMSG_BATTLE_PAY_GET_PURCHASE_LIST`), numbers **bright yellow** (`14019`, `366`). Literal text stays default — the values stand out.

The rolling file (`Logs/hermes-YYYYMMDD.log`, 30-day retention) uses the same layout without ANSI so it stays grep-friendly and pasteable into bug reports.

## Performance — structured logging benchmark

`HermesProxy.Benchmarks/LoggingBenchmarks.cs`, `ShortRunJob`, `MemoryDiagnoser`, .NET 10. Each scenario writes the equivalent of `_log.Debug("Received opcode {Opcode} ({OpcodeId}).", ...)`:

| Scenario                                                   | Mean        | Allocated | Alloc vs baseline |
|------------------------------------------------------------|------------:|----------:|------------------:|
| 1a. Interpolated, **disabled** (old pattern, baseline)     |    43.70 ns |     144 B |             1.00x |
| 1b. Interpolated, **enabled**                              |   408.17 ns |     536 B |             3.72x |
| 2a. Structured template, **disabled**                      |     0.14 ns |       0 B |         **0.00x** |
| 2b. Structured template, **enabled**                       |   225.45 ns |     424 B |             2.94x |
| 3a. `[LoggerMessage]` (direct MEL), **disabled**           |     0.84 ns |       0 B |         **0.00x** |
| 3b. `[LoggerMessage]` (direct MEL), **enabled**            |   545.33 ns |     768 B |             5.33x |
| **4a. `[LoggerMessage]` + SwappableMelLogger, disabled** ⭐ | **1.73 ns** |   **0 B** |         **0.00x** |
| **4b. `[LoggerMessage]` + SwappableMelLogger, enabled** ⭐  | **529.35 ns** | **768 B** |           5.33x |

⭐ = production path used by the migrated call sites.

Takeaways:

1. **Zero allocations when the level is filtered out** — the important case in production where `Packet` category default is `Warning` but source is peppered with `Debug` / `Verbose` traces. Old pattern was allocating **144 B on every such call**; now it's 0 B.
2. **SwappableMelLogger overhead is ~1 ns / 0 bytes** — the per-instance cache keyed on factory identity eliminates the `SerilogLoggerProvider.CreateLogger` allocation that would otherwise fire on every call (an earlier iteration without the cache showed 130 ns / 936 B for the disabled case; that was caught by this benchmark and fixed before merge).
3. The enabled path is slightly slower via the MEL → Serilog bridge (545 vs 225 ns) because MEL's `TState` → Serilog-property translation does extra work, but **the enabled cost only applies when a sink actually consumes the event**, and we gain compile-time template safety for it.

## Performance — SniffFile (packet dump writer)

Not benchmarked with BenchmarkDotNet, but concrete changes to the packet hot path:

| Improvement | Before | After |
|---|---|---|
| Outbound client packet payload write | `for (i = 2; i < data.Length; i++) _fileWriter.Write(data[i]);` — ~1000 virtual-dispatch calls for a 1 KB packet | Single `BinaryWriter.Write(ReadOnlySpan<byte>)` bulk write |
| `FileStream` buffer | 4 KB default (more syscalls under burst) | 64 KB with `FileOptions.SequentialScan` |
| Filename uniqueness | `modern_<build>_<unixtime>.pkt` — 1-second resolution → collision on simultaneous logins | `modern_<build>_<unixtime>_<seq>.pkt` via `Interlocked.Increment`, guaranteed unique |
| `CloseFile()` vs in-flight `WritePacket` | Unlocked → `ObjectDisposedException` race possible | Takes `_lock` + explicit `Flush()` before `Close()` |

`WritePacket` signature also changed from `byte[] data` to `ReadOnlySpan<byte> data` — existing callers compile unchanged via implicit conversion; future callers with a `Span<byte>` from `SpanPacketWriter` can pass it directly.

## Configuration reference

New `HermesProxy.config` keys (all overridable via `--set`):

| Setting                    | Default       | Purpose                                                                              |
|----------------------------|---------------|--------------------------------------------------------------------------------------|
| `Log.MinimumLevel`         | `Information` | Absolute floor across all sinks                                                      |
| `Log.Server.MinimumLevel`  | `Information` | Per-category override for `S`                                                        |
| `Log.Network.MinimumLevel` | `Information` | Per-category override for `N`                                                        |
| `Log.Storage.MinimumLevel` | `Information` | Per-category override for `T`                                                        |
| `Log.Packet.MinimumLevel`  | `Warning`     | Per-category override for `P` (`Verbose` enables SpanStats)                          |
| `Log.Console.MinimumLevel` | `Information` | Additional floor applied **only** to console — file gets category output unfiltered  |
| `Log.ToFile`               | **`true`**    | Rolling daily file at `Log.Directory/hermes-YYYY-MM-DD.log`, 30-day retention        |
| `Log.Directory`            | `Logs`        | Directory for rolling log files                                                      |

Legacy `DebugOutput` / `SpanStatsLog` keys remain supported as back-compat shortcuts (translated into the new per-category levels).

**Recommended bug-report-friendly setup** (now the default when users fall back to config defaults):

```xml
<add key="Log.Packet.MinimumLevel"  value="Warning" />
<add key="Log.Console.MinimumLevel" value="Information" />
<add key="Log.ToFile"               value="true" />
```

When a user reports an issue, ask for `Logs/hermes-YYYYMMDD.log` for the affected day and you have full startup context + per-session flow.

## CLI examples

```bash
# Capture packet debug in the log file, keep console at Info — the ideal default
# for "always-on logging for bug reports".
HermesProxy --set Log.Packet.MinimumLevel=Debug --set Log.Console.MinimumLevel=Information

# Crank everything to max verbosity for interactive debugging.
HermesProxy --set Log.MinimumLevel=Verbose --set Log.Console.MinimumLevel=Verbose --set Log.Packet.MinimumLevel=Verbose

# Enable SpanStats output to file only (useful for profiling packet serialization).
HermesProxy --set Log.Packet.MinimumLevel=Verbose --set Log.Console.MinimumLevel=Information

# Silence the Packet category entirely while debugging auth.
HermesProxy --set Log.Packet.MinimumLevel=Error

# Opt out of the file sink.
HermesProxy --set Log.ToFile=false

# Alternate log directory.
HermesProxy --set Log.Directory=D:/HermesLogs

# Legacy shortcuts still work via back-compat translation.
HermesProxy --set DebugOutput=true      # lowers Log.MinimumLevel + Log.Console.MinimumLevel to Debug
HermesProxy --set SpanStatsLog=true     # lowers Log.Packet.MinimumLevel to Verbose
```

## What got migrated to source-gen

47 call sites across 11 files, with `EventId` ranges namespaced per class so future filtering is straightforward:

| Class | EventId range | Calls |
|---|---|---|
| `ServerPacket` | 1–2 | 2 (SpanMiss + SpanStats) |
| `WorldSocket` | 100–102 | 3 (receive / send / no-handler) |
| `WorldClient` | 200–207 | 8 (receive / send / no-handler / read-error / connection lifecycle) |
| `AuthClient` | 300–315 | 16 (full auth + realmlist flow with structured enums + exceptions) |
| `RealmManager` | 400–402 | 3 (added / updating / table row) |
| `BnetServices.ServiceManager` | 500–504 | 5 (service dispatch + handler-registration diagnostics) |
| `Server` | 600–606 | 7 (startup lifecycle + version / build / opcode counts) |
| `GameData` | 700–701 | 2 (loading / finished-loading) |
| `BnetTcpSession` | 800 | 1 (accepting connection) |
| `NetworkThread` | 900 | 1 (thread starting) |

Remaining ~236 call sites still use the `Log.Print` adapter — all startup / per-session one-shots where the allocation overhead of interpolation is insignificant. Incremental migration can continue when surrounding code is touched.

## Behavioral notes for reviewers

- **`Server.cs` captures its MEL loggers before `Log.Configure` runs.** The `SwappableMelLogger` wrapper re-resolves through the current MEL factory on every call (with a per-instance cache keyed on factory identity) specifically to make this safe. Without that wrapper, captures would point at the pre-configure bootstrap pipeline that `Log.Configure` later disposes, and writes would silently drop. This was caught during development — there's a comment in `Server.cs` explaining why the wrapper exists.
- **The adapter (`Log.Print` / `Log.PrintNet`) passes the pre-formatted text as the message template itself** (with `{` / `}` escaped), not as a `{Text}` property. This prevents Serilog's console `String` theme from coloring the entire message cyan — coloring only applies to actual property values from structured templates.
- **File sink always creates files on-demand** (no file-system activity if `Log.ToFile=false`). Uses `FileShare.Read` so you can `tail` / inspect `.pkt` and `.log` files from another process while the proxy runs.

## Test plan

- [x] `dotnet build HermesProxy.csproj -c Release` — clean (0 warnings, 0 errors)
- [x] `dotnet test HermesProxy.Tests` — 296/296 passing
- [x] `dotnet run --project HermesProxy.Benchmarks -c Release -- --filter "*LoggingBenchmarks*"` — numbers match the table above
- [x] Live smoke test: full startup + auth + realmlist + world connect flow renders with expected per-property coloring, rolling log file created at `Logs/hermes-20260419.log`, format matches the pre-migration layout
- [x] Second reviewer to visually compare `default.log` (pre-PR) vs a fresh `hermes-YYYYMMDD.log` on this branch side-by-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)
