### PR TITLE
feat: Phase 3 — modern-side world auth works for V3_4_3_54261 (Ed25519 + RealmSocket pending queue)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,10 @@
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.2" />
     <!-- HermesProxy project packages -->
     <PackageVersion Include="GitVersion.MsBuild" Version="6.5.1" />
+    <!-- BouncyCastle — Ed25519ctx signer for SMSG_ENTER_ENCRYPTED_MODE on WotLK Classic 3.4.3+
+         clients, which switched from RSA to Ed25519 signatures. .NET's built-in crypto doesn't
+         expose the RFC 8032 "Ed25519ctx" context variant. -->
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <!-- Test packages -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -70,6 +70,12 @@ public sealed class GameSessionData
     public bool IsConnectedToInstance;
     public Queue<ServerPacket> PendingUninstancedPackets = new(); // Here packets are queued while IsConnectedToInstance = false;
     public readonly Lock PendingUninstancedPacketsLock = new();
+    // Realm-destined packets queued while RealmSocket is null (modern client's BNet→Realm
+    // handoff hasn't completed yet but the legacy server is already sending early-session
+    // packets like SMSG_TUTORIAL_FLAGS). Flushed in WorldSocket.HandleEnterEncryptedModeAck
+    // when RealmSocket is assigned.
+    public Queue<ServerPacket> PendingRealmPackets = new();
+    public readonly Lock PendingRealmPacketsLock = new();
     public bool IsInWorld;
     public uint? CurrentMapId;
     public uint CurrentZoneId;

--- a/HermesProxy/HermesProxy.csproj
+++ b/HermesProxy/HermesProxy.csproj
@@ -82,6 +82,7 @@
     <PackageReference Include="Sep" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+    <PackageReference Include="BouncyCastle.Cryptography" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -339,6 +339,25 @@ public partial class WorldClient
         var pendingLock = gameState.PendingUninstancedPacketsLock;
         if (packet.GetConnection() == ConnectionType.Realm)
         {
+            // Legacy backends (CMaNGOS / TrinityCore 3.3.5a) emit early-session Realm packets
+            // (SMSG_TUTORIAL_FLAGS, SMSG_CACHE_VERSION, etc.) as soon as the legacy world auth
+            // handshake completes. But on the modern-client side, the BNet→Realm socket
+            // handoff is still in flight — RealmSocket is null for a brief window.
+            // Mirror the InstanceSocket pattern below: queue and flush in
+            // WorldSocket.HandleEnterEncryptedModeAck when RealmSocket is assigned.
+            if (GetSession().RealmSocket == null)
+            {
+                lock (gameState.PendingRealmPacketsLock)
+                {
+                    if (GetSession().RealmSocket == null)
+                    {
+                        gameState.PendingRealmPackets.Enqueue(packet);
+                        Log.PrintNet(LogType.Warn, LogNetDir.P2C, $"Can't send opcode {packet.GetUniversalOpcode()} ({packet.GetOpcode()}) before RealmSocket ready! Queue");
+                        return;
+                    }
+                }
+            }
+
             GetSession().RealmSocket.SendPacket(packet);
         }
         else

--- a/HermesProxy/World/Server/Packets/AuthenticationPackets.cs
+++ b/HermesProxy/World/Server/Packets/AuthenticationPackets.cs
@@ -456,7 +456,24 @@ class EnterEncryptedMode : ServerPacket
     byte[] EncryptionKey;
     bool Enabled;
 
-    static byte[] EnableEncryptionSeed = { 0x90, 0x9C, 0xD0, 0x50, 0x5A, 0x2C, 0x14, 0xDD, 0x5C, 0x2C, 0xC0, 0x64, 0x14, 0xF3, 0xFE, 0xC9 };
+    // The HMAC input seed has always been these 16 bytes. Retail/TBC-Classic/Era (<= 2.5.x)
+    // signs the HMAC output with the server's RSA private key; the client verifies with
+    // the baked-in RSA public key and the client-embedded `EnableEncryptionSeed`.
+    static readonly byte[] EnableEncryptionSeed = { 0x90, 0x9C, 0xD0, 0x50, 0x5A, 0x2C, 0x14, 0xDD, 0x5C, 0x2C, 0xC0, 0x64, 0x14, 0xF3, 0xFE, 0xC9 };
+
+    // WotLK Classic 3.4.3+ replaced the RSA signature with Ed25519ctx (RFC 8032) using a
+    // fixed context string. Private key and context are Blizzard constants; the client has
+    // the matching public key + context baked in. Values match the advocaite/HermesProxy-WOTLK
+    // fork, cross-checked against the published 3.4.3 client binary's signature verification.
+    static readonly byte[] Ed25519Context =
+    {
+        0xA7, 0x1F, 0xB6, 0x9B, 0xC9, 0x7C, 0xDD, 0x96, 0xE9, 0xBB, 0xB8, 0x21, 0x39, 0x8D, 0x5A, 0xD4
+    };
+    static readonly byte[] Ed25519PrivateKey =
+    {
+        0x08, 0xBD, 0xC7, 0xA3, 0xCC, 0xC3, 0x4F, 0x3F, 0x6A, 0x0B, 0xFF, 0xCF, 0x31, 0xC1, 0xB6, 0x97,
+        0x69, 0x1E, 0x72, 0x9A, 0x0A, 0xAB, 0x2C, 0x77, 0xC3, 0x6F, 0x8A, 0xE7, 0x5A, 0x9A, 0xA7, 0xC9
+    };
 
     public EnterEncryptedMode(byte[] encryptionKey, bool enabled) : base(Opcode.SMSG_ENTER_ENCRYPTED_MODE)
     {
@@ -466,13 +483,33 @@ class EnterEncryptedMode : ServerPacket
 
     public override void Write()
     {
+        // Both paths start with HMAC-SHA256(EncryptionKey) over [Enabled] || EnableEncryptionSeed.
         HmacSha256 hash = new(EncryptionKey);
         hash.Process(BitConverter.GetBytes(Enabled), 1);
         hash.Finish(EnableEncryptionSeed, 16);
+        byte[] toSign = hash.Digest!;
 
-        _worldPacket.WriteBytes(RsaCrypt.RSA.SignHash(hash.Digest!, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1).Reverse().ToArray());
+        if (ModernVersion.ExpansionVersion >= 3)
+            WriteEd25519(toSign);
+        else
+            WriteRsa(toSign);
+
         _worldPacket.WriteBit(Enabled);
         _worldPacket.FlushBits();
+    }
+
+    void WriteRsa(byte[] toSign)
+    {
+        _worldPacket.WriteBytes(RsaCrypt.RSA.SignHash(toSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1).Reverse().ToArray());
+    }
+
+    void WriteEd25519(byte[] toSign)
+    {
+        var privateKey = new Org.BouncyCastle.Crypto.Parameters.Ed25519PrivateKeyParameters(Ed25519PrivateKey, 0);
+        var signer = new Org.BouncyCastle.Crypto.Signers.Ed25519ctxSigner(Ed25519Context);
+        signer.Init(forSigning: true, privateKey);
+        signer.BlockUpdate(toSign, 0, toSign.Length);
+        _worldPacket.WriteBytes(signer.GenerateSignature());
     }
 }
 

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -761,6 +761,18 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
             SendBnetConnectionState(1);
             GetSession().AccountDataMgr = new AccountDataManager(GetSession().Username, GetSession().RealmManager.GetRealm(_realmId)!.Name);
             GetSession().RealmSocket = this;
+
+            // Flush any Realm-destined packets the legacy WorldClient queued before this
+            // socket was ready. See WorldClient.SendPacketToClientDirect for the producer.
+            var gameState = GetSession().GameState;
+            if (gameState.PendingRealmPackets.Count > 0)
+            {
+                lock (gameState.PendingRealmPacketsLock)
+                {
+                    while (gameState.PendingRealmPackets.TryDequeue(out var queuedPacket))
+                        SendPacket(queuedPacket);
+                }
+            }
         }
         else
         {


### PR DESCRIPTION
## Summary

Implements **Phase 3** of the WotLK Classic 3.4.3.54261 roadmap (`wotlk.md`): the modern-side `WorldSocket` now completes the encrypted-mode handshake with a 3.4.3 client and lets the legacy server's early-session packets flow through to it. Combined with the already-merged Phases 0–2, this achieves **wotlk.md's v0.1 ship-it milestone**:

> **Initial done-scope**: **Reach character-select (through Phase 4)**.

**End-to-end flow validated tonight**:
Modern 3.4.3.54261 WotLK Classic client (via Arctium launcher) → BNet TLS → realm list → modern world auth (Ed25519-signed) → legacy 3.3.5a auth handshake with CMaNGOS → `CMSG_ENUM_CHARACTERS` round-trip → **character-select screen renders**.

## Commits

1. **`86f44f0` feat: add PendingRealmPackets queue for session-handoff race (Phase 3)**

   Adds a `PendingRealmPackets` queue + lock on `GlobalSessionData`, symmetrical to the existing `PendingUninstancedPackets` for `InstanceSocket`. CMaNGOS starts emitting Realm-layer early-session packets (`SMSG_CACHE_VERSION`, `SMSG_TUTORIAL_FLAGS`, …) the moment the legacy `SMSG_AUTH_RESPONSE` is exchanged — but on the modern-client side the BNet→Realm socket handoff is still in flight, so `WorldClient.SendPacketToClientDirect` would NRE on the null `GetSession().RealmSocket.SendPacket(...)`. Now queues + flushes in `WorldSocket.HandleEnterEncryptedModeAck` once `RealmSocket` is assigned.

   This race was hit by Phase 0's 2.5.x smoke test too — fix was foreshadowed in PR #45's "Out of scope" note.

2. **`63d4152` feat: sign SMSG_ENTER_ENCRYPTED_MODE with Ed25519ctx for WotLK Classic 3.4.3+**

   Blizzard swapped the signature scheme between TBC Classic and WotLK Classic: `ExpansionVersion <= 2` stays on the legacy `RSA PKCS#1` path; `ExpansionVersion >= 3` uses **Ed25519ctx** (RFC 8032 §5.1, the "context" variant). `System.Security.Cryptography` doesn't expose Ed25519ctx at all — [BouncyCastle.Cryptography](https://github.com/bcgit/bc-csharp) 2.4.0 added as a pure-managed dependency (the same package the advocaite fork uses for this exact problem). HMAC step factored out so both paths share `toSign`; only the signature bytes differ on the wire.

## Out of scope

- **Per-build auth seed** for 3.4.3.54261 — the Phase 2 PR already bypasses the seed check with a warning when the seed is unknown. If the correct 54261 seed ever gets published, drop it into `CSV/BuildAuthSeeds.csv` and the check starts passing without further code changes.
- **Phase 5** — `ObjectUpdateBuilder` descriptor-tree serializer (~3,400 lines, the big one). Character-select doesn't hit it. World-enter does.
- **Warden** — disable `Warden.Enable = 0` in CMaNGOS's `anticheat.conf`. The 3.4.3 modern client's Warden protocol differs from 3.3.5a's anyway; proxying it is probably never worthwhile.

## Test plan

- [x] `dotnet build -c Release` — 0 errors (43 HPSG001 warnings carrying over from Phase 1 scaffolding)
- [x] `dotnet test -c Release` — 296/296 passing
- [x] End-to-end smoke: 3.4.3.54261 client + Arctium (`--version=WotLKClassic`) + CMaNGOS wotlk backend → character-select screen rendered (screenshot attached to the issue description of the merge commit, if anyone asks).
- [x] Regression smoke: 2.5.x TBC Classic + 3.3.5a backend (Phase 0 flow) still works — RSA path unchanged, `PendingRealmPackets` queue also fixes the NRE we hit in Phase 0 round 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)