### PR TITLE
Dispell macos crash

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -99,6 +99,12 @@ public sealed class GameSessionData
     public uint CurrentGuildNumAccounts;
     public WowGuid128 CurrentInteractedWithNPC;
     public WowGuid128 CurrentInteractedWithGO;
+    // Last target the client sent via CMSG_SET_SELECTION. Used to un-do the
+    // patched macOS 1.14 client's tendency to silently retarget friendly-only
+    // spells away from non-attackable NPCs (vendors, innkeepers) onto a nearby
+    // player. When the cast target differs from this selection and the
+    // selection is a Creature, the proxy substitutes the selection back in.
+    public WowGuid128 CurrentSelection;
     public uint LastWhoRequestId;
     public WowGuid128 CurrentPetGuid;
     public WowGuid64 CurrentAttackTarget;        // active CMSG_ATTACK_SWING victim, cleared on ATTACK_STOP/CANCEL_COMBAT

--- a/HermesProxy/World/Server/PacketHandlers/MiscHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MiscHandler.cs
@@ -39,6 +39,7 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_SET_SELECTION)]
     void HandleSetSelection(SetSelection selection)
     {
+        GetSession().GameState.CurrentSelection = selection.TargetGUID;
         WorldPacket packet = new WorldPacket(Opcode.CMSG_SET_SELECTION);
         packet.WriteGuid(selection.TargetGUID.To64());
         SendPacketToServer(packet);

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -109,6 +109,25 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_CAST_SPELL)]
     void HandleCastSpell(CastSpell cast)
     {
+        // Patched macOS 1.14 client workaround: when the user selected a Creature
+        // (vendor/innkeeper/non-combat NPC) but the client decided the spell can't
+        // target it and silently auto-retargeted the cast to another player or
+        // self, substitute the selection back in. Detected as: cast target is a
+        // Player and differs from the user's last CMSG_SET_SELECTION, and that
+        // selection was a Creature. Windows-client casts won't trigger this
+        // because Windows sends the original creature target through.
+        {
+            var selection = GetSession().GameState.CurrentSelection;
+            if (!selection.IsEmpty()
+                && selection.GetHighType() == HighGuidType.Creature
+                && cast.Cast.Target.Unit.GetHighType() == HighGuidType.Player
+                && cast.Cast.Target.Unit != selection
+                && cast.Cast.Target.Flags.HasAnyFlag(SpellCastTargetFlags.Unit))
+            {
+                cast.Cast.Target.Unit = selection;
+            }
+        }
+
         bool isNextMelee = GameData.NextMeleeSpells.Contains(cast.Cast.SpellID);
         bool isAutoRepeat = GameData.AutoRepeatSpells.Contains(cast.Cast.SpellID);
 


### PR DESCRIPTION
https://github.com/Xian55/HermesProxy/issues/79
Partial fix, for cmangos. 

There is still an issue if autocast self is disabled, you will get out of range error.

Tested on Cmangos
Vmangos wont work for certain faction NPCs.