### PR TITLE
fix(packets): use Count > 0 on auto-initialized list write gates

### DIFF
--- a/HermesProxy/World/Server/Packets/GroupPackets.cs
+++ b/HermesProxy/World/Server/Packets/GroupPackets.cs
@@ -741,7 +741,7 @@ class PartyMemberPartialState : ServerPacket
         _worldPacket.WriteBit(WmoDoodadPlacementID.HasValue);
         _worldPacket.WriteBit(Position != null);
         _worldPacket.WriteBit(VehicleSeatRecID.HasValue);
-        _worldPacket.WriteBit(Auras != null);
+        _worldPacket.WriteBit(Auras.Count > 0);
         _worldPacket.WriteBit(Pet != null);
         _worldPacket.WriteBit(Phase != null);
         _worldPacket.WriteBit(Unk901_2 != null);
@@ -789,7 +789,7 @@ class PartyMemberPartialState : ServerPacket
         }
         if (VehicleSeatRecID.HasValue)
             _worldPacket.WriteUInt32(VehicleSeatRecID.Value);
-        if (Auras != null)
+        if (Auras.Count > 0)
         {
             _worldPacket.WriteInt32(Auras.Count);
             foreach (var aura in Auras)
@@ -998,7 +998,7 @@ public class PartyMemberPetStats
         data.WriteBit(DisplayID.HasValue);
         data.WriteBit(MaxHealth.HasValue);
         data.WriteBit(Health.HasValue);
-        data.WriteBit(Auras != null);
+        data.WriteBit(Auras.Count > 0);
         data.FlushBits();
 
         if (NewPetName != null)
@@ -1014,7 +1014,7 @@ public class PartyMemberPetStats
             data.WriteUInt32(MaxHealth.Value);
         if (Health.HasValue)
             data.WriteUInt32(Health.Value);
-        if (Auras != null)
+        if (Auras.Count > 0)
         {
             data.WriteInt32(Auras.Count);
             foreach (var aura in Auras)

--- a/HermesProxy/World/Server/Packets/SystemPackets.cs
+++ b/HermesProxy/World/Server/Packets/SystemPackets.cs
@@ -125,7 +125,7 @@ public class FeatureSystemStatus : ServerPacket
         if (ModernVersion.IsClassicVersionBuild())
         {
             _worldPacket.WriteBit(BattlegroundsEnabled);
-            _worldPacket.WriteBit(RaceClassExpansionLevels != null);
+            _worldPacket.WriteBit(RaceClassExpansionLevels.Count > 0);
         }
         
         _worldPacket.FlushBits();
@@ -165,7 +165,7 @@ public class FeatureSystemStatus : ServerPacket
 
         if (ModernVersion.IsClassicVersionBuild())
         {
-            if (RaceClassExpansionLevels != null)
+            if (RaceClassExpansionLevels.Count > 0)
             {
                 _worldPacket.WriteInt32(RaceClassExpansionLevels.Count);
                 for (var i = 0; i < RaceClassExpansionLevels.Count; ++i)


### PR DESCRIPTION
## Summary

- Closes #69
- Fixes a client-crash-on-login regression for `V1_14_2 + cMaNGOS vanilla` (and any other classic build emitting empty list payloads) introduced by commit 97e431a.
- Three packet writer sites gated emission on `field != null` while the field was auto-initialized to `= new()`. Empty lists flipped the presence bit to `true` and emitted a phantom `Int32(0)` count, shifting the wire layout and crashing the modern client mid-loading-screen.
- Rewrites the gates to `Count > 0` so empty list ≡ absent again, matching pre-97e431a wire output byte-for-byte while keeping the `= new()` initializers (and the CS8618 silence intact).

Sites fixed:
- `SystemPackets.FeatureSystemStatus.RaceClassExpansionLevels` (lines 128, 168)
- `GroupPackets.PartyMemberPartialState.Auras` (lines 744, 792)
- `GroupPackets.PartyMemberPetStats.Auras` (lines 1001, 1017)

## 🙌 Huge thanks to @Thorsten42

This one is almost entirely his work — one of the best bug reports this project has ever seen:

- **Clean bisect** down to a single commit (`97e431a`).
- **Codex-assisted narrowing** to the exact field (`RaceClassExpansionLevels`) and root cause (`= new()` vs `!= null` writer gate semantic drift).
- **Reproducible Docker build recipe** (`mcr.microsoft.com/dotnet/sdk:10.0`, `linux-x64` self-contained publish) that let us audit the build pipeline as a variable.
- **Side-by-side proof** — built master with and without the offending line, demonstrated the regression flips on/off cleanly.
- **End-to-end validation** of the branch fix on his Linux + Steam Flatpak + Proton/DXVK setup, which is the environment that surfaced the bug in the first place.

Without that level of detail, this would have been "intermittent client crash on classic login" sitting in the bug tracker for months. Thank you @Thorsten42 🙏

## Test plan

- [x] `dotnet build` — clean.
- [x] `dotnet test` — 557/557 passing.
- [x] @Thorsten42 validated the branch end-to-end on `V1_14_2 + cMaNGOS vanilla` (Linux/Wine/DXVK) — world-enter no longer crashes ([confirmation](https://github.com/Xian55/HermesProxy/issues/69#issuecomment-4463433538)).
- [x] Reviewer sanity-check: V3_4_3 + TC WotLK login + group/pet party UI still renders correctly (the `GroupPackets.cs` sites are on the in-use WotLK path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)