### PR TITLE
fix(taxi): restore control on Kronos flight-end via taxi-flag clear (#73)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -55,10 +55,6 @@ public partial class WorldClient
         moveUpdate.MoveInfo.ReadMovementInfoLegacy(packet, GetSession().GameState);
         moveUpdate.MoveInfo.Flags = (uint)(((MovementFlagWotLK)moveUpdate.MoveInfo.Flags).CastFlags<MovementFlagModern>());
         moveUpdate.MoveInfo.ValidateMovementInfo();
-        // Issue #73 diagnostic: which MSG_MOVE_* broadcast(s) arrive for the player at flight end
-        // (Kronos varies between MSG_MOVE_TELEPORT / heartbeat / fall-land, etc.).
-        if (moveUpdate.MoverGUID == GetSession().GameState.CurrentPlayerGuid && GetSession().GameState.IsInTaxiFlight)
-            Log.Print(LogType.Server, $"[Taxi73Diag] player MSG_MOVE during taxi: {packet.GetUniversalOpcode(false)} moveFlags=0x{moveUpdate.MoveInfo.Flags:X8}");
         SendPacketToClient(moveUpdate);
     }
 
@@ -96,9 +92,6 @@ public partial class WorldClient
         ControlUpdate control = new ControlUpdate();
         control.Guid = packet.ReadPackedGuid().To128(GetSession().GameState);
         control.HasControl = packet.ReadBool();
-        // Issue #73 diagnostic: does Kronos ever send HasControl=true at a same-map flight landing?
-        if (control.Guid == GetSession().GameState.CurrentPlayerGuid)
-            Log.Print(LogType.Server, $"[Taxi73Diag] SMSG_CONTROL_UPDATE player hasControl={control.HasControl} inTaxiState={GetSession().GameState.IsInTaxiFlight}");
         SendPacketToClient(control);
     }
 
@@ -106,10 +99,6 @@ public partial class WorldClient
     void HandleMoveTeleportAck(WorldPacket packet)
     {
         WowGuid128 guid = packet.ReadPackedGuid().To128(GetSession().GameState);
-
-        // Issue #73 diagnostic: does Kronos send MSG_MOVE_TELEPORT_ACK for the player at flight end?
-        if (guid == GetSession().GameState.CurrentPlayerGuid)
-            Log.Print(LogType.Server, $"[Taxi73Diag] MSG_MOVE_TELEPORT_ACK player inTaxiState={GetSession().GameState.IsInTaxiFlight}");
 
         if (GetSession().GameState.IsInTaxiFlight &&
             GetSession().GameState.CurrentPlayerGuid == guid)
@@ -368,10 +357,6 @@ public partial class WorldClient
         MoveSetFlag flag = new MoveSetFlag(packet.GetUniversalOpcode(false));
         flag.MoverGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
         flag.MoveCounter = packet.ReadUInt32();
-        // Issue #73 diagnostic: does Kronos send SMSG_MOVE_UNROOT / ENABLE_GRAVITY / UNSET_CAN_FLY
-        // for the player at flight end? (these are the force-flag opcodes the jimsproxy timer synthesizes)
-        if (flag.MoverGUID == GetSession().GameState.CurrentPlayerGuid && GetSession().GameState.IsInTaxiFlight)
-            Log.Print(LogType.Server, $"[Taxi73Diag] player SMSG_MOVE force-flag during taxi: {packet.GetUniversalOpcode(false)}");
         SendPacketToClient(flag);
     }
 
@@ -610,11 +595,6 @@ public partial class WorldClient
                 GetSession().GameState.IsWaitingForTaxiStart = false;
             }
             GetSession().GameState.IsInTaxiFlight = true;
-            // Issue #73 diagnostic: mark flight start + server-reported duration so the landing can
-            // be located in the capture and the expected flag-clear / control-restore window bounded.
-            Log.Print(LogType.Server,
-                $"[Taxi73Diag] takeoff player=0x{guid.Low:X} splineTimeFull={moveSpline.SplineTimeFull}ms " +
-                $"splineFlags=0x{(uint)moveSpline.SplineFlags:X8}");
         }
     }
 }

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -55,6 +55,10 @@ public partial class WorldClient
         moveUpdate.MoveInfo.ReadMovementInfoLegacy(packet, GetSession().GameState);
         moveUpdate.MoveInfo.Flags = (uint)(((MovementFlagWotLK)moveUpdate.MoveInfo.Flags).CastFlags<MovementFlagModern>());
         moveUpdate.MoveInfo.ValidateMovementInfo();
+        // Issue #73 diagnostic: which MSG_MOVE_* broadcast(s) arrive for the player at flight end
+        // (Kronos varies between MSG_MOVE_TELEPORT / heartbeat / fall-land, etc.).
+        if (moveUpdate.MoverGUID == GetSession().GameState.CurrentPlayerGuid && GetSession().GameState.IsInTaxiFlight)
+            Log.Print(LogType.Server, $"[Taxi73Diag] player MSG_MOVE during taxi: {packet.GetUniversalOpcode(false)} moveFlags=0x{moveUpdate.MoveInfo.Flags:X8}");
         SendPacketToClient(moveUpdate);
     }
 
@@ -92,6 +96,9 @@ public partial class WorldClient
         ControlUpdate control = new ControlUpdate();
         control.Guid = packet.ReadPackedGuid().To128(GetSession().GameState);
         control.HasControl = packet.ReadBool();
+        // Issue #73 diagnostic: does Kronos ever send HasControl=true at a same-map flight landing?
+        if (control.Guid == GetSession().GameState.CurrentPlayerGuid)
+            Log.Print(LogType.Server, $"[Taxi73Diag] SMSG_CONTROL_UPDATE player hasControl={control.HasControl} inTaxiState={GetSession().GameState.IsInTaxiFlight}");
         SendPacketToClient(control);
     }
 
@@ -99,6 +106,10 @@ public partial class WorldClient
     void HandleMoveTeleportAck(WorldPacket packet)
     {
         WowGuid128 guid = packet.ReadPackedGuid().To128(GetSession().GameState);
+
+        // Issue #73 diagnostic: does Kronos send MSG_MOVE_TELEPORT_ACK for the player at flight end?
+        if (guid == GetSession().GameState.CurrentPlayerGuid)
+            Log.Print(LogType.Server, $"[Taxi73Diag] MSG_MOVE_TELEPORT_ACK player inTaxiState={GetSession().GameState.IsInTaxiFlight}");
 
         if (GetSession().GameState.IsInTaxiFlight &&
             GetSession().GameState.CurrentPlayerGuid == guid)
@@ -357,6 +368,10 @@ public partial class WorldClient
         MoveSetFlag flag = new MoveSetFlag(packet.GetUniversalOpcode(false));
         flag.MoverGUID = packet.ReadPackedGuid().To128(GetSession().GameState);
         flag.MoveCounter = packet.ReadUInt32();
+        // Issue #73 diagnostic: does Kronos send SMSG_MOVE_UNROOT / ENABLE_GRAVITY / UNSET_CAN_FLY
+        // for the player at flight end? (these are the force-flag opcodes the jimsproxy timer synthesizes)
+        if (flag.MoverGUID == GetSession().GameState.CurrentPlayerGuid && GetSession().GameState.IsInTaxiFlight)
+            Log.Print(LogType.Server, $"[Taxi73Diag] player SMSG_MOVE force-flag during taxi: {packet.GetUniversalOpcode(false)}");
         SendPacketToClient(flag);
     }
 
@@ -595,6 +610,11 @@ public partial class WorldClient
                 GetSession().GameState.IsWaitingForTaxiStart = false;
             }
             GetSession().GameState.IsInTaxiFlight = true;
+            // Issue #73 diagnostic: mark flight start + server-reported duration so the landing can
+            // be located in the capture and the expected flag-clear / control-restore window bounded.
+            Log.Print(LogType.Server,
+                $"[Taxi73Diag] takeoff player=0x{guid.Low:X} splineTimeFull={moveSpline.SplineTimeFull}ms " +
+                $"splineFlags=0x{(uint)moveSpline.SplineFlags:X8}");
         }
     }
 }

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1856,6 +1856,19 @@ public partial class WorldClient
                 if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V3_0_2_9056) &&
                     updateData.UnitData.PvpFlags == null)
                     updateData.UnitData.PvpFlags = ReadPvPFlags(updates);
+
+                // Issue #73 DIAGNOSTIC (not a fix): log every player UNIT_FIELD_FLAGS update so a
+                // Kronos same-map flight-landing capture reveals whether/when UNIT_FLAG_TAXI_FLIGHT
+                // (0x00100000) actually clears on that custom fork, alongside the control/movement
+                // opcodes logged elsewhere ([Taxi73Diag]). Remove once the real flight-end signal
+                // on Kronos is identified.
+                if (guid == GetSession().GameState.CurrentPlayerGuid)
+                {
+                    bool taxiBit = updateData.UnitData.Flags.HasAnyFlag(UnitFlags.TaxiFlight);
+                    Log.Print(LogType.Server,
+                        $"[Taxi73Diag] player UNIT_FIELD_FLAGS=0x{updateData.UnitData.Flags:X8} " +
+                        $"taxiBit={taxiBit} inTaxiState={GetSession().GameState.IsInTaxiFlight} isCreate={isCreate}");
+                }
             }
             int UNIT_FIELD_FLAGS_2 = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_FLAGS_2);
             if (UNIT_FIELD_FLAGS_2 >= 0 && updateMaskArray[UNIT_FIELD_FLAGS_2])

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -1857,17 +1857,25 @@ public partial class WorldClient
                     updateData.UnitData.PvpFlags == null)
                     updateData.UnitData.PvpFlags = ReadPvPFlags(updates);
 
-                // Issue #73 DIAGNOSTIC (not a fix): log every player UNIT_FIELD_FLAGS update so a
-                // Kronos same-map flight-landing capture reveals whether/when UNIT_FLAG_TAXI_FLIGHT
-                // (0x00100000) actually clears on that custom fork, alongside the control/movement
-                // opcodes logged elsewhere ([Taxi73Diag]). Remove once the real flight-end signal
-                // on Kronos is identified.
-                if (guid == GetSession().GameState.CurrentPlayerGuid)
+                // Issue #73: Kronos signals flight-end ONLY by clearing UNIT_FLAG_TAXI_FLIGHT
+                // (0x00100000) in this UPDATE_OBJECT Values delta — it never sends
+                // MSG_MOVE_TELEPORT_ACK / MSG_MOVE_TELEPORT / MSG_MOVE_UNROOT at landing. Without
+                // reacting to the bit clearing, IsInTaxiFlight stays set and no SMSG_CONTROL_UPDATE
+                // is sent, so the client is held in server-controlled flight state until relog.
+                // Mirror HandleMoveTeleportAck here. Version-gated to pre-WotLK (vanilla/TBC) legacy
+                // backends — WotLK (V3_0_2+) ends flight via the proper MSG_MOVE_TELEPORT_ACK path,
+                // so V3_4_3 must not run this hook. Also self-gating: cMaNGOS/TC clear IsInTaxiFlight
+                // via MSG_MOVE_TELEPORT_ACK before this update arrives, so the guard is already false.
+                if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V3_0_2_9056) &&
+                    guid == GetSession().GameState.CurrentPlayerGuid &&
+                    GetSession().GameState.IsInTaxiFlight &&
+                    !updateData.UnitData.Flags.HasAnyFlag(UnitFlags.TaxiFlight))
                 {
-                    bool taxiBit = updateData.UnitData.Flags.HasAnyFlag(UnitFlags.TaxiFlight);
-                    Log.Print(LogType.Server,
-                        $"[Taxi73Diag] player UNIT_FIELD_FLAGS=0x{updateData.UnitData.Flags:X8} " +
-                        $"taxiBit={taxiBit} inTaxiState={GetSession().GameState.IsInTaxiFlight} isCreate={isCreate}");
+                    ControlUpdate control = new ControlUpdate();
+                    control.Guid = guid;
+                    control.HasControl = true;
+                    SendPacketToClient(control);
+                    GetSession().GameState.IsInTaxiFlight = false;
                 }
             }
             int UNIT_FIELD_FLAGS_2 = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_FLAGS_2);


### PR DESCRIPTION
## Summary

Fixes #73 — on **Kronos** (vanilla backend, 1.14 macOS client), leaving a flight path left the character frozen until a relog.

## Root cause

Kronos signals flight-end **only** by clearing `UNIT_FLAG_TAXI_FLIGHT (0x00100000)` in an `SMSG_UPDATE_OBJECT` Values delta — it never sends `MSG_MOVE_TELEPORT_ACK` / `MSG_MOVE_TELEPORT` / `MSG_MOVE_UNROOT` at landing. The two earlier attempts (`feature/fix/73`, `feature/fix/73-2`) hooked opcodes Kronos never emits, so they did nothing. With no reaction to the flag clearing, `IsInTaxiFlight` stayed set and no `SMSG_CONTROL_UPDATE` was sent — client held in server-controlled flight state until relog.

A diagnostic build captured the flight-end window and pinned it: `UNIT_FIELD_FLAGS=0x00001008 taxiBit=False inTaxiState=True` at landing, then zero client movement input until relog.

## Fix

Hook the taxi-flag-clear transition in the `UNIT_FIELD_FLAGS` Values block of `UpdateHandler.cs`: when the player's flag drops `UNIT_FLAG_TAXI_FLIGHT` while `IsInTaxiFlight` is set, mirror `HandleMoveTeleportAck` — send `SMSG_CONTROL_UPDATE(HasControl=true)` and clear `IsInTaxiFlight`.

- **Version-gated** to pre-WotLK (`RemovedInVersion(V3_0_2_9056)`); WotLK V3_4_3 ends flight via the proper TELEPORT_ACK path and must not run this hook.
- **Self-gating** on other backends: cMaNGOS/TC/vmangos clear `IsInTaxiFlight` via `MSG_MOVE_TELEPORT_ACK` before this update arrives, so the guard is already false there.

Also removes the temporary `[Taxi73Diag]` logging now that its job is done.

## Verification

Reporter @b4bass confirmed on the pre-release build: *"I can confirm character now moves fine after FP"* — control restored without relog. `dotnet build` clean.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)