### PR TITLE
fix(v3_4_3) make the visual effect of the AOE spell rendered.

### DIFF
--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -1279,7 +1279,7 @@ public partial class ObjectUpdateBuilder
         var dyn = _updateData.DynamicObjectData ?? new DynamicObjectData();
         data.WritePackedGuid128(dyn.Caster ?? WowGuid128.Empty);
         data.WriteUInt8(0);
-        data.WriteInt32(0);
+        data.WriteInt32(dyn.SpellXSpellVisualID.GetValueOrDefault());
         data.WriteInt32(dyn.SpellID.GetValueOrDefault());
         data.WriteFloat(dyn.Radius.GetValueOrDefault());
         data.WriteUInt32(dyn.CastTime.GetValueOrDefault());


### PR DESCRIPTION
Confirmed visible visual effects for those spells: 

- Paladin's "Consecration"
- DK's "Death and Decay"

Previous behavior: no visual effect visible

Tested on AzerothCore

<img width="1919" height="1079" alt="Test" src="https://github.com/user-attachments/assets/e716da31-e56f-47f2-a1a9-14c0611d5cd0" />
