### PR TITLE
fix(framework): ReadBits<T> overflow at bitCount=32 with high bit set

### DIFF
--- a/Framework/IO/ByteBuffer.cs
+++ b/Framework/IO/ByteBuffer.cs
@@ -364,15 +364,29 @@ public class ByteBuffer : IDisposable
         return Convert.ToBoolean(returnValue >> 7);
     }
 
-    public T ReadBits<T>(int bitCount)
+    /// <summary>
+    /// Reads <paramref name="bitCount"/> bits MSB-first into a <see cref="uint"/>
+    /// accumulator and reinterprets it as <typeparamref name="T"/>. Supports
+    /// <c>bitCount</c> in [0, 32]. <typeparamref name="T"/> must be at most
+    /// 4 bytes (byte/sbyte, ushort/short, uint/int) — larger types would read
+    /// uninitialized stack bytes.
+    ///
+    /// The previous formulation used <c>int</c> as the accumulator, which made
+    /// the bit-31 contribution equal to <see cref="int.MinValue"/>; the trailing
+    /// <see cref="Convert.ChangeType(object, Type)"/> then threw
+    /// <see cref="OverflowException"/> when converting that negative int back to
+    /// <see cref="uint"/>. The new <see cref="uint"/> accumulator + reinterpret
+    /// also drops the per-call <c>Convert.ChangeType</c> boxing.
+    /// </summary>
+    public T ReadBits<T>(int bitCount) where T : unmanaged
     {
-        int value = 0;
+        uint value = 0;
 
         for (var i = bitCount - 1; i >= 0; --i)
             if (HasBit())
-                value |= (1 << i);
+                value |= 1u << i;
 
-        return (T)Convert.ChangeType(value, typeof(T));
+        return Unsafe.As<uint, T>(ref value);
     }
     #endregion
 

--- a/Framework/IO/SpanPacketReader.cs
+++ b/Framework/IO/SpanPacketReader.cs
@@ -25,8 +25,9 @@ using Framework.GameMath;
 namespace Framework.IO;
 
 /// <summary>
-/// High-performance packet reader using ReadOnlySpan&lt;byte&gt; for zero-allocation reads.
-/// This is a ref struct that lives on the stack.
+/// High-performance packet reader over a <see cref="ReadOnlySpan{T}"/> of
+/// <see cref="byte"/> for zero-allocation reads. This is a
+/// <see langword="ref struct"/> that lives on the stack.
 /// </summary>
 public ref struct SpanPacketReader
 {
@@ -245,15 +246,29 @@ public ref struct SpanPacketReader
         return (returnValue >> 7) != 0;
     }
 
+    /// <summary>
+    /// Reads <paramref name="bitCount"/> bits MSB-first into a <see cref="uint"/>
+    /// accumulator and reinterprets it as <typeparamref name="T"/>. Supports
+    /// <c>bitCount</c> in [0, 32]. <typeparamref name="T"/> must be at most
+    /// 4 bytes (byte/sbyte, ushort/short, uint/int) — larger types would read
+    /// uninitialized stack bytes.
+    ///
+    /// The previous formulation used <c>int</c> as the accumulator, which made
+    /// the bit-31 contribution equal to <see cref="int.MinValue"/>; the trailing
+    /// <see cref="Convert.ChangeType(object, Type)"/> then threw
+    /// <see cref="OverflowException"/> when converting that negative int back to
+    /// <see cref="uint"/>. The new <see cref="uint"/> accumulator + reinterpret
+    /// also drops the per-call <c>Convert.ChangeType</c> boxing.
+    /// </summary>
     public T ReadBits<T>(int bitCount) where T : unmanaged
     {
-        int value = 0;
+        uint value = 0;
 
         for (int i = bitCount - 1; i >= 0; --i)
             if (ReadBit())
-                value |= (1 << i);
+                value |= 1u << i;
 
-        return (T)Convert.ChangeType(value, typeof(T));
+        return Unsafe.As<uint, T>(ref value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Framework/IO/SpanPacketWriter.cs
+++ b/Framework/IO/SpanPacketWriter.cs
@@ -25,8 +25,9 @@ using Framework.GameMath;
 namespace Framework.IO;
 
 /// <summary>
-/// High-performance packet writer using Span&lt;byte&gt; for zero-allocation writes.
-/// This is a ref struct that lives on the stack.
+/// High-performance packet writer over a <see cref="Span{T}"/> of
+/// <see cref="byte"/> for zero-allocation writes. This is a
+/// <see langword="ref struct"/> that lives on the stack.
 /// </summary>
 public ref struct SpanPacketWriter
 {

--- a/HermesProxy.Tests/Framework/ByteBufferTests.cs
+++ b/HermesProxy.Tests/Framework/ByteBufferTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers.Binary;
 using System.Text;
 using Framework.IO;
 using Xunit;
@@ -290,30 +291,111 @@ public class ByteBufferGetDataTests
 }
 
 /// <summary>
+/// Coverage for <see cref="ByteBuffer.ReadBits{T}(int)"/> — locks the post-fix
+/// behavior. The previous formulation used an <c>int</c> accumulator and
+/// <see cref="Convert.ChangeType(object, Type)"/>, which threw
+/// <see cref="OverflowException"/> at <c>bitCount=32</c> with the high bit set
+/// (the negative-int → uint conversion path). The fix switches to a
+/// <see cref="uint"/> accumulator and a
+/// <see cref="System.Runtime.CompilerServices.Unsafe.As{TFrom, TTo}(ref TFrom)"/>
+/// reinterpret. These tests exercise the previously broken cases at the bit
+/// boundaries plus a sampling of small-T cases to confirm the reinterpret
+/// truncates correctly.
+/// </summary>
+public class ByteBufferReadBitsTests
+{
+    private static byte[] MsbFirst32(uint value)
+    {
+        // ReadBits reads MSB-first per byte, so for a 32-bit value we want
+        // the most significant byte at offset 0 — i.e., big-endian encoding.
+        var data = new byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(data, value);
+        return data;
+    }
+
+    [Theory]
+    [InlineData(0x80000000u)] // the bit that triggered the original OverflowException
+    [InlineData(0xFFFFFFFFu)]
+    [InlineData(0xCAFEBABEu)]
+    [InlineData(0xAAAAAAAAu)]
+    [InlineData(0x55555555u)]
+    [InlineData(0u)]
+    public void ReadBits_uint_32bit(uint expected)
+    {
+        using var buffer = new ByteBuffer(MsbFirst32(expected));
+        Assert.Equal(expected, buffer.ReadBits<uint>(32));
+    }
+
+    [Fact]
+    public void ReadBits_int_32bit_AllOnes_IsMinusOne()
+    {
+        using var buffer = new ByteBuffer(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF });
+        Assert.Equal(-1, buffer.ReadBits<int>(32));
+    }
+
+    [Fact]
+    public void ReadBits_int_32bit_HighBitOnly_IsIntMinValue()
+    {
+        using var buffer = new ByteBuffer(new byte[] { 0x80, 0x00, 0x00, 0x00 });
+        Assert.Equal(int.MinValue, buffer.ReadBits<int>(32));
+    }
+
+    [Theory]
+    [InlineData(0u, 8)]
+    [InlineData(0xFFu, 8)]
+    [InlineData(0xAAu, 8)]
+    [InlineData(0x7u, 3)]
+    [InlineData(0x1Fu, 5)]
+    public void ReadBits_byte_RoundTrip(uint value, int bitCount)
+    {
+        // Pad the 8-bit value into the high bits of a single byte for MSB-first reading.
+        byte b = (byte)(value << (8 - bitCount));
+        using var buffer = new ByteBuffer(new byte[] { b });
+        Assert.Equal((byte)value, buffer.ReadBits<byte>(bitCount));
+    }
+
+    [Theory]
+    [InlineData(0u, 16)]
+    [InlineData(0xFFFFu, 16)]
+    [InlineData(0xCAFEu, 16)]
+    [InlineData(0x7FFu, 11)]    // ItemLevel — actual production caller
+    public void ReadBits_ushort_RoundTrip(uint value, int bitCount)
+    {
+        var data = new byte[2];
+        BinaryPrimitives.WriteUInt16BigEndian(data, (ushort)(value << (16 - bitCount)));
+        using var buffer = new ByteBuffer(data);
+        Assert.Equal((ushort)value, buffer.ReadBits<ushort>(bitCount));
+    }
+
+    [Fact]
+    public void ReadBits_uint_30bit_AllOnes_StillCorrect()
+    {
+        // MovementInfo.Flags is a real 30-bit production read. Locks that the
+        // fix doesn't regress it.
+        const uint expected = (1u << 30) - 1u;
+        var data = new byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(data, expected << 2);
+        using var buffer = new ByteBuffer(data);
+        Assert.Equal(expected, buffer.ReadBits<uint>(30));
+    }
+
+    [Fact]
+    public void ReadBits_Zero_BitCount_ReturnsZero()
+    {
+        using var buffer = new ByteBuffer(new byte[] { 0xFF });
+        Assert.Equal(0u, buffer.ReadBits<uint>(0));
+    }
+}
+
+/// <summary>
 /// Round-trip coverage for ByteBuffer.WriteBits across bit widths, value patterns,
-/// and starting bit positions. Locks the wire format so the upcoming chunked-packing
-/// optimization (mirroring <c>SpanPacketWriter</c> commit 27d7e52) is byte-identical.
-/// Pattern: write via write-mode ByteBuffer → FlushBits → GetData → wrap in
-/// read-mode ByteBuffer → reconstruct via per-bit <c>ReadBit</c> loop.
-///
-/// We deliberately avoid <c>ReadBits&lt;uint&gt;(N)</c> because that helper has a
-/// latent overflow bug at <c>N=32</c> with the high bit set (uses <c>int value</c>
-/// internally, then <c>Convert.ChangeType</c> throws on the negative-int → uint
-/// conversion). The bug is shared with <c>SpanPacketReader.ReadBits&lt;T&gt;</c>;
-/// neither suite currently exercises it. Out of scope for this perf commit —
-/// tracked as a follow-up.
+/// and starting bit positions. Locks the wire format byte-identical to the
+/// SpanPacketWriter chunked-packing path (commit 27d7e52). Pattern: write via
+/// write-mode ByteBuffer → FlushBits → GetData → wrap in read-mode ByteBuffer →
+/// <see cref="ByteBuffer.ReadBits{T}(int)"/>.
 /// </summary>
 public class ByteBufferWriteBitsRoundTripTests
 {
-    private static uint ReadBitsAsUInt(ByteBuffer reader, int bitCount)
-    {
-        uint value = 0;
-        for (int i = bitCount - 1; i >= 0; --i)
-            if (reader.ReadBit())
-                value |= 1u << i;
-        return value;
-    }
-
     [Theory]
     [InlineData(1)] [InlineData(2)] [InlineData(3)] [InlineData(4)]
     [InlineData(5)] [InlineData(6)] [InlineData(7)] [InlineData(8)]
@@ -327,7 +409,7 @@ public class ByteBufferWriteBitsRoundTripTests
         var data = writer.GetData();
 
         using var reader = new ByteBuffer(data);
-        uint actual = ReadBitsAsUInt(reader, bitCount);
+        uint actual = reader.ReadBits<uint>(bitCount);
         Assert.Equal(0u, actual);
     }
 
@@ -346,7 +428,7 @@ public class ByteBufferWriteBitsRoundTripTests
         var data = writer.GetData();
 
         using var reader = new ByteBuffer(data);
-        uint actual = ReadBitsAsUInt(reader, bitCount);
+        uint actual = reader.ReadBits<uint>(bitCount);
         Assert.Equal(expected, actual);
     }
 
@@ -372,8 +454,8 @@ public class ByteBufferWriteBitsRoundTripTests
 
         using var reader = new ByteBuffer(data);
         if (paddingBits > 0)
-            ReadBitsAsUInt(reader, paddingBits);
-        uint actual = ReadBitsAsUInt(reader, bitCount);
+            reader.ReadBits<uint>(paddingBits);
+        uint actual = reader.ReadBits<uint>(bitCount);
         Assert.Equal(value, actual);
     }
 
@@ -391,7 +473,7 @@ public class ByteBufferWriteBitsRoundTripTests
         var data = writer.GetData();
 
         using var reader = new ByteBuffer(data);
-        uint actual = ReadBitsAsUInt(reader, 32);
+        uint actual = reader.ReadBits<uint>(32);
         Assert.Equal(value, actual);
     }
 
@@ -410,7 +492,7 @@ public class ByteBufferWriteBitsRoundTripTests
         var data = writer.GetData();
 
         using var reader = new ByteBuffer(data);
-        uint actual = ReadBitsAsUInt(reader, bitCount);
+        uint actual = reader.ReadBits<uint>(bitCount);
         Assert.Equal(value, actual);
     }
 
@@ -428,12 +510,12 @@ public class ByteBufferWriteBitsRoundTripTests
         var data = writer.GetData();
 
         using var reader = new ByteBuffer(data);
-        Assert.Equal(0xAu, ReadBitsAsUInt(reader, 4));
-        Assert.Equal(0x5u, ReadBitsAsUInt(reader, 4));
+        Assert.Equal(0xAu, reader.ReadBits<uint>(4));
+        Assert.Equal(0x5u, reader.ReadBits<uint>(4));
         Assert.Equal((byte)0x42, reader.ReadUInt8());
-        Assert.Equal(0x7u, ReadBitsAsUInt(reader, 3));
+        Assert.Equal(0x7u, reader.ReadBits<uint>(3));
         Assert.Equal(1.5f, reader.ReadFloat());
-        Assert.Equal(0x123456u, ReadBitsAsUInt(reader, 24));
+        Assert.Equal(0x123456u, reader.ReadBits<uint>(24));
     }
 }
 
@@ -666,15 +748,6 @@ public class ByteBufferWriteStringRoundTripTests
 /// </summary>
 public class ByteBufferCrossModeRoundTripTests
 {
-    private static uint ReadBitsAsUInt(ByteBuffer reader, int bitCount)
-    {
-        uint value = 0;
-        for (int i = bitCount - 1; i >= 0; --i)
-            if (reader.ReadBit())
-                value |= 1u << i;
-        return value;
-    }
-
     [Fact]
     public void CrossMode_WriteBits_ByteBuffer_ReadVia_SpanPacketReader()
     {
@@ -700,8 +773,8 @@ public class ByteBufferCrossModeRoundTripTests
         var data = spanWriter.ToArray();
 
         using var reader = new ByteBuffer(data);
-        Assert.Equal(0x123u, ReadBitsAsUInt(reader, 9));
-        Assert.Equal(0xFFu, ReadBitsAsUInt(reader, 8));
+        Assert.Equal(0x123u, reader.ReadBits<uint>(9));
+        Assert.Equal(0xFFu, reader.ReadBits<uint>(8));
     }
 
     [Fact]

--- a/HermesProxy.Tests/Framework/SpanPacketTests.cs
+++ b/HermesProxy.Tests/Framework/SpanPacketTests.cs
@@ -6,6 +6,7 @@ using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using Xunit;
 using System;
+using System.Buffers.Binary;
 using HermesProxy.World.Server.Packets;
 
 namespace HermesProxy.Tests.Framework;
@@ -492,6 +493,63 @@ public class SpanPacketReaderTests
         Assert.True(reader.CanRead);
         reader.ReadUInt32();
         Assert.False(reader.CanRead);
+    }
+}
+
+/// <summary>
+/// Coverage for <see cref="SpanPacketReader.ReadBits{T}(int)"/> — locks the
+/// post-fix behavior. Mirrors <c>ByteBufferReadBitsTests</c> for the same
+/// surfaces. Previous formulation threw <see cref="OverflowException"/> at
+/// <c>bitCount=32</c> with the high bit set.
+/// </summary>
+public class SpanPacketReaderReadBitsTests
+{
+    private static byte[] MsbFirst32(uint value)
+    {
+        var data = new byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(data, value);
+        return data;
+    }
+
+    [Theory]
+    [InlineData(0x80000000u)]
+    [InlineData(0xFFFFFFFFu)]
+    [InlineData(0xCAFEBABEu)]
+    [InlineData(0xAAAAAAAAu)]
+    [InlineData(0x55555555u)]
+    [InlineData(0u)]
+    public void ReadBits_uint_32bit(uint expected)
+    {
+        var reader = new SpanPacketReader(MsbFirst32(expected));
+        Assert.Equal(expected, reader.ReadBits<uint>(32));
+    }
+
+    [Fact]
+    public void ReadBits_int_32bit_AllOnes_IsMinusOne()
+    {
+        var reader = new SpanPacketReader(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF });
+        Assert.Equal(-1, reader.ReadBits<int>(32));
+    }
+
+    [Fact]
+    public void ReadBits_int_32bit_HighBitOnly_IsIntMinValue()
+    {
+        var reader = new SpanPacketReader(new byte[] { 0x80, 0x00, 0x00, 0x00 });
+        Assert.Equal(int.MinValue, reader.ReadBits<int>(32));
+    }
+
+    [Fact]
+    public void ReadBits_byte_8bit_RoundTrip()
+    {
+        var reader = new SpanPacketReader(new byte[] { 0xAA });
+        Assert.Equal((byte)0xAA, reader.ReadBits<byte>(8));
+    }
+
+    [Fact]
+    public void ReadBits_ushort_16bit_RoundTrip()
+    {
+        var reader = new SpanPacketReader(new byte[] { 0xCA, 0xFE });
+        Assert.Equal((ushort)0xCAFE, reader.ReadBits<ushort>(16));
     }
 }
 


### PR DESCRIPTION
## Summary

`ByteBuffer.ReadBits<T>` and `SpanPacketReader.ReadBits<T>` both used `int value = 0` as the bit-accumulator. At `bitCount=32` with the high bit set, `(1 << 31) = int.MinValue`, value goes negative, and the trailing `Convert.ChangeType(negative_int, typeof(uint))` throws `OverflowException`:

```
System.OverflowException : Value was either too large or too small for a UInt32.
   at System.Convert.ThrowUInt32OverflowException()
   at System.Int32.System.IConvertible.ToUInt32(IFormatProvider provider)
   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
   at Framework.IO.ByteBuffer.ReadBits[T](Int32 bitCount)
```

**Production exposure: zero.** Widest production read is 30 bits (`MovementInfo.Flags`). The bug was discovered by the WriteBits round-trip matrix in #56, which had to side-step it via a per-bit `ReadBitsAsUInt` workaround helper — flagged as "out of scope" in #57's description and tracked here.

## Fix

- **`uint` accumulator** — bit 31's `1u << 31` is just `0x80000000`, no sign weirdness.
- **`Unsafe.As<uint, T>(ref value)` reinterpret** — drops the per-call `Convert.ChangeType` boxing as a side benefit. `T` must be ≤ 4 bytes (byte/sbyte, ushort/short, uint/int); larger types would read uninitialized stack bytes — not a real risk because `bitCount` tops out at 32, but documented in the xmldoc.
- **`where T : unmanaged` constraint** added on `ByteBuffer.ReadBits<T>` (SpanPacketReader already had it).

The two implementations are now structurally identical (modulo `ReadBit` vs `HasBit`, which are themselves identical bit-by-bit).

## Cleanup

- Removed the `ReadBitsAsUInt` per-bit workaround helper from #56's `ByteBufferWriteBitsRoundTripTests` and `ByteBufferCrossModeRoundTripTests`. Those tests now call `ReadBits<uint>` directly. Removed the "out of scope / tracked as follow-up" docstring note that referenced the bug.
- Fixed the entity-encoded `Span&lt;byte&gt;` / `ReadOnlySpan&lt;byte&gt;` in the `SpanPacketWriter` and `SpanPacketReader` class summaries — same kind of cleanup the user did for one docstring in their fork's `27d7e52` and explicitly flagged in this session as "unreadable characters like '&lt;'".

## Tests added

`HermesProxy.Tests/Framework/ByteBufferTests.cs` (`ByteBufferReadBitsTests`) and `HermesProxy.Tests/Framework/SpanPacketTests.cs` (`SpanPacketReaderReadBitsTests`) — mirrored matrix:

- `ReadBits<uint>(32)` with `0x80000000` (the bit that triggered the original bug), `0xFFFFFFFF`, `0xCAFEBABE`, `0xAAAAAAAA`, `0x55555555`, `0`
- `ReadBits<int>(32)` with `0x80000000` → `int.MinValue` and `0xFFFFFFFF` → `-1` (verifies the reinterpret behaves like a typed cast)
- `ReadBits<byte>` and `ReadBits<ushort>` sampling with various bit widths to confirm `Unsafe.As` truncates correctly
- `ReadBits<uint>(30)` with `(1u << 30) - 1` (locks the actual production `MovementInfo.Flags` width against regression)

## Test plan

- [x] `dotnet test --filter "ReadBits"` — 30 tests pass against the fix (both new + the freshly-direct PR-#56 tests)
- [x] `dotnet test` — full 434-test suite green (was 405 before this PR; +29 new ReadBits tests)
- [x] No more `&lt;` or `&gt;` HTML entities in `Framework/IO/*.cs` or `HermesProxy.Tests/Framework/*.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)