### PR TITLE
ci: honor GitVersion.yml next-version floor in Release workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -59,8 +59,22 @@ jobs:
             minor="${rest%%.*}"
             patch="${rest#*.}"
             next_patch=$((patch + 1))
-            tag="v${major}.${minor}.${next_patch}"
-            echo "Latest tag: $latest → Next: $tag"
+            auto_bump="${major}.${minor}.${next_patch}"
+
+            # GitVersion.yml's next-version acts as a floor — lets us cut a
+            # major/minor bump by editing one line rather than by pushing a
+            # throwaway tag first. When auto_bump is already higher (i.e. we've
+            # already released past the floor), auto_bump wins and patches
+            # continue as normal.
+            floor=$(grep -E "^\s*next-version:" GitVersion.yml 2>/dev/null \
+                    | sed -E "s/.*next-version:\s*['\"]?([0-9]+\.[0-9]+\.[0-9]+)['\"]?.*/\1/" \
+                    | head -1)
+            floor="${floor:-0.0.0}"
+
+            # sort -V gives correct semver ordering for plain x.y.z triples.
+            winner=$(printf "%s\n%s\n" "$auto_bump" "$floor" | sort -V | tail -1)
+            tag="v${winner}"
+            echo "Latest tag: $latest → auto=$auto_bump, floor(GitVersion.yml)=$floor → $tag"
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

The Release workflow's version computation ignored `GitVersion.yml`.
Landing PR #43 (v4.3.0 modernization) auto-cut `v4.2.11` instead of the
intended `v4.3.0` because the \"Compute next version\" step does plain
`git describe` + patch+1 and never reads `GitVersion.yml`.

This teaches it to read `next-version:` from `GitVersion.yml` and treat
it as a **floor**: pick whichever is higher between the auto-bumped
patch and the floor.

## Behavior

| Scenario | Latest tag | `GitVersion.yml` floor | Computed tag |
|---|---|---|---|
| Normal patch bump | `v4.2.10` | `0.0.0` (default) | `v4.2.11` |
| Today — want minor bump | `v4.2.11` | `4.3.0` | **`v4.3.0`** (floor wins) |
| After v4.3.0 ships | `v4.3.0` | `4.3.0` | `v4.3.1` (auto_bump wins) |
| After v4.3.5 ships | `v4.3.5` | `4.3.0` | `v4.3.6` (auto_bump wins) |

Manual `inputs.version` override path is untouched.

## Implementation

Uses `grep | sed` to pull `next-version` from the YAML (no new deps),
and `sort -V | tail -1` for semver comparison. Smoke-tested the regex
and comparison locally:

```
$ echo \"next-version: '4.3.0'\" | sed -E \"s/.*next-version:\s*['\\\"]?([0-9]+\.[0-9]+\.[0-9]+)['\\\"]?.*/\1/\"
4.3.0
$ printf \"%s\n%s\n\" \"4.2.12\" \"4.3.0\" | sort -V | tail -1
4.3.0
$ printf \"%s\n%s\n\" \"4.3.1\" \"4.3.0\" | sort -V | tail -1
4.3.1
```

## Test plan

- [x] Merge PR.
- [x] Delete the misnamed `v4.2.11` release + tag.
- [x] Manually trigger Release workflow via Actions → Release → Run
      workflow. Leave \"version\" input empty.
- [x] Confirm the workflow log reports
      `Latest tag: v4.2.10 → auto=4.2.11, floor(GitVersion.yml)=4.3.0 → v4.3.0`.
- [x] Confirm the new GitHub release is `v4.3.0` with the usual 7 assets
      (Windows/MacOS/Ubuntu/Ubuntu-arm64 + checksums + verify scripts).

## Follow-up (out of scope)

Longer-term, replacing the hand-rolled bash with the GitVersion CLI
(`gitversion /output json`) would remove the regex parsing and pick up
GitVersion's other features for free. Not worth doing in this hotfix
PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)