### PR TITLE
fix(vendor): open merchant frame for class-filtered empty vendor (#88)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
@@ -84,6 +84,11 @@ public partial class WorldClient
         SendPacketToClient(confirm);
     }
 
+    // Shown (greyed, out of stock) only when a legacy vendor's entire stock is class-filtered to
+    // empty, purely so the modern client opens the merchant frame so the player can still sell.
+    // Cheap era-ubiquitous item; change freely.
+    private const uint PlaceholderVendorItemId = 6948; // Hearthstone
+
     [PacketHandler(Opcode.SMSG_VENDOR_INVENTORY)]
     void HandleVendorInventory(WorldPacket packet)
     {
@@ -95,6 +100,20 @@ public partial class WorldClient
         if (itemsCount == 0)
         {
             vendor.Reason = packet.ReadUInt8();
+            // cMaNGOS class-filters a vendor's whole stock server-side (e.g. Cylina Darkheart, a
+            // warlock-only vendor, sends 0 items to non-warlocks). The modern client opens the
+            // merchant frame only when the list has >=1 item and Reason==0, so otherwise the player
+            // can't even sell. Inject one out-of-stock placeholder (Quantity=0 => greyed + unbuyable)
+            // so the frame opens. (#88)
+            vendor.Reason = 0;
+            vendor.Items.Add(new VendorItem
+            {
+                Slot = 1,
+                Quantity = 0,        // 0 left in stock -> client greys it and blocks purchase
+                StackCount = 1,
+                Price = 1,
+                Item = { ItemID = PlaceholderVendorItemId },
+            });
             SendPacketToClient(vendor);
             return;
         }


### PR DESCRIPTION
## Summary

Fixes #88 — on a modern client (1.14.2 Classic Era / V1_14_2_42597) connected to a 1.12.1 cMaNGOS server, a **non-warlock** could not open the merchant window when talking to **Cylina Darkheart** (NPC `6374`), a warlock-only vendor + trainer. The gossip dialogue opened and "I want to browse your goods." did nothing — the player couldn't even sell. A warlock, and native 1.12.1 clients, work fine.

`Closes #88`

## Root cause

Cylina's vendor stock is **class-restricted**, and cMaNGOS filters those items out **server-side** in `WorldSession::SendListInventory` (`src/game/Entities/ItemHandler.cpp`). So:

- **Warlock** → `SMSG_LIST_INVENTORY` with 39 items → client queries each item → merchant frame opens.
- **Non-warlock** → every item fails the class condition → server sends an **empty** list (`count = 0`, plus a trailing `uint8(0)` so `Reason = 0`).

The modern client fires `MERCHANT_SHOW` (i.e. opens the merchant frame) **only when the list has `Reason == 0` AND `itemCount > 0`**. An empty list is silently dropped, so the frame never opens and selling is impossible. The native 1.12.1 client opened an empty merchant frame; the modern client does not.

This is a fundamental modern-vs-legacy mismatch: TrinityCore / modern servers never send an empty list — they send **all** items flagged `PlayerConditionFailed` (rendered greyed), so `count` is always `> 0`. cMaNGOS instead drops the items before they ever reach the proxy, so the proxy cannot reconstruct or "un-filter" them.

## How it was diagnosed

Temporary `[GossipDiag]` tracing of the gossip options, the selected option index, and the vendor item count showed the warrior and warlock flows were **byte-identical** up to the vendor list — same gossip (`options=1`, `icon=1` Vendor, `'I want to browse your goods.'`), same selected `index=0` — differing only in `itemsCount` (`0` vs `39`). That isolated the cause to the empty list, not the gossip/option/icon/routing.

Two earlier hypotheses were investigated and **ruled out** (so reviewers don't re-chase them):

1. **"An open gossip frame blocks the merchant frame"** — disproven: the warlock reaches the merchant through the *same* gossip-gated path with the gossip frame open, and it works. Synthesizing `SMSG_GOSSIP_COMPLETE` before the vendor list had no effect.
2. **"Force `Reason = 0`"** — no-op: cMaNGOS already sends `0` for the empty case, so the client was already receiving `Reason == 0`. The gate is the item count, not the reason.

## The fix

The proxy's only lever is the packet it sends to the client. On the empty-list path in `HandleVendorInventory` (`HermesProxy/World/Client/PacketHandlers/NPCHandler.cs`), inject a **single out-of-stock placeholder item** so the modern client opens the merchant frame and the player can sell:

- `Quantity = 0` (0 left in stock) → the client renders it **greyed and blocks purchase**.
- `Item.ItemID = 6948` (Hearthstone) → an obviously-not-real-stock entry, exposed as a clearly-named `const PlaceholderVendorItemId` so it's trivial to change.

The change is **strictly gated to `itemsCount == 0`**. Vendors that return one or more items take the existing code path and are **byte-for-byte unchanged** — no regression to the working (warlock / plain-vendor / gossip-gated-with-items) paths.

```csharp
if (itemsCount == 0)
{
    vendor.Reason = packet.ReadUInt8();
    vendor.Reason = 0;
    vendor.Items.Add(new VendorItem
    {
        Slot = 1,
        Quantity = 0,        // 0 left in stock -> client greys it and blocks purchase
        StackCount = 1,
        Price = 1,
        Item = { ItemID = PlaceholderVendorItemId },
    });
    SendPacketToClient(vendor);
    return;
}
```
<img width="354" height="434" alt="workaround" src="https://github.com/user-attachments/assets/d5d92a9d-4143-43f1-8b77-53d7b85ddc17" />

## Testing

Verified end-to-end against the 1.12.1 cMaNGOS backend with a 1.14.2 client:

- **Warrior** → Cylina (`6374`) → "browse goods": merchant frame now **opens**; the placeholder shows greyed/0-available and is unbuyable; the **Sell tab works** (the reporter's original goal). ✅
- **Warlock** → Cylina: still shows the full 39-item stock and opens normally. ✅
- **Plain vendor** (no gossip) and gossip-gated vendors that return items: unchanged. ✅

## Scope / notes

- Affects any class- or condition-restricted legacy vendor whose entire stock filters to empty for the current character; this is not specific to Cylina.
- The placeholder is the only proxy-side way to make the modern client open an empty merchant — the alternative is leaving non-warlocks unable to sell at such vendors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
