### PR TITLE
tests: centralize ClientBuild setup via ModuleInitializer, unfilter MovementInfoSpanTests

### DIFF
--- a/.github/workflows/Build_Proxy.yml
+++ b/.github/workflows/Build_Proxy.yml
@@ -42,7 +42,7 @@ jobs:
         run: dotnet restore
 
       - name: Test
-        run: dotnet test --no-restore --filter "FullyQualifiedName!~MovementInfoSpanTests"
+        run: dotnet test --no-restore
 
   build:
     strategy:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -89,7 +89,7 @@ jobs:
         run: dotnet restore
 
       - name: Test
-        run: dotnet test --no-restore --filter "FullyQualifiedName!~MovementInfoSpanTests"
+        run: dotnet test --no-restore
 
   build:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true

--- a/HermesProxy.Tests/Framework/SpanPacketTests.cs
+++ b/HermesProxy.Tests/Framework/SpanPacketTests.cs
@@ -563,26 +563,12 @@ public class SpanPacketRoundTripTests
 }
 
 /// <summary>
-/// Note: Full MovementInfo comparison tests cannot run in unit tests because
-/// WriteMovementInfoModern depends on ModernVersion which requires application-level
-/// configuration. The Span-based implementation should be verified through integration
-/// testing with the actual proxy.
-///
-/// These tests verify that the Span-based writer produces reasonable output and
-/// doesn't crash for various MovementInfo configurations.
+/// Verifies that the Span-based MovementInfo writer produces reasonable output and
+/// doesn't crash for various MovementInfo configurations. ModernVersion is satisfied
+/// by the assembly-level ModuleInitializer that pins ClientBuild before any test loads.
 /// </summary>
 public class MovementInfoSpanTests
 {
-    static MovementInfoSpanTests()
-    {
-        // Initialize required settings for ModernVersion static constructor
-        // This must run before any test that uses ModernVersion.AddedInVersion()
-        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
-        {
-            global::Framework.Settings.ClientBuild = ClientVersionBuild.V9_0_1_36216;
-        }
-    }
-
     [Fact]
     public void WriteMovementInfoModernToSpan_Simple_ProducesOutput()
     {

--- a/HermesProxy.Tests/TestModuleInitializer.cs
+++ b/HermesProxy.Tests/TestModuleInitializer.cs
@@ -1,0 +1,14 @@
+using System.Runtime.CompilerServices;
+using Framework;
+using HermesProxy.Enums;
+
+namespace HermesProxy.Tests;
+
+internal static class TestModuleInitializer
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
+    }
+}

--- a/HermesProxy.Tests/World/MonsterMoveTests.cs
+++ b/HermesProxy.Tests/World/MonsterMoveTests.cs
@@ -12,12 +12,6 @@ namespace HermesProxy.Tests.World;
 
 public class MonsterMoveConstructorTests
 {
-    static MonsterMoveConstructorTests()
-    {
-        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
-            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
-    }
-
     private static WowGuid128 TestGuid => WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
 
     private static ServerSideMovement CreateBaseSpline(
@@ -93,12 +87,6 @@ public class MonsterMoveConstructorTests
 
 public class MonsterMoveWriteTests
 {
-    static MonsterMoveWriteTests()
-    {
-        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
-            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
-    }
-
     private static WowGuid128 TestGuid => WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
 
     private static ServerSideMovement CreateSpline(SplineTypeModern splineType)

--- a/HermesProxy.Tests/World/ObjectUpdateTests.cs
+++ b/HermesProxy.Tests/World/ObjectUpdateTests.cs
@@ -10,12 +10,6 @@ namespace HermesProxy.Tests.World;
 
 public class ObjectUpdateConstructorTests
 {
-    static ObjectUpdateConstructorTests()
-    {
-        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
-            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
-    }
-
     private static GlobalSessionData CreateGlobalSession()
     {
         return (GlobalSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GlobalSessionData));
@@ -127,12 +121,6 @@ public class ObjectUpdateConstructorTests
 
 public class ObjectUpdateFieldExclusivityTests
 {
-    static ObjectUpdateFieldExclusivityTests()
-    {
-        if (global::Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
-            global::Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
-    }
-
     private static GlobalSessionData CreateGlobalSession()
     {
         return (GlobalSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GlobalSessionData));


### PR DESCRIPTION
## Summary

Replaces five copy-pasted `static FooTests()` workarounds with a single `[ModuleInitializer]` that pins `Framework.Settings.ClientBuild` before any test class loads. Also removes the `--filter "FullyQualifiedName!~MovementInfoSpanTests"` from both CI workflows — those tests now pass.

## The pattern being replaced

Five classes each carried their own:

```csharp
static FooTests()
{
    if (Framework.Settings.ClientBuild == ClientVersionBuild.Zero)
        Framework.Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
}
```

- `ObjectUpdateConstructorTests` / `ObjectUpdateFieldExclusivityTests`
- `MonsterMoveConstructorTests` / `MonsterMoveWriteTests`
- `MovementInfoSpanTests` (used `V9_0_1_36216` — see race below)

The pattern existed because `Framework.Settings.ClientBuild` is a mutable static normally populated by `HermesProxy.config` at startup. Tests skip the bootstrap, so `ModernVersion.AddedInVersion()` and related checks see `ClientBuild=Zero` and branch wrong.

## Why first-writer-wins was fragile

`if (== Zero) set ...` is test-class-load-order-dependent. `MovementInfoSpanTests` wanted `V9_0_1_36216`; the other four wanted `V1_14_2_42597`. Whichever xUnit touched first silently decided the build for the whole process, and the others quietly got the "wrong" value without failing. Classic shared-global-state race.

## The fix

One `TestModuleInitializer.cs` with a `[ModuleInitializer]`-annotated method that runs exactly once at assembly load, before any type's static constructor. C# 9 / .NET 5+ feature, perfect fit for one-shot global-state setup.

```csharp
[ModuleInitializer]
internal static void Initialize()
{
    Settings.ClientBuild = ClientVersionBuild.V1_14_2_42597;
}
```

All scattered static ctors deleted.

## Unfiltering MovementInfoSpanTests

The CI filter existed because those tests couldn't get the `ClientBuild` value they needed reliably. With the initializer providing `V1_14_2_42597` uniformly before any test loads, all 5 `MovementInfoSpanTests` pass. Verified locally: **296/296 tests pass** without the filter, up from 291/291 with it.

The class's XML doc comment about "full MovementInfo comparison tests cannot run in unit tests" is also stale — that limitation was the `ClientBuild=Zero` problem all along. Comment rewritten to explain what the tests actually do.

## Known non-change

`Framework.Settings.ClientBuild` remains a static mutable singleton. A proper DI refactor is a larger cleanup, out of scope here. This commit just eliminates the scattered workarounds and the filter they were propping up.

## Test plan

- [x] `dotnet test` locally — 296/296 pass on master's net10.0 without `--filter`.
- [x] CI Build Proxy green on this PR ([run 24638103986](https://github.com/Xian55/HermesProxy/actions/runs/24638103986)).
- [x] After merge: `feature/dotnet11` rebase-forward should also stop needing the filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
