### PR TITLE
perf(framework): ByteBuffer hot-path tightening

### DIFF
--- a/Framework/IO/ByteBuffer.cs
+++ b/Framework/IO/ByteBuffer.cs
@@ -22,6 +22,7 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Framework.IO;
@@ -408,7 +409,19 @@ public class ByteBuffer : IDisposable
         AdvanceWrite(8);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteBool(bool data)
+    {
+        FlushBits();
+        EnsureCapacity(1);
+        _buffer[_position] = Unsafe.As<bool, byte>(ref data);
+        AdvanceWrite(1);
+    }
+
+    /// <summary>
+    /// Original implementation for benchmarking comparison. DO NOT USE.
+    /// </summary>
+    internal void WriteBoolOriginal(bool data)
     {
         FlushBits();
         EnsureCapacity(1);
@@ -465,10 +478,35 @@ public class ByteBuffer : IDisposable
     }
 
     /// <summary>
-    /// Writes a string to the packet with a null terminated (0)
+    /// Writes a UTF-8 string to the buffer terminated with a NUL byte. Single-pass:
+    /// one FlushBits, one EnsureCapacity, encode directly into the destination span,
+    /// then write the NUL byte. Avoids the byte[] allocation the original WriteString
+    /// went through.
     /// </summary>
-    /// <param name="str"></param>
-    public void WriteCString(string str)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteCString(string? str)
+    {
+        FlushBits();
+
+        if (string.IsNullOrEmpty(str))
+        {
+            EnsureCapacity(1);
+            _buffer[_position] = 0;
+            AdvanceWrite(1);
+            return;
+        }
+
+        int byteCount = Encoding.UTF8.GetByteCount(str);
+        EnsureCapacity(byteCount + 1);
+        Encoding.UTF8.GetBytes(str, _buffer.AsSpan(_position, byteCount));
+        _buffer[_position + byteCount] = 0;
+        AdvanceWrite(byteCount + 1);
+    }
+
+    /// <summary>
+    /// Original implementation for benchmarking comparison. DO NOT USE.
+    /// </summary>
+    internal void WriteCStringOriginal(string str)
     {
         if (string.IsNullOrEmpty(str))
         {
@@ -476,11 +514,27 @@ public class ByteBuffer : IDisposable
             return;
         }
 
-        WriteString(str);
+        WriteStringOriginal(str);
         WriteUInt8(0);
     }
 
-    public void WriteString(string str)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteString(string? str)
+    {
+        if (string.IsNullOrEmpty(str))
+            return;
+
+        FlushBits();
+        int byteCount = Encoding.UTF8.GetByteCount(str);
+        EnsureCapacity(byteCount);
+        Encoding.UTF8.GetBytes(str, _buffer.AsSpan(_position, byteCount));
+        AdvanceWrite(byteCount);
+    }
+
+    /// <summary>
+    /// Original implementation for benchmarking comparison. DO NOT USE.
+    /// </summary>
+    internal void WriteStringOriginal(string str)
     {
         if (str.IsEmpty())
             return;
@@ -518,7 +572,30 @@ public class ByteBuffer : IDisposable
         WriteBytes(buffer.GetData());
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteVector4(Vector4 pos)
+    {
+        FlushBits();
+        EnsureCapacity(16);
+        var dst = _buffer.AsSpan(_position, 16);
+        if (BitConverter.IsLittleEndian)
+        {
+            MemoryMarshal.Write(dst, in pos);
+        }
+        else
+        {
+            BinaryPrimitives.WriteSingleLittleEndian(dst,             pos.X);
+            BinaryPrimitives.WriteSingleLittleEndian(dst.Slice(4),    pos.Y);
+            BinaryPrimitives.WriteSingleLittleEndian(dst.Slice(8),    pos.Z);
+            BinaryPrimitives.WriteSingleLittleEndian(dst.Slice(12),   pos.W);
+        }
+        AdvanceWrite(16);
+    }
+
+    /// <summary>
+    /// Original implementation for benchmarking comparison. DO NOT USE.
+    /// </summary>
+    internal void WriteVector4Original(Vector4 pos)
     {
         WriteFloat(pos.X);
         WriteFloat(pos.Y);
@@ -526,20 +603,77 @@ public class ByteBuffer : IDisposable
         WriteFloat(pos.W);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteVector3(Vector3 pos)
+    {
+        FlushBits();
+        EnsureCapacity(12);
+        var dst = _buffer.AsSpan(_position, 12);
+        if (BitConverter.IsLittleEndian)
+        {
+            MemoryMarshal.Write(dst, in pos);
+        }
+        else
+        {
+            BinaryPrimitives.WriteSingleLittleEndian(dst,           pos.X);
+            BinaryPrimitives.WriteSingleLittleEndian(dst.Slice(4),  pos.Y);
+            BinaryPrimitives.WriteSingleLittleEndian(dst.Slice(8),  pos.Z);
+        }
+        AdvanceWrite(12);
+    }
+
+    /// <summary>
+    /// Original implementation for benchmarking comparison. DO NOT USE.
+    /// </summary>
+    internal void WriteVector3Original(Vector3 pos)
     {
         WriteFloat(pos.X);
         WriteFloat(pos.Y);
         WriteFloat(pos.Z);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void WriteVector2(Vector2 pos)
+    {
+        FlushBits();
+        EnsureCapacity(8);
+        var dst = _buffer.AsSpan(_position, 8);
+        if (BitConverter.IsLittleEndian)
+        {
+            MemoryMarshal.Write(dst, in pos);
+        }
+        else
+        {
+            BinaryPrimitives.WriteSingleLittleEndian(dst,           pos.X);
+            BinaryPrimitives.WriteSingleLittleEndian(dst.Slice(4),  pos.Y);
+        }
+        AdvanceWrite(8);
+    }
+
+    /// <summary>
+    /// Original implementation for benchmarking comparison. DO NOT USE.
+    /// </summary>
+    internal void WriteVector2Original(Vector2 pos)
     {
         WriteFloat(pos.X);
         WriteFloat(pos.Y);
     }
 
     public void WritePackXYZ(Vector3 pos)
+    {
+        // Pack X (11 bits), Y (11 bits), Z (10 bits) into a single uint32.
+        // Multiply by 4f instead of dividing by 0.25f — the JIT cannot rewrite
+        // float division to multiplication automatically due to rounding semantics.
+        uint packed  =  (uint)(int)(pos.X * 4f) & 0x7FF;
+        packed      |= ((uint)(int)(pos.Y * 4f) & 0x7FF) << 11;
+        packed      |= ((uint)(int)(pos.Z * 4f) & 0x3FF) << 22;
+        WriteUInt32(packed);
+    }
+
+    /// <summary>
+    /// Original implementation for benchmarking comparison. DO NOT USE.
+    /// </summary>
+    internal void WritePackXYZOriginal(Vector3 pos)
     {
         // Cast to int first to preserve negative values (two's complement),
         // then mask to extract the correct number of bits
@@ -569,10 +703,61 @@ public class ByteBuffer : IDisposable
         return bit;
     }
 
-    public void WriteBits(object bit, int count)
+    /// <summary>
+    /// Chunked bit packing — takes <c>min(bitCount, _bitPosition)</c> bits per
+    /// iteration, ORs them into the pending byte at the right shift, and emits
+    /// the byte when full. Identical wire output to the per-bit loop, ~10-30x
+    /// fewer iterations on common widths (4, 6, 8, 9, 16, 24, 32).
+    /// </summary>
+    public void WriteBits(uint value, int bitCount)
+    {
+        while (bitCount > 0)
+        {
+            int take = Math.Min(bitCount, (int)_bitPosition);
+            int shift = bitCount - take;
+            uint chunk = (value >> shift) & ((1u << take) - 1u);
+            _bitPosition -= (byte)take;
+            _bitValue |= (byte)(chunk << _bitPosition);
+            bitCount = shift;
+
+            if (_bitPosition == 0)
+            {
+                EnsureCapacity(1);
+                _buffer[_position] = _bitValue;
+                AdvanceWrite(1);
+                _bitPosition = 8;
+                _bitValue = 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Convenience overload for the many call sites that pass <see cref="int"/>
+    /// (e.g. <c>List.Count</c>, <c>Encoding.UTF8.GetByteCount(s)</c>, small enum
+    /// casts). The <c>(uint)</c> cast wraps negative values to <c>0xFFFFFFFF</c>;
+    /// WriteBits is only ever called with non-negative bit-pack values in this
+    /// codebase, so wraparound is the safer behavior than the throwing
+    /// <c>Convert.ToUInt32(int)</c> the obsolete <c>(object, int)</c> shim
+    /// preserves.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteBits(int value, int bitCount) => WriteBits((uint)value, bitCount);
+
+    /// <summary>
+    /// Legacy overload kept for source compatibility — boxes via
+    /// <see cref="Convert.ToUInt32(object)"/>. Prefer <c>WriteBits(uint,int)</c>
+    /// or <c>WriteBits(int,int)</c>.
+    /// </summary>
+    [Obsolete("Use WriteBits(uint, int) or WriteBits(int, int) — the (object, int) overload boxes its first argument.")]
+    public void WriteBits(object bit, int count) => WriteBits(Convert.ToUInt32(bit), count);
+
+    /// <summary>
+    /// Original implementation for benchmarking comparison. DO NOT USE.
+    /// </summary>
+    internal void WriteBitsOriginal(uint bit, int count)
     {
         for (int i = count - 1; i >= 0; --i)
-            WriteBit(((Convert.ToUInt32(bit) >> i) & 1) != 0);
+            WriteBit(((bit >> i) & 1) != 0);
     }
 
     public void WritePackedTime(long time)

--- a/HermesProxy.Benchmarks/ByteBufferBenchmarks.cs
+++ b/HermesProxy.Benchmarks/ByteBufferBenchmarks.cs
@@ -146,11 +146,11 @@ public class ByteBufferReadCStringBenchmarks
 }
 
 // =====================================================================
-// Write-side benchmarks added for the ByteBuffer hot-path tightening port
-// of SpanPacketWriter commit 27d7e52. Single benchmark per surface today;
-// the follow-up perf commit will pair each with a `*_Original` baseline
-// using the same internal-`*Original` pattern as ReadCStringOriginal /
-// GetDataOriginal already in this file.
+// Write-side benchmarks for the ByteBuffer hot-path tightening port of
+// SpanPacketWriter commit 27d7e52. Each benchmark class pairs the new
+// optimized impl (Optimized) against the frozen-original baseline kept
+// internally in ByteBuffer (Original) — same precedent as the existing
+// ReadCStringOriginal / GetDataOriginal benchmark pattern.
 // =====================================================================
 
 [MemoryDiagnoser]
@@ -169,8 +169,18 @@ public class ByteBufferWriteBitsBenchmarks
         _value = BitWidth == 32 ? 0xCAFEBABEu : (1u << BitWidth) - 1u;
     }
 
+    [Benchmark(Baseline = true)]
+    public byte[] WriteBits_Original()
+    {
+        using var buffer = new ByteBuffer();
+        for (int i = 0; i < Iterations; i++)
+            buffer.WriteBitsOriginal(_value, BitWidth);
+        buffer.FlushBits();
+        return buffer.GetData();
+    }
+
     [Benchmark]
-    public byte[] WriteBits_Current()
+    public byte[] WriteBits_Optimized()
     {
         using var buffer = new ByteBuffer();
         for (int i = 0; i < Iterations; i++)
@@ -189,8 +199,17 @@ public class ByteBufferWriteVectorBenchmarks
     private static readonly Vector3 V3 = new(1.5f, -2.25f, 0.125f);
     private static readonly Vector4 V4 = new(1.5f, -2.25f, 0.125f, 1024.0f);
 
+    [Benchmark(Baseline = true)]
+    public byte[] WriteVector2_Original()
+    {
+        using var buffer = new ByteBuffer();
+        for (int i = 0; i < Iterations; i++)
+            buffer.WriteVector2Original(V2);
+        return buffer.GetData();
+    }
+
     [Benchmark]
-    public byte[] WriteVector2_Current()
+    public byte[] WriteVector2_Optimized()
     {
         using var buffer = new ByteBuffer();
         for (int i = 0; i < Iterations; i++)
@@ -199,7 +218,16 @@ public class ByteBufferWriteVectorBenchmarks
     }
 
     [Benchmark]
-    public byte[] WriteVector3_Current()
+    public byte[] WriteVector3_Original()
+    {
+        using var buffer = new ByteBuffer();
+        for (int i = 0; i < Iterations; i++)
+            buffer.WriteVector3Original(V3);
+        return buffer.GetData();
+    }
+
+    [Benchmark]
+    public byte[] WriteVector3_Optimized()
     {
         using var buffer = new ByteBuffer();
         for (int i = 0; i < Iterations; i++)
@@ -208,7 +236,16 @@ public class ByteBufferWriteVectorBenchmarks
     }
 
     [Benchmark]
-    public byte[] WriteVector4_Current()
+    public byte[] WriteVector4_Original()
+    {
+        using var buffer = new ByteBuffer();
+        for (int i = 0; i < Iterations; i++)
+            buffer.WriteVector4Original(V4);
+        return buffer.GetData();
+    }
+
+    [Benchmark]
+    public byte[] WriteVector4_Optimized()
     {
         using var buffer = new ByteBuffer();
         for (int i = 0; i < Iterations; i++)
@@ -224,8 +261,16 @@ public class ByteBufferWriteCStringBenchmarks
     [Params("hello", "Player_Name_Goes_Here_Filling_Sixty_Four_Bytes_Or_Thereabouts!", "héllo wörld 你好")]
     public string Value = null!;
 
+    [Benchmark(Baseline = true)]
+    public byte[] WriteCString_Original()
+    {
+        using var buffer = new ByteBuffer();
+        buffer.WriteCStringOriginal(Value);
+        return buffer.GetData();
+    }
+
     [Benchmark]
-    public byte[] WriteCString_Current()
+    public byte[] WriteCString_Optimized()
     {
         using var buffer = new ByteBuffer();
         buffer.WriteCString(Value);
@@ -233,7 +278,15 @@ public class ByteBufferWriteCStringBenchmarks
     }
 
     [Benchmark]
-    public byte[] WriteCString_Empty_Current()
+    public byte[] WriteCString_Empty_Original()
+    {
+        using var buffer = new ByteBuffer();
+        buffer.WriteCStringOriginal(string.Empty);
+        return buffer.GetData();
+    }
+
+    [Benchmark]
+    public byte[] WriteCString_Empty_Optimized()
     {
         using var buffer = new ByteBuffer();
         buffer.WriteCString(string.Empty);
@@ -248,8 +301,16 @@ public class ByteBufferWriteStringBenchmarks
     [Params("hello", "Player_Name_Goes_Here_Filling_Sixty_Four_Bytes_Or_Thereabouts!", "héllo wörld 你好")]
     public string Value = null!;
 
+    [Benchmark(Baseline = true)]
+    public byte[] WriteString_Original()
+    {
+        using var buffer = new ByteBuffer();
+        buffer.WriteStringOriginal(Value);
+        return buffer.GetData();
+    }
+
     [Benchmark]
-    public byte[] WriteString_Current()
+    public byte[] WriteString_Optimized()
     {
         using var buffer = new ByteBuffer();
         buffer.WriteString(Value);
@@ -263,8 +324,17 @@ public class ByteBufferWriteBoolBenchmarks
 {
     private const int Iterations = 1024;
 
+    [Benchmark(Baseline = true)]
+    public byte[] WriteBool_Original()
+    {
+        using var buffer = new ByteBuffer();
+        for (int i = 0; i < Iterations; i++)
+            buffer.WriteBoolOriginal((i & 1) == 0);
+        return buffer.GetData();
+    }
+
     [Benchmark]
-    public byte[] WriteBool_Current()
+    public byte[] WriteBool_Optimized()
     {
         using var buffer = new ByteBuffer();
         for (int i = 0; i < Iterations; i++)
@@ -280,8 +350,17 @@ public class ByteBufferWritePackXYZBenchmarks
     private const int Iterations = 1024;
     private static readonly Vector3 Pos = new(100.5f, -200.25f, 50.125f);
 
+    [Benchmark(Baseline = true)]
+    public byte[] WritePackXYZ_Original()
+    {
+        using var buffer = new ByteBuffer();
+        for (int i = 0; i < Iterations; i++)
+            buffer.WritePackXYZOriginal(Pos);
+        return buffer.GetData();
+    }
+
     [Benchmark]
-    public byte[] WritePackXYZ_Current()
+    public byte[] WritePackXYZ_Optimized()
     {
         using var buffer = new ByteBuffer();
         for (int i = 0; i < Iterations; i++)
@@ -301,8 +380,28 @@ public class ByteBufferMixedWorkloadBenchmarks
 
     // Approximates a small bit-packed packet: 4×WriteBits (typical mask widths)
     // + 2×WriteCString + 1×WriteVector3 + 8×WriteBool, repeated 32 times.
+    [Benchmark(Baseline = true)]
+    public byte[] Mixed_Original()
+    {
+        using var buffer = new ByteBuffer();
+        for (int i = 0; i < Iterations; i++)
+        {
+            buffer.WriteBitsOriginal(0xAu, 4);
+            buffer.WriteBitsOriginal(0x123u, 9);
+            buffer.WriteBitsOriginal(0xCAFEu, 16);
+            buffer.WriteBitsOriginal(0xFFFFFFu, 24);
+            buffer.FlushBits();
+            buffer.WriteCStringOriginal(Name);
+            buffer.WriteCStringOriginal(Title);
+            buffer.WriteVector3Original(Pos);
+            for (int b = 0; b < 8; b++)
+                buffer.WriteBoolOriginal((b & 1) == 0);
+        }
+        return buffer.GetData();
+    }
+
     [Benchmark]
-    public byte[] Mixed_Current()
+    public byte[] Mixed_Optimized()
     {
         using var buffer = new ByteBuffer();
         for (int i = 0; i < Iterations; i++)


### PR DESCRIPTION
## Summary

Six changes to `ByteBuffer` write methods, mirroring [SpanPacketWriter commit 27d7e52](https://github.com/Xian55/HermesProxy/commit/27d7e52) for the older legacy-compatible buffer. Wire output is unchanged for every call; verified by the 162-test ByteBuffer round-trip suite added in #56 (the parent PR).

**Stacked on #56** — review/merge that first; this PR's diff is just the production change + benchmark baselines.

## What changed

- **`WriteBits`**: per-bit loop → batched chunked packing (`min(bitCount, _bitPosition)` bits per iteration). Plus the `(object,int)` → `(uint,int)` signature change kills the per-call boxing via `Convert.ToUInt32(object)`. Three overloads land:
  - `WriteBits(uint, int)` — new optimized core
  - `WriteBits(int, int)` — convenience for the many call sites passing `List.Count` / `GetByteCount` / etc.
  - `WriteBits(object, int)` — `[Obsolete]` shim for source compatibility (no production call site needs to change in this PR; the warnings surface migration debt for a follow-up)
- **`WriteVector{2,3,4}`**: single `FlushBits` + single `EnsureCapacity` + single `MemoryMarshal.Write` blit on little-endian; per-float `BinaryPrimitives` fallback on big-endian (JIT folds the BE branch away on x64/arm64).
- **`WriteCString`**: single-pass — `Encoding.UTF8.GetBytes` directly into the destination span, then NUL byte. `string?` signature, `[AggressiveInlining]`. **Removes the intermediate `byte[]` allocation** the original `WriteString` went through.
- **`WriteString`**: same single-pass treatment + `string?` signature.
- **`WritePackXYZ`**: `f * 4f` instead of `f / 0.25f` (JIT can't rewrite float division), drop dead `packed = 0` initial OR.
- **`WriteBool`**: `Unsafe.As<bool, byte>` instead of `value ? 1 : 0`. Branchless.

Each affected method preserves its current body as `internal *Original` so the side-by-side benchmarks in #56 stay live (matches the existing `ReadCStringOriginal` / `GetDataOriginal` pattern).

`WriteBit(bool)` keeps its `bool` return — `UpdatePackets.cs:462` (`if (buffer.WriteBit(...))`) depends on it.

## Benchmark results

`ShortRunJob` on Intel i7-6700K (Skylake), .NET 10.0.7. `Ratio = Optimized / Original`; lower = faster.

### `WriteBits` — the headline change

| BitWidth | Original | Optimized | Ratio | Speedup |
|---:|---:|---:|---:|---:|
| 4  |   542 ns |  231 ns | 0.43 | 2.3× |
| 6  |   756 ns |  317 ns | 0.42 | 2.4× |
| 8  | 1,007 ns |  266 ns | 0.26 | 3.8× |
| 9  | 1,090 ns |  385 ns | 0.35 | 2.8× |
| 16 | 1,900 ns |  455 ns | 0.24 | 4.2× |
| 24 | 2,775 ns |  639 ns | 0.23 | 4.3× |
| 32 | 3,279 ns |  795 ns | 0.24 | 4.1× |

Allocation unchanged. Hot in V3_4_3 update masks, packed-guid masks, char-enum env.

### `WriteVector{2,3,4}` — single-blit on LE

| Method | Original | Optimized | Ratio |
|---|---:|---:|---:|
| WriteVector2 | 1,898 ns |   849 ns | 0.45 |
| WriteVector3 | 2,749 ns | 1,055 ns | 0.56 |
| WriteVector4 | 3,544 ns | 1,105 ns | 0.58 |

### `WriteCString` / `WriteString` — single-pass, no intermediate `byte[]`

| Method | Value | Mean orig | Mean opt | Ratio | Alloc orig | Alloc opt | Alloc ratio |
|---|---|---:|---:|---:|---:|---:|---:|
| WriteCString | "hello" (5b)  | 110 ns | 100 ns | 0.91 | 112 B | 80 B | 0.71 |
| WriteCString | UTF-8 18b     | 131 ns | 122 ns | 0.93 | 144 B | 96 B | 0.67 |
| WriteCString | 62-char ASCII | 152 ns | 114 ns | 0.75 | 224 B | 136 B | 0.61 |
| WriteString  | "hello"       | 113 ns |  98 ns | 0.87 | 112 B | 80 B | 0.71 |
| WriteString  | UTF-8 18b     | 133 ns | 119 ns | 0.89 | 144 B | 96 B | 0.67 |
| WriteString  | 62-char ASCII | 138 ns | 115 ns | 0.84 | 224 B | 136 B | 0.61 |

Allocation drops 29-39% on the populated-string path.

### `WriteBool` / `WritePackXYZ` — within noise

| Method | Original | Optimized | Ratio |
|---|---:|---:|---:|
| WriteBool (1024 iter)    | 2,153 ns | 2,177 ns | 1.01 |
| WritePackXYZ (1024 iter) | 2,715 ns | 2,676 ns | 0.99 |

The `FlushBits` + `EnsureCapacity` + `WriteUInt32` paths dominate at this scale; the branchless byte read and the `* 4f` constant fold are too small to measure independently. They land for symmetry with the SpanPacketWriter sibling and to remove the JIT-blocked divide.

### Mixed workload — closest stand-in for a real bit-packed packet

4×WriteBits + 2×WriteCString + WriteVector3 + 8×WriteBool, ×32:

| Method | Mean | Allocated |
|---|---:|---:|
| Mixed_Original  | 5,763 ns | 4.82 KB |
| Mixed_Optimized | 2,561 ns | 2.07 KB |
| **Ratio**       | **0.44 (2.27× faster)** | **0.43 (57% less alloc)** |

## Test plan

- [x] `dotnet build` — clean, 0 errors. ~80 expected `[Obsolete]` `CS0618` warnings on legacy `WriteBits(object,int)` call sites — intentional migration signal, follow-up.
- [x] `dotnet test --filter "ByteBuffer"` — all 162 PR-1 tests still green on the optimized impl
- [x] `dotnet test` — full 405-test suite still green; nothing else regresses
- [x] `dotnet run --project HermesProxy.Benchmarks -c Release -- --filter "*ByteBufferWrite*"` — captured above
- [x] `dotnet run --project HermesProxy.Benchmarks -c Release -- --filter "*ByteBufferMixedWorkload*"` — captured above
- [x] Optional: smoke against cMangos WotLK test server (movement + chat) — not run yet; the round-trip suite gives high confidence on wire equivalence

## Out of scope

- **`ReadBits<T>` overflow at bitCount=32 with high bit set** — uses `int value = 0` then `Convert.ChangeType` throws on negative-int → uint conversion. Same bug in `SpanPacketReader.ReadBits`. Tests in #56 side-step it with a per-bit `ReadBit` loop. Tracked for a follow-up read-side commit.
- **Migrating ~80 `WriteBits(object,…)` call sites** to the `(int, int)` / `(uint, int)` overloads. Mechanical, file-by-file or one sweep, not a blocker for the perf win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)