### PR TITLE
test(crypt): modernize WorldCryptTests skip pattern to xUnit v3 Assert.SkipUnless

### DIFF
--- a/.github/workflows/PreRelease.yml
+++ b/.github/workflows/PreRelease.yml
@@ -75,8 +75,18 @@ jobs:
           echo "floor=$floor" >> "$GITHUB_OUTPUT"
           echo "slug=$slug" >> "$GITHUB_OUTPUT"
 
+  # Tests run on both Linux and macOS so platform-specific paths are exercised
+  # in CI — notably the AES-GCM 12-byte-tag fallback in WorldCrypt which kicks
+  # in on macOS (Apple CommonCrypto rejects 12-byte tags). The WorldCryptTests
+  # suite uses Assert.SkipUnless to mark cross-check sites Skipped on macOS,
+  # so a regression that breaks the BC fallback would surface here instead
+  # of silently passing on Linux.
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository content
         uses: actions/checkout@v4
@@ -92,8 +102,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ hashFiles('Directory.Packages.props') }}
-          restore-keys: nuget-
+          key: nuget-${{ runner.os }}-${{ hashFiles('Directory.Packages.props') }}
+          restore-keys: nuget-${{ runner.os }}-
 
       - name: Restore
         run: dotnet restore

--- a/HermesProxy.Tests/CLAUDE.md
+++ b/HermesProxy.Tests/CLAUDE.md
@@ -12,7 +12,7 @@ dotnet test --filter "ClassName"    # Filter by class or method name
 
 ## Test Framework
 
-- **xUnit 2.9.3** — test runner
+- **xunit.v3 3.2.2** — test runner (supports `Assert.Skip` / `Assert.SkipUnless` / `Assert.SkipWhen` natively)
 - **Moq 4.20.72** — mocking
 - **coverlet.collector** — code coverage
 

--- a/HermesProxy.Tests/Framework/Cryptography/WorldCryptTests.cs
+++ b/HermesProxy.Tests/Framework/Cryptography/WorldCryptTests.cs
@@ -3,6 +3,9 @@ using System.Buffers.Binary;
 using System.Security.Cryptography;
 using System.Text;
 using Framework.Cryptography;
+using Org.BouncyCastle.Crypto.Engines;
+using Org.BouncyCastle.Crypto.Modes;
+using Org.BouncyCastle.Crypto.Parameters;
 using Xunit;
 
 namespace HermesProxy.Tests.Framework.Cryptography;
@@ -78,8 +81,16 @@ public class WorldCryptTests : IDisposable
     {
         WorldCrypt.ForceBouncyCastleForTests = forceBouncyCastle;
 
-        // Hand-encrypt a CLNT-direction packet using the platform primitive, then feed a
+        // Hand-encrypt a CLNT-direction packet with a portable AES-GCM, then feed a
         // bit-flipped tag into WorldCrypt.Decrypt and assert it surfaces as a false return.
+        //
+        // Uses BouncyCastle as the reference encryptor so the test runs on every
+        // platform — System.Security.Cryptography.AesGcm rejects 12-byte tags on
+        // macOS (Apple CommonCrypto). BC implements standards-compliant AES-GCM
+        // and produces wire-compatible output, so WorldCrypt's decryptor accepts
+        // the ciphertext regardless of which backend it ends up using internally.
+        // Tamper detection itself is the actual SUT here — that path runs on all
+        // platforms with this change, instead of being silently skipped on macOS.
         byte[] plaintext = "client packet"u8.ToArray();
         byte[] ciphertext = new byte[plaintext.Length];
         byte[] tag = new byte[12];
@@ -87,8 +98,13 @@ public class WorldCryptTests : IDisposable
         BinaryPrimitives.WriteUInt64LittleEndian(nonce.AsSpan(), 0);
         BinaryPrimitives.WriteUInt32LittleEndian(nonce.AsSpan(8), 0x544E4C43);
 
-        using (var refEncryptor = new AesGcm(Key16, 12))
-            refEncryptor.Encrypt(nonce, plaintext, ciphertext, tag);
+        var bcEncryptor = new GcmBlockCipher(new AesEngine());
+        bcEncryptor.Init(true, new AeadParameters(new KeyParameter(Key16), 96, nonce));
+        byte[] bcOutput = new byte[plaintext.Length + 12];
+        int bcWritten = bcEncryptor.ProcessBytes(plaintext, 0, plaintext.Length, bcOutput, 0);
+        bcEncryptor.DoFinal(bcOutput, bcWritten);
+        Array.Copy(bcOutput, 0, ciphertext, 0, plaintext.Length);
+        Array.Copy(bcOutput, plaintext.Length, tag, 0, 12);
 
         tag[0] ^= 0xFF; // tamper
 

--- a/HermesProxy.Tests/Framework/Cryptography/WorldCryptTests.cs
+++ b/HermesProxy.Tests/Framework/Cryptography/WorldCryptTests.cs
@@ -13,6 +13,18 @@ public class WorldCryptTests : IDisposable
     // what's in the bytes, only that the length is 16/24/32.
     private static readonly byte[] Key16 = "0123456789ABCDEF"u8.ToArray();
 
+    // Probe once at class load: does the platform's native AesGcm accept the 12-byte (96-bit) tag
+    // the WoW protocol uses? macOS Apple CommonCrypto rejects it; .NET there falls back to BC.
+    // Tests that depend on native AesGcm as an independent verifier use Assert.SkipUnless on this.
+    private static readonly bool PlatformSupportsAesGcm12ByteTag = ProbeNativeAesGcm12();
+    private static bool ProbeNativeAesGcm12()
+    {
+        Span<byte> probeKey = stackalloc byte[16];
+        try { using var _ = new AesGcm(probeKey, 12); return true; }
+        catch (ArgumentException) { return false; }
+        catch (PlatformNotSupportedException) { return false; }
+    }
+
     public WorldCryptTests()
     {
         WorldCrypt.ForceBouncyCastleForTests = false;
@@ -28,6 +40,9 @@ public class WorldCryptTests : IDisposable
     [InlineData(true)]
     public void Encrypt_ThenDecrypt_RoundtripsThroughSameBackend(bool forceBouncyCastle)
     {
+        Assert.SkipUnless(PlatformSupportsAesGcm12ByteTag,
+            "Native AesGcm rejects 12-byte tags here; both the unforced-backend invariant and the cross-decrypt verifier require it.");
+
         WorldCrypt.ForceBouncyCastleForTests = forceBouncyCastle;
 
         // The two WorldCrypt instances simulate the proxy's two halves: one Encrypt-side
@@ -100,12 +115,12 @@ public class WorldCryptTests : IDisposable
         Assert.True(bc.UsingBouncyCastle);
 
         WorldCrypt.ForceBouncyCastleForTests = false;
+        Assert.SkipUnless(PlatformSupportsAesGcm12ByteTag,
+            "Platform falls back to BC even without the test flag; cannot verify unforced→native invariant here.");
+
         using var native = new WorldCrypt();
         native.Initialize(Key16);
-        // On platforms where native AesGcm with 12-byte tag works (Win/most Linux) this is false.
-        // On macOS where native rejects the tag, even without the force flag we fall through to BC.
-        // The contract is: the flag forces BC; clearing it allows either.
-        // We only assert the forcing direction strongly.
+        Assert.False(native.UsingBouncyCastle);
     }
 
     [Theory]
@@ -129,20 +144,13 @@ public class WorldCryptTests : IDisposable
         byte[] nonce = new byte[12];
         BinaryPrimitives.WriteUInt32LittleEndian(nonce.AsSpan(8), 0x52565253);
 
-        // Always verify against the native primitive — if 12-byte tag isn't supported here
-        // (macOS without our fallback logic) skip the cross-check rather than fail.
-        AesGcm? reference = null;
-        try { reference = new AesGcm(Key16, 12); }
-        catch (ArgumentException) { /* platform native rejects 12-byte tag — skip cross-check */ }
-        catch (PlatformNotSupportedException) { /* skip */ }
-        if (reference is null) return;
+        Assert.SkipUnless(PlatformSupportsAesGcm12ByteTag,
+            "Native AesGcm rejects 12-byte tags here; cross-check requires it.");
 
-        using (reference)
-        {
-            byte[] decrypted = new byte[data.Length];
-            reference.Decrypt(nonce, data, tag, decrypted);
-            Assert.Equal(plaintext, decrypted);
-        }
+        byte[] decrypted = new byte[data.Length];
+        using var reference = new AesGcm(Key16, 12);
+        reference.Decrypt(nonce, data, tag, decrypted);
+        Assert.Equal(plaintext, decrypted);
     }
 
     [Fact]
@@ -169,16 +177,12 @@ public class WorldCryptTests : IDisposable
         BinaryPrimitives.WriteUInt64LittleEndian(nonce.AsSpan(), 3);
         BinaryPrimitives.WriteUInt32LittleEndian(nonce.AsSpan(8), 0x52565253);
 
-        AesGcm? reference = null;
-        try { reference = new AesGcm(Key16, 12); }
-        catch (ArgumentException) { return; }
-        catch (PlatformNotSupportedException) { return; }
+        Assert.SkipUnless(PlatformSupportsAesGcm12ByteTag,
+            "Native AesGcm rejects 12-byte tags here; counter-advancement verifier requires it.");
 
-        using (reference)
-        {
-            byte[] decrypted = new byte[finalData.Length];
-            reference.Decrypt(nonce, finalData, finalTag, decrypted);
-            Assert.Equal(plaintext, decrypted);
-        }
+        byte[] decrypted = new byte[finalData.Length];
+        using var reference = new AesGcm(Key16, 12);
+        reference.Decrypt(nonce, finalData, finalTag, decrypted);
+        Assert.Equal(plaintext, decrypted);
     }
 }


### PR DESCRIPTION
## Summary

`WorldCryptTests` had three sites that handled macOS's lack of 12-byte-tag `AesGcm` with a silent `try { new AesGcm(Key16, 12) } catch { return; }` pattern. On macOS those tests reported as **Passed** even though their core cross-decrypt verification was silently skipped — a regression on the unexercised branch would never surface as a visible Skipped/Failed signal in CI.

The project is already on `xunit.v3` (3.2.2), which ships `Assert.Skip` / `Assert.SkipUnless` / `Assert.SkipWhen` as first-class APIs. This PR switches to those so macOS CI reports honest Skipped counts with stated reasons.

## Changes

- Added `PlatformSupportsAesGcm12ByteTag` static probe (runs once at class load via `stackalloc byte[16]`, zero heap allocation per the project's perf philosophy).
- Replaced silent `return;` with `Assert.SkipUnless(...)` at five sites:
  - `Encrypt_ThenDecrypt_RoundtripsThroughSameBackend`
  - `UsingBouncyCastle_ReflectsForceFlag`
  - `Encrypt_NativeAndBc_ProduceWireCompatibleOutput`
  - `Encrypt_AdvancesServerCounter_DecryptAdvancesClientCounter`
  - plus the round-trip's previously-unguarded `new AesGcm(Key16, 12)` cross-check
- Restored strict `Assert.False(native.UsingBouncyCastle)` and `Assert.Equal(plaintext, decrypted)` assertions that the silent-return pattern had weakened — they only run on platforms where the probe passes, so they're now meaningful invariants again.
- Updated `HermesProxy.Tests/CLAUDE.md`: said "xUnit 2.9.3" but the project has been on `xunit.v3` 3.2.2 for a while.

## Test plan

- [x] Windows: `dotnet test HermesProxy.Tests` → **557 passed, 1 pre-existing unrelated skip, 0 failed**, 0 new skips (probe passes, all assertions exercised).
- [x] macOS CI: expect the 3 crypt cross-check tests to now report **Skipped** with the stated reason strings visible in logs (instead of silently passing). This PR's PreRelease run will validate that on the `macos-latest` builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)