### PR TITLE
fix(dispel): parse Kronos SMSG_SPELLDISPELLOG layout (#79)

### DIFF
--- a/Framework/IO/ByteBuffer.cs
+++ b/Framework/IO/ByteBuffer.cs
@@ -294,6 +294,11 @@ public class ByteBuffer : IDisposable
         return _position < _length;
     }
 
+    public int Remaining()
+    {
+        return _length - _position;
+    }
+
     public uint ReadPackedTime()
     {
         return (uint)Time.GetUnixTimeFromPackedTime(ReadUInt32());

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -1013,30 +1013,58 @@ public partial class WorldClient
         spell.CasterGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
 
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
+        {
+            // TBC+: dispel spell id + debug flag + count, per-entry Harmful, optional debug tail.
             spell.DispelledBySpellID = packet.ReadUInt32();
-        else
-            spell.DispelledBySpellID = GetSession().GameState.LastDispellSpellId;
+            bool hasDebug = packet.ReadBool();
 
-        bool hasDebug;
-        if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
-            hasDebug = packet.ReadBool();
-        else
-            hasDebug = false;
-
-        int count = packet.ReadInt32();
-        for (int i = 0; i < count; i++)
-        {
-            SpellDispellData dispel = new SpellDispellData();
-            dispel.SpellID = packet.ReadUInt32();
-            if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
+            int count = packet.ReadInt32();
+            for (int i = 0; i < count; i++)
+            {
+                SpellDispellData dispel = new SpellDispellData();
+                dispel.SpellID = packet.ReadUInt32();
                 dispel.Harmful = packet.ReadBool();
-            spell.DispellData.Add(dispel);
-        }
+                spell.DispellData.Add(dispel);
+            }
 
-        if (hasDebug)
+            if (hasDebug)
+            {
+                packet.ReadInt32(); // unk
+                packet.ReadInt32(); // unk
+            }
+        }
+        else
         {
-            packet.ReadInt32(); // unk
-            packet.ReadInt32(); // unk
+            // Vanilla 1.12 SMSG_SPELLDISPELLOG has two wire layouts in the wild (issue #79):
+            //   mangos/VMaNGOS: uint32 count, uint32[count] spellId
+            //   Kronos:         uint32 dispelBySpellId, { uint32 spellId, uint8 charges }*
+            // Tell them apart with pure byte-math, no realm/config heuristic: for mangos the
+            // leading uint32 IS the count, so the bytes left equal (count + 1) spell-id slots.
+            // Kronos's leading uint32 is a real spell id (~1152) that can never line up that way.
+            const int SpellIdSize = sizeof(uint);                 // count field and each spell id
+            const int KronosEntrySize = sizeof(uint) + sizeof(byte); // spell id + charges byte
+
+            int bytesAfterGuids = packet.Remaining();
+            uint countOrDispelledSpellId = packet.ReadUInt32();
+            if (bytesAfterGuids == SpellIdSize * ((int)countOrDispelledSpellId + 1))
+            {
+                // mangos / VMaNGOS — count-based, dispel spell id not carried on the wire.
+                spell.DispelledBySpellID = GetSession().GameState.LastDispellSpellId;
+                for (uint i = 0; i < countOrDispelledSpellId; i++)
+                    spell.DispellData.Add(new SpellDispellData { SpellID = packet.ReadUInt32() });
+            }
+            else
+            {
+                // Kronos — leading field is the dispelling spell id; entries are length-driven.
+                spell.DispelledBySpellID = countOrDispelledSpellId;
+                while (packet.Remaining() >= KronosEntrySize)
+                {
+                    SpellDispellData dispel = new SpellDispellData();
+                    dispel.SpellID = packet.ReadUInt32();
+                    packet.ReadUInt8(); // charges / flag — no slot in the modern struct
+                    spell.DispellData.Add(dispel);
+                }
+            }
         }
 
         SendPacketToClient(spell);


### PR DESCRIPTION
Closes #79

## TL;DR

Dispelling a debuff against a **Kronos** backend disconnected the client on every successful cast. Root cause: Kronos's vanilla `SMSG_SPELLDISPELLOG` uses a different wire layout than mangos/VMaNGOS/cMaNGOS, and our handler only knew the mangos layout — so it misread the packet, ran off the end of the buffer, threw `ArgumentOutOfRangeException`, and tore down the world socket. This PR teaches the handler both layouts and tells them apart with pure byte‑math (no realm or config heuristic).

---

## The journey

This issue had a long tail — three earlier fix attempts (`feature/fix/79`) were made and reverted because they were guessing at the wire format. This time we refused to guess and instead captured the actual bytes.

### 1. Reproduce, and rule out the obvious

The report said "macOS, VMaNGOS." Both turned out to be red herrings:

- **Not VMaNGOS.** Every crash capture in the issue connects to `login.twinstar-wow.com` — that's **Twinstar / Kronos V**, a closed‑source 1.12.1 core, not VMaNGOS. Running the *exact* reported scenario (paladin Purify on a poisoned target) against a stock VMaNGOS instance forwarded the dispel **cleanly, no crash**. So the bug is backend‑specific.
- **Not macOS.** The crash is an `ArgumentOutOfRangeException` in managed code — OS‑independent. We later reproduced it on **Windows** too. The "macOS‑only" framing simply reflected where the reporter happened to run the proxy. There was only ever **one** failure mechanism: a proxy‑side over‑read, not the client rejecting a packet.

### 2. Get the actual bytes

The attached `.pkt` captures were useless for this — `SniffFile` only logs the **modern client** direction, never the legacy server→proxy packets. So the raw Kronos `SMSG_SPELLDISPELLOG` bytes existed nowhere.

We added a temporary one‑line hex dump at the top of the handler (using `GetData()` / `GetSize()`, which don't move the read cursor, so the existing parse — and its crash — still ran identically), shipped that build, and captured the inbound bytes from a live Kronos dispel. The capture was reproduced **three times across two machines/OSes**, byte‑for‑byte identical.

### 3. Decode

Captured Kronos packet (a self‑cast Purify; `GetData()` includes the 2‑byte opcode header):

```
7B 02 | 03 5C F9 | 03 5C F9 | 80 04 00 00 | 8E 2E 00 00 | 00
opcode   Target     Caster     uint32         uint32        u8
=635     pGUID      pGUID       =1152          =11918        =0
         0xF95C     0xF95C      (Purify)       (poison aura) (charges)
```

The decisive observation: `1152` (Purify) sits **right after the two GUIDs**, where the mangos layout expects the **count**. The handler's vanilla branch never read a `DispelledBySpellID` (it uses the proxy‑tracked `LastDispellSpellId` instead), so its cursor was 4 bytes short — it read `1152` as the count, looped ~1152 times, and `ReadUInt32` walked off the end of the buffer → `ArgumentOutOfRangeException` → socket teardown → client DC.

### 4. Two layouts, confirmed

| Core | Vanilla `SMSG_SPELLDISPELLOG` payload (after the two pGUIDs) |
|---|---|
| mangos / VMaNGOS / cMaNGOS | `uint32 count`, then `uint32[count]` spell ids |
| **Kronos** | `uint32 DispelledBySpellID`, then `{ uint32 spellId, uint8 charges }` entries (no count) |

(The mangos layout is confirmed against VMaNGOS source: `SpellEffects.cpp` `EffectDispel` writes `target, caster, uint32 count, uint32[count]` — no dispel spell id, no per‑entry byte.)

---

## The fix

Rather than gate on the realm address (fragile, and we explicitly didn't want a server‑identity branch), the two layouts are distinguished by **self‑validating byte math**:

- For mangos, the leading `uint32` **is** the count, so the bytes remaining after the two GUIDs are exactly `(count + 1)` spell‑id slots → `bytesAfterGuids == SpellIdSize * (count + 1)`.
- Kronos's leading `uint32` is a real spell id (~1152), which could only satisfy that equation with multiple kilobytes of payload — impossible. So a mismatch unambiguously means Kronos.

```csharp
int bytesAfterGuids = packet.Remaining();
uint countOrDispelledSpellId = packet.ReadUInt32();
if (bytesAfterGuids == SpellIdSize * ((int)countOrDispelledSpellId + 1))
{
    // mangos / VMaNGOS — count-based, dispel spell id not carried on the wire.
    ...
}
else
{
    // Kronos — leading field is the dispelling spell id; entries are length-driven.
    ...
}
```

The Kronos branch is **length‑driven and bounded** (`while (packet.Remaining() >= KronosEntrySize)`), so it can never over‑read regardless of how many auras were dispelled — which also means we didn't need to farm a rare multi‑dispel capture to prove correctness.

The TBC+ (`V2_0_1_6180`) path is unchanged; only the vanilla branch was rewritten.

### Changes
- **`HermesProxy/World/Client/PacketHandlers/SpellHandler.cs`** — `HandleSpellDispellLog`: split TBC+ vs vanilla; vanilla now picks the mangos or Kronos layout by byte‑math.
- **`Framework/IO/ByteBuffer.cs`** — added `Remaining()` (read‑only accessor) to support the length‑driven parse.

Notes:
- Kronos's per‑entry `charges` byte has no slot in the modern `SpellDispellData`, so it's read‑and‑discarded (cosmetic only).
- The temporary diagnostic dump used to capture the bytes was removed before this PR.

---

## Verification

Tested end‑to‑end with the same build against all three backends (paladin Purify on a poison debuff), each producing a real dispel in the client combat log with **no crash**:

| Backend | Layout selected | Result |
|---|---|---|
| cMaNGOS | mangos (count‑based) | ✅ forwarded, no crash |
| VMaNGOS | mangos (count‑based) | ✅ forwarded, no crash |
| Kronos  | Kronos (dispelBy + entries) | ✅ forwarded ×4, no crash |

The exact 17‑byte Kronos packet that crashed the pre‑fix build now forwards cleanly. mangos backends are unaffected — the discriminator always classifies them count‑based.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
