### PR TITLE
ci: serialize Release runs + publish linux-arm64 artifact

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -93,13 +93,20 @@ jobs:
         include:
           - os: windows
             artifact: Windows
-            runtime: ''
+            runtimeArg: '--use-current-runtime'
           - os: ubuntu
             artifact: Ubuntu
-            runtime: ''
+            runtimeArg: '--use-current-runtime'
+          # linux-arm64: cross-compile from the x64 ubuntu runner. .NET SDK
+          # supports cross-RID self-contained publish, so no ARM runner is
+          # needed. The verify step below only executes the x64 artifact;
+          # arm64 is built but not smoke-tested in CI (would need qemu).
+          - os: ubuntu
+            artifact: Ubuntu-arm64
+            runtimeArg: '--runtime linux-arm64'
           - os: macos
             artifact: MacOS
-            runtime: ''
+            runtimeArg: ''
     runs-on: ${{ matrix.os }}-latest
 
     steps:
@@ -130,7 +137,7 @@ jobs:
 
       - name: Publish
         if: matrix.os != 'macos'
-        run: dotnet publish HermesProxy --configuration Release --use-current-runtime -p:UsePublishBuildSettings=true -p:UpdateVersionProperties=false -p:Version=${{ steps.ver.outputs.semver }} -p:AssemblyVersion=${{ steps.ver.outputs.semver }} -p:FileVersion=${{ steps.ver.outputs.semver }} -p:InformationalVersion=${{ steps.ver.outputs.semver }}
+        run: dotnet publish HermesProxy --configuration Release ${{ matrix.runtimeArg }} -p:UsePublishBuildSettings=true -p:UpdateVersionProperties=false -p:Version=${{ steps.ver.outputs.semver }} -p:AssemblyVersion=${{ steps.ver.outputs.semver }} -p:FileVersion=${{ steps.ver.outputs.semver }} -p:InformationalVersion=${{ steps.ver.outputs.semver }}
 
       - name: Publish (MacOS x86_64 and arm64)
         if: matrix.os == 'macos'
@@ -204,8 +211,12 @@ jobs:
           find artifacts -type f -name "HermesProxy-*" | sort
           echo ""
 
-          for platform in Windows Ubuntu MacOS; do
-            files=$(find artifacts -name "HermesProxy-${platform}-*" -type f | head -1)
+          # Ubuntu matches both -Ubuntu-v* (x64) and -Ubuntu-arm64-v* — list
+          # each flavor explicitly so a missing arm64 artifact fails here
+          # instead of silently shipping. Suffix regex anchors on '-v' so
+          # 'Ubuntu' doesn't accidentally swallow 'Ubuntu-arm64'.
+          for platform in "Windows-v" "Ubuntu-v" "Ubuntu-arm64-v" "MacOS-v"; do
+            files=$(find artifacts -name "HermesProxy-${platform}*" -type f | head -1)
             if [ -z "$files" ]; then
               echo "FAIL: Missing artifact for $platform"
               exit 1
@@ -220,12 +231,16 @@ jobs:
 
       - name: Verify Linux binary executes
         run: |
-          tarball=$(find artifacts -name "HermesProxy-Ubuntu-*.tar.gz" -type f | head -1)
+          # Only the x64 artifact runs on ubuntu-latest (x64). The arm64
+          # artifact is cross-compiled and can't be smoke-tested here
+          # without qemu-user. Pattern 'Ubuntu-v*' anchors to exclude
+          # 'Ubuntu-arm64-v*'.
+          tarball=$(find artifacts -name "HermesProxy-Ubuntu-v*.tar.gz" -type f | head -1)
           tar -xzf "$tarball"
-          dir=$(find . -maxdepth 1 -name "HermesProxy-Ubuntu-*" -type d | head -1)
+          dir=$(find . -maxdepth 1 -name "HermesProxy-Ubuntu-v*" -type d | head -1)
           chmod +x "$dir/HermesProxy"
           "$dir/HermesProxy" --help || true
-          echo "OK: Linux binary executes"
+          echo "OK: Linux x64 binary executes"
 
   release:
     needs: [version, test, build, verify]

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -11,6 +11,16 @@ on:
         required: false
         type: string
 
+# Serialize release runs so a second PR merging while the first is still
+# building can't race the "Compute next version" step and ship an artifact
+# from an older commit. cancel-in-progress is deliberately false — we do
+# NOT want to interrupt a running release mid-upload and leave a partial
+# GitHub release. Each queued run recomputes the next version tag, so the
+# second run will produce the *next* patch (not overwrite the first).
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   DOTNET_VERSION: '10.0.x'
   DOTNET_NOLOGO: true


### PR DESCRIPTION
## Summary

Two CI changes to `.github/workflows/Release.yml`, both discovered while diagnosing issue #37:

1. **Serialize release runs** so two PRs merging in quick succession can't race the pipeline and ship artifacts from the wrong commit. This is the actual bug behind #37.
2. **Publish a `linux-arm64` artifact** cross-compiled from the x64 ubuntu runner, so ARM SBC / cloud users don't have to build from source.

## 1. Serialize release runs (#37 root cause)

`@mslookup` reported on #37 that HermesProxy 4.2.5 Linux fails at startup with the same `MissingMethodException: Cannot dynamically create an instance of type 'System.Configuration.ClientConfigurationHost'` that PR #36 was supposed to fix. The v4.2.5 Linux binary was actually built from commit `b252bbd` (PR #35 merge), **before** the trim fix in #36 (`b225825`) landed — verified by:

- Version banner prints `4.2.5+3(b252bbd)` (GitVersion's `ShortSha`).
- `git merge-base --is-ancestor b225825 b252bbd` → not an ancestor.
- `git show b252bbd:HermesProxy/HermesProxy.csproj` has no `<TrimmerRootAssembly>` entry.

What happened: PR #35 merged and triggered Release. While that build was running, PR #36 merged. `gh release create --generate-notes` at the end of PR #35's run pulled PRs from the current master state and listed both PRs in the notes, but the binaries uploaded were frozen at `b252bbd`. So the release looked fine on GitHub but the artifacts didn't actually contain PR #36.

Reproduced end-to-end on Debian aarch64:
- Pre-fix (`b252bbd`) build → same `MissingMethodException` stack trace as #37, version banner `4.2.5+3(b252bbd)` (exact match).
- Post-fix (master HEAD) build → clean startup, all four listeners bind, banner `4.2.6+6(02c2a20)`.

### Fix

```yaml
concurrency:
  group: release-${{ github.ref }}
  cancel-in-progress: false
```

`cancel-in-progress: false` (not `true` like `Build_Proxy.yml`) — we do NOT want to interrupt an in-progress release mid-upload and leave a half-published GitHub release. Queued runs recompute the next version tag when they finally run, so the second run ships the *next* patch rather than overwriting the first.

## 2. linux-arm64 artifact

Cross-compiles on the x64 `ubuntu-latest` runner via `--runtime linux-arm64`. .NET SDK handles cross-RID self-contained publish natively — no ARM runner required. Produces `HermesProxy-Ubuntu-arm64-vX.Y.Z.tar.gz` alongside the existing `HermesProxy-Ubuntu-vX.Y.Z.tar.gz` (x64).

Targets that previously had to build from source: Raspberry Pi 4/5, Orange Pi, AWS Graviton, Ampere, Azure/GCP Arm instances, Apple Silicon Linux VMs, etc.

### Matrix + verify changes

- Renamed the unused `runtime: ''` matrix field to `runtimeArg` and populated it with the full flag (`--use-current-runtime` or `--runtime linux-arm64`). Publish step just substitutes it verbatim.
- Added `Ubuntu-arm64` matrix entry on `ubuntu-latest`.
- Tightened the "Verify artifacts exist" loop: `HermesProxy-${platform}-*` matched both x64 and arm64 Ubuntu tarballs, so a missing arm64 artifact would have silently passed. Now lists each flavor explicitly.
- "Verify Linux binary executes" pattern tightened to `Ubuntu-v*.tar.gz` so it only tries to exec the x64 artifact. arm64 can't run on the x64 runner without qemu-user; skipping its smoke test is acceptable because publish-time trim analysis is arch-agnostic.

Tested locally: cross-compile produces a 59 MB self-contained single file; runs cleanly on Debian 12 aarch64 (Orange Pi 5 Pro).

## Follow-up (not in this PR)

Merging this PR will itself trigger a Release run and cut **v4.2.6** from master HEAD — which carries the trim fix + the Serilog logging work from #38 + the new arm64 artifact. That v4.2.6 is what #37's reporter should download.

## Test plan

- [ ] Merge PR — Release workflow should complete one run cleanly and tag v4.2.6.
- [ ] Four artifacts present on the v4.2.6 release: `Windows`, `Ubuntu` (x64), `Ubuntu-arm64`, `MacOS` (universal).
- [ ] `HermesProxy-Ubuntu-v4.2.6.tar.gz` banner prints `Version … 4.2.6(<hash>)` **without** the `+N(hash)` suffix (suffix would mean the race happened again).
- [ ] `HermesProxy-Ubuntu-arm64-v4.2.6.tar.gz` runs on an arm64 Linux host (already spot-checked locally on Debian 12 aarch64).
- [ ] No `MissingMethodException` on startup.
- [ ] Ask #37 reporter to verify on their Ubuntu 24.04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)