### PR TITLE
Enable trim-safe publish

### DIFF
--- a/Framework/Networking/SocketManager.cs
+++ b/Framework/Networking/SocketManager.cs
@@ -17,11 +17,19 @@
 
 using Framework.Logging;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Sockets;
 
 namespace Framework.Networking;
 
-public class SocketManager<TSocketType> where TSocketType : ISocket
+// TSocketType is reflectively constructed in OnSocketOpen via
+// Activator.CreateInstance(typeof(TSocketType), socket). The trimmer
+// can't see that call path, so the constructor gets stripped from
+// published (PublishTrimmed=true) binaries — MissingMethodException
+// at first inbound connection. The annotation tells the trimmer to
+// preserve public ctors on any T that SocketManager<T> is closed over.
+// Same fix family as the Singleton<T> annotation in PR #36.
+public class SocketManager<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSocketType> where TSocketType : ISocket
 {
     public AsyncAcceptor Acceptor = null!;
     NetworkThread<TSocketType>[] _threads = null!;

--- a/HermesProxy/HermesProxy.csproj
+++ b/HermesProxy/HermesProxy.csproj
@@ -25,11 +25,26 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UsePublishBuildSettings)' == 'true'">
-    <!-- ConfigurationManager reflectively constructs ClientConfigurationHost,
-         which the trimmer can't see and otherwise strips. Without this the
-         published binary throws MissingMethodException on first config read.
-         See issue #34 follow-up. -->
+    <!-- Trimmer roots for assemblies that use reflection paths the IL linker
+         can't see statically. Without these, published (PublishTrimmed=true)
+         binaries throw at runtime when the looked-up types were stripped.
+
+         System.Configuration.ConfigurationManager — issue #34 follow-up:
+           reflectively constructs ClientConfigurationHost.
+         HermesProxy — VersionChecker.cs Assembly.GetType("HermesProxy.World.Enums.V*.*")
+           per-build enums; AccountDataManager.cs JsonSerializer on account data;
+           Server.cs JsonSerializer for update check; WorldSocket.cs packet
+           handler reflection; BnetServices.ServiceManager.cs Assembly.GetTypes()
+           + Activator.CreateInstance on request/response types; GameData.cs
+           Type.GetFields/GetProperties for EstimateAvgBytesPerRow<T>.
+         Framework — Framework.Serialization.Json and Framework.Util.RandomHelper
+           use reflection over app types passed in by the caller.
+         Serilog — internal reflection paths flagged as IL2104 at assembly
+           level; root so Serilog's configuration/enrichment surface stays intact. -->
     <TrimmerRootAssembly Include="System.Configuration.ConfigurationManager" />
+    <TrimmerRootAssembly Include="HermesProxy" />
+    <TrimmerRootAssembly Include="Framework" />
+    <TrimmerRootAssembly Include="Serilog" />
   </ItemGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">

--- a/HermesProxy/HermesProxy.csproj
+++ b/HermesProxy/HermesProxy.csproj
@@ -12,6 +12,18 @@
     <Copyright>Copyright © WowLegacyCore 2023</Copyright>
     <Authors>WowLegacyCore</Authors>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+
+    <!-- Keep System.Text.Json reflection-based serialization on under
+         PublishTrimmed=true. Without this, JsonSerializer.Deserialize<T>(string)
+         throws InvalidOperationException "Reflection-based serialization has
+         been disabled for this application" the first time AccountDataManager
+         reads a character settings file (hit after PlayerLogin). The SDK
+         auto-disables reflection serialization with trimming as a safety,
+         but our HermesProxy assembly is rooted via TrimmerRootAssembly so
+         the deserialized types remain intact — reflection is safe. A proper
+         fix would use JsonSerializerContext source generation on every
+         serialized type; that's a bigger refactor. -->
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UsePublishBuildSettings)' == 'true'">
@@ -24,11 +36,14 @@
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(UsePublishBuildSettings)' == 'true'">
-    <!-- Trimmer roots for assemblies that use reflection paths the IL linker
-         can't see statically. Without these, published (PublishTrimmed=true)
-         binaries throw at runtime when the looked-up types were stripped.
+  <!-- Trimmer roots. Intentionally NOT gated on UsePublishBuildSettings: those
+       <ItemGroup Condition> evaluations happen before publish profiles import,
+       so a `dotnet publish -p:PublishProfile=...` that sets the flag in its
+       pubxml would see an empty list and strip reflectively-looked-up types.
+       TrimmerRootAssembly items are no-ops when PublishTrimmed is off, so
+       leaving them unconditional is safe.
 
+       Without these, PublishTrimmed=true binaries fail at runtime:
          System.Configuration.ConfigurationManager — issue #34 follow-up:
            reflectively constructs ClientConfigurationHost.
          HermesProxy — VersionChecker.cs Assembly.GetType("HermesProxy.World.Enums.V*.*")
@@ -41,6 +56,7 @@
            use reflection over app types passed in by the caller.
          Serilog — internal reflection paths flagged as IL2104 at assembly
            level; root so Serilog's configuration/enrichment surface stays intact. -->
+  <ItemGroup>
     <TrimmerRootAssembly Include="System.Configuration.ConfigurationManager" />
     <TrimmerRootAssembly Include="HermesProxy" />
     <TrimmerRootAssembly Include="Framework" />

--- a/HermesProxy/Program.cs
+++ b/HermesProxy/Program.cs
@@ -8,6 +8,8 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
+using Framework.Logging;
 
 namespace HermesProxy;
 
@@ -17,6 +19,16 @@ public class Program
     {
         CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
         Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+
+        // Route crashes to the log file before the process dies. The Serilog
+        // async sink buffers entries; without explicit flush, a worker-thread
+        // exception (packet handler, network thread, etc.) takes the process
+        // down faster than pending entries can reach disk. Bug reporters see
+        // an empty log and a terminal window that closed before they could
+        // read the stack trace.
+        AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+        AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+        TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
 
         var commandTree = new RootCommand("Hermes Proxy: Allows you to play on legacy WoW server with modern client")
         {
@@ -64,6 +76,53 @@ public class Program
         }
 
         return exitCode;
+    }
+
+    private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+    {
+        TryLogAndFlushException(e.ExceptionObject as Exception, isTerminating: e.IsTerminating,
+            source: "AppDomain.UnhandledException");
+    }
+
+    private static void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+    {
+        TryLogAndFlushException(e.Exception, isTerminating: false,
+            source: "TaskScheduler.UnobservedTaskException");
+        e.SetObserved();
+    }
+
+    private static void OnProcessExit(object? sender, EventArgs e)
+    {
+        // Final drain on normal shutdown — covers clean exits that still left
+        // async-sink entries in flight.
+        try { Log.Shutdown(); } catch { /* best effort */ }
+    }
+
+    private static void TryLogAndFlushException(Exception? ex, bool isTerminating, string source)
+    {
+        try
+        {
+            if (Log.IsLogging && ex != null)
+                Log.outException(ex);
+        }
+        catch { /* don't let the crash-logger itself crash */ }
+
+        // Always echo to stderr so something is visible even if Log isn't
+        // configured yet (config parse failure, very early startup crash).
+        try
+        {
+            Console.Error.WriteLine($"[{source}] terminating={isTerminating}");
+            Console.Error.WriteLine(ex?.ToString() ?? "<null exception>");
+        }
+        catch { /* best effort */ }
+
+        // Flush Serilog synchronously before the CLR tears everything down.
+        // Only on terminating events — a non-terminating UnobservedTaskException
+        // shouldn't kill the logging pipeline the rest of the process relies on.
+        if (isTerminating)
+        {
+            try { Log.Shutdown(); } catch { /* best effort */ }
+        }
     }
 
     private static Dictionary<string, string> ParseMultiArgument(string[]? multiArgs)

--- a/HermesProxy/Server.cs
+++ b/HermesProxy/Server.cs
@@ -13,6 +13,7 @@ using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -184,7 +185,7 @@ partial class Server
         Log.RegisterCallerMapping(nameof(GameData), Log.Storage);
     }
 
-    private static SocketManager<TSocketType> StartServer<TSocketType>(IPEndPoint bindIp) where TSocketType : ISocket
+    private static SocketManager<TSocketType> StartServer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSocketType>(IPEndPoint bindIp) where TSocketType : ISocket
     {
         var socketManager = new SocketManager<TSocketType>();
 


### PR DESCRIPTION
## Summary

Fixes a cascade of `PublishTrimmed=true` bugs that, together, made the released Windows artifact unusable end-to-end. Each fix addresses a distinct reflection path the IL linker can't see statically. Validated live: trimmed binary now boots → bnet auth → realm list → world handshake → Enter World → **character in game**, no crashes.

All were reproduced locally on a trimmed Windows x64 single-file publish. Each one only surfaces in that configuration — untrimmed `dotnet run` / `dotnet publish -p:PublishTrimmed=false` hides every one of them.

## Bug 1: BnetTcpSession ctor stripped on first accept

User's log from a released artifact:

```
System.MissingMethodException: Constructor on type
'BNetServer.Networking.BnetTcpSession' not found.
   at System.Activator.CreateInstance(Type type, Object[] args)
   at Framework.Networking.SocketManager`1.OnSocketOpen(Socket sock)
     in Framework/Networking/SocketManager.cs:line 83
```

`SocketManager<TSocketType>.OnSocketOpen` reflectively constructs a new session per accepted TCP connect via `Activator.CreateInstance(typeof(TSocketType), sock)`. Trimmer strips the `(Socket)` ctor on every concrete session type (`BnetTcpSession`, `RealmSocket`, `WorldSocket`, `BnetRestApiSession`).

**Fix**: annotate the generic parameter with `[DynamicallyAccessedMembers(PublicConstructors)]`. Same family as PR #36's `Singleton<T>` fix. Annotation propagates up, so `Server.StartServer<TSocketType>()` also gets it.

## Bug 2: VersionChecker update-field tables silently empty

Every trimmed build logged, on every startup:

```
E | S | VersionChecker | Could not load update fields for current legacy version.
E | S | VersionChecker | Could not load update fields for current modern version.
```

Root cause — `VersionChecker.cs:241`, `:620`:

```csharp
Type? vEnumType = Assembly.GetExecutingAssembly().GetType(
    $"HermesProxy.World.Enums.{ufDefiningBuild}.{enumType.Name}");
```

Per-build enum lookup (`HermesProxy.World.Enums.V1_14_2_42597.UnitField`, etc.). String-based → trimmer doesn't see → every version-specific enum namespace stripped. `GetType` returns null → `LoadUFDictionariesInto` skips every field → translation tables stay empty → **update-field mapping between legacy and modern protocols is wrong**. Silent functional bug, not just log noise.

**Fix**: expand the `TrimmerRootAssembly` list and lift the `ItemGroup` out of the `UsePublishBuildSettings='true'` gate.

```xml
<!-- Unconditional — MSBuild evaluates ItemGroup conditions before
     publish-profile import, so gating makes .pubxml-driven publishes
     silently skip the roots. Roots are no-ops when PublishTrimmed is off. -->
<ItemGroup>
  <TrimmerRootAssembly Include="System.Configuration.ConfigurationManager" /> <!-- existing -->
  <TrimmerRootAssembly Include="HermesProxy" />
  <TrimmerRootAssembly Include="Framework" />
  <TrimmerRootAssembly Include="Serilog" />
</ItemGroup>
```

Covers every other reflection site flagged by `IL2026`/`IL2075`/`IL2077`/`IL2090` in the trimmed publish:

| File | Reflection |
|---|---|
| `HermesProxy/Server.cs:221` | `JsonSerializer.Deserialize` for update check |
| `HermesProxy/World/Server/AccountDataManager.cs:125/142` | `JsonSerializer.Serialize/Deserialize` on account data |
| `HermesProxy/World/GameData.cs:529/533` | `Type.GetFields/GetProperties` on generic `T` |
| `HermesProxy/World/Server/WorldSocket.cs:1136/1145` | Packet handler dispatch via `Type.GetMethod` + `MakeGenericMethod` + `Activator.CreateInstance` |
| `HermesProxy/BnetServer/Services/BnetServices.ServiceManager.cs:19/21/112/118` | `Assembly.GetTypes()` + `Activator.CreateInstance` on RPC request/response types |
| `Framework/Serialization/Json.cs:34/37/44/46` | Reflection over caller-supplied types |
| `Framework/Util/RandomHelper.cs:61` | Reflection on the target type |
| Serilog (`IL2104`) | Internal Serilog reflection |

## Bug 3: `JsonSerializer` reflection disabled under trim

```
System.InvalidOperationException: Reflection-based serialization has been disabled for this application.
   at System.Text.Json.JsonSerializer.Deserialize[TValue](String json, JsonSerializerOptions options)
   at HermesProxy.World.Server.AccountMetaDataManager.LoadCharacterSettingsStorage(...) in AccountDataManager.cs:141
   at HermesProxy.World.Server.WorldSocket.HandlePlayerLogin(...)
```

Trimmed publishes auto-disable `JsonSerializer` reflection fallback as a safety. First hit during `HandlePlayerLogin` reading character settings — crashes right at "Enter World".

**Fix**: `<JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>` on the main PropertyGroup. With HermesProxy rooted, the deserialized types are preserved; reflection is safe.

Proper long-term fix: `JsonSerializerContext` source generation on each serialized type. Bigger refactor — out of scope, noted.

## Bug 4: Worker-thread crashes lost because Serilog async sink didn't flush

During debugging this PR we discovered: when a packet-handler exception killed the process, nothing hit `hermes-YYYYMMDD.log` and the terminal closed before the stack trace was readable. Bug 3 was initially invisible for that reason.

`Program.cs` only had a `try/catch` around the main-thread `parser.Invoke(args)` — worker-thread crashes (network thread, packet handler, async continuations) bypassed it entirely and the `Serilog.Sinks.Async` queue lost every pending entry.

**Fix**: register at the top of `Main`:
- `AppDomain.UnhandledException` → log via `Log.outException`, echo stderr fallback, call `Log.Shutdown()` to synchronously flush on terminating events.
- `TaskScheduler.UnobservedTaskException` → log, mark observed (don't crash the process for unobserved task faults).
- `AppDomain.ProcessExit` → final drain on clean shutdown.

All handler bodies wrapped in bare `try/catch` — a crashing crash handler is the worst kind of bug.

## Size trade

`+5 MB` on the Windows x64 single-file trimmed publish (20 MB → 25 MB) from the expanded `TrimmerRootAssembly` list. Worth it; the alternative is a non-functional release.

## Verified locally

- Trimmed publish via `FolderProfile.pubxml` on Windows x64.
- `127.0.0.1:1119` accept → `BnetTcpSession | Accepting connection from ...` in log (Bug 1 gone).
- No `Could not load update fields ...` warnings on startup (Bug 2 gone).
- Client auth → realm list → character select → **Enter World → character loaded in game** (Bug 3 gone).
- Earlier intentional crashes landed in the log with full stack traces (Bug 4 handlers working).

## Test plan

- [x] Local trimmed publish — all four bugs no longer reproduce.
- [x] Live client test on the cmangos 1.12 legacy server — fully into the game world.
- [ ] CI Build Proxy green on this PR branch.
- [ ] After merge and release, original reporter of Bug 1 verifies their Windows crash is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
