### PR TITLE
fix(sniff): make SniffFile.CloseFile idempotent (#75)

### DIFF
--- a/HermesProxy/World/SniffFile.cs
+++ b/HermesProxy/World/SniffFile.cs
@@ -42,6 +42,7 @@ public sealed class SniffFile
     BinaryWriter _fileWriter;
     ushort _gameVersion;
     readonly Lock _lock = new();
+    bool _closed;
 
     public void WriteHeader()
     {
@@ -63,6 +64,9 @@ public sealed class SniffFile
     {
         lock (_lock)
         {
+            if (_closed)
+                return;
+
             byte direction = !isFromClient ? (byte)0xff : (byte)0x0;
             _fileWriter.Write(direction);
 
@@ -92,13 +96,14 @@ public sealed class SniffFile
 
     public void CloseFile()
     {
-        // Guard against races with an in-flight WritePacket on another thread — session teardown
-        // can run concurrently with the last packets being flushed.
-        // Flush() is redundant here (BinaryWriter.Close -> FileStream.Dispose flushes the 64 KB
-        // buffer before closing the handle) but makes the intent explicit, and keeps the invariant
-        // that "CloseFile returned cleanly => all previously-written bytes are in the OS page cache".
+        // Idempotent: callers (CMSG_LOG_DISCONNECT in WorldSocket.ReadData, GlobalSessionData.OnDisconnect)
+        // race on the unsynchronised ModernSniff field; first wins, repeats must no-op rather than
+        // throw ObjectDisposedException on the already-closed FileStream (issue #75).
         lock (_lock)
         {
+            if (_closed)
+                return;
+            _closed = true;
             _fileWriter.Flush();
             _fileWriter.Close();
         }


### PR DESCRIPTION
## Summary

Fixes #75 — `ObjectDisposedException` crash when client quits without the ~20 s grace.

`SniffFile` is closed from two paths with no synchronisation on the `ModernSniff` field:

- `WorldSocket.ReadData()` on `CMSG_LOG_DISCONNECT`
- `GlobalSessionData.OnDisconnect()` on socket teardown / `SendPacket` after close

On abrupt quit both paths pass the non-null check, both call `CloseFile()`, and the second hits a disposed `FileStream` inside `BinaryWriter.Flush()` → unhandled on the IOCP thread → process termination.

Repro evidence in local Release log `hermes-20260517_73846.log`: every quit cycle fires `CMSG_LOG_DISCONNECT` **twice** back-to-back (lines 1557-58, 2131-33, 3579-80).

## Fix

Track `_closed` inside the existing `_lock` in `SniffFile`. `CloseFile()` becomes first-writer-wins idempotent; `WritePacket()` no-ops post-close so a late packet racing teardown cannot throw on the disposed writer.

One-file change. No call sites need updating.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 557 pass, 0 fail
- [x] Local Release run: 3 rapid-quit cycles, each with the double `CMSG_LOG_DISCONNECT` pattern, all survived — no `ObjectDisposedException`, no `Unhandled`, clean `Client disconnected with reason 13`
- [x] Reporter (#75) confirms macOS 1.14.0 → Solocraft fast-quit no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
