### PR TITLE
fix(auth): trim password before SRP to survive clipboard paste

### DIFF
--- a/HermesProxy/BnetServer/Networking/BnetRestApiSession.cs
+++ b/HermesProxy/BnetServer/Networking/BnetRestApiSession.cs
@@ -110,7 +110,7 @@ public sealed class BnetRestApiSession : SSLSocket
             switch (field.Id)
             {
                 case "account_name": login = field.Value!.Trim().ToUpperInvariant(); break;
-                case "password": password = field.Value!; break;
+                case "password": password = field.Value!.Trim(); break;
             }
         }
 


### PR DESCRIPTION
## Summary

The BNet REST login handler trimmed `account_name` but forwarded the **password verbatim** into the SRP6 hash. A clipboard-pasted password carrying a trailing newline/space corrupts the SRP proof. mangos-lineage cores (cMaNGOS, Kronos/TwinStar, SoloCraft) report a bad password as `WOW_FAIL_UNKNOWN_ACCOUNT` (anti-enumeration), so the symptom reads as **"account not found"** even though the account exists.

## Root cause

`HermesProxy/BnetServer/Networking/BnetRestApiSession.cs` — `HandleLoginRequest`:

```csharp
case "account_name": login = field.Value!.Trim().ToUpperInvariant(); break;
case "password":     password = field.Value!;                         break;  // RAW
```

The password flows untrimmed into `AuthClient.ConnectToAuthServer` →
`authstring = $"{_username}:{password}"` → `SHA1(authstring.ToUpper())`. Any stray
trailing whitespace from a paste poisons the hash.

## Fix

```diff
- case "password": password = field.Value!; break;
+ case "password": password = field.Value!.Trim(); break;
```

The password should be trimmed before sending it, mirroring the existing `account_name`
handling. Vanilla/Classic WoW passwords exclude surrounding whitespace and the SRP path
upper-cases the whole `user:password` string, so `Trim()` only strips clipboard artifacts —
never a legitimate password character.

## How it was diagnosed

- Reported on a new Mac mini M4: external profiles (`era-1.14.0-kronos.json`,
  `era-1.14.0-solocraft.json`) failed with `FAIL_UNKNOWN_ACCOUNT`; same profiles worked on Windows.
- Verified both hostnames resolve fine (solocraft `51.255.225.111`, twinstar `46.105.37.11`);
  a one-off DNS error in the log was transient, not the cause.
- Local LAN cMaNGOS authenticated fine on the same Mac → proxy/crypto/network healthy.
- **Reproduced**: pasting a password with trailing whitespace makes even local cMaNGOS
  return `FAIL_UNKNOWN_ACCOUNT`. Not Mac-specific, not server-specific.

## Testing

- `dotnet build` — 0 errors.
- `dotnet test` — **557 passed, 0 failed, 1 skipped**.
- Manual: paste a password with a deliberate trailing space against any vanilla backend →
  authenticates after the fix (failed before).

## Risk

Minimal. One-line change, symmetric with existing `account_name` trimming. No wire-format
or version-gated behavior touched; applies to all client/server versions.
