### PR TITLE
fix(v3_4_3): fix enter-world crashes and contain packet-handler failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -524,3 +524,6 @@ test-loop2.ps1
 
 # Local deploy scripts
 deploy_local/
+### Local dev environment (not committed)
+.dotnet/
+.env

--- a/HermesProxy.Tests/World/Server/CurrentPlayerStorageTests.cs
+++ b/HermesProxy.Tests/World/Server/CurrentPlayerStorageTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using HermesProxy;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Server;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+/// <summary>
+/// Regression coverage for the enter-world crash: the modern client opens the instance
+/// socket on its own thread and touches CurrentPlayerStorage while HandlePlayerLogin is
+/// still loading it, so a half-built PlayerSettings must never become visible.
+/// </summary>
+public class CurrentPlayerStorageTests : IDisposable
+{
+    private readonly string _accountName = "HermesTests_" + Guid.NewGuid().ToString("N");
+    private readonly string _realmName = "TestRealm";
+    private readonly string _charName = "Testchar";
+
+    private string CharDirectory =>
+        Path.GetFullPath(Path.Combine("AccountData", _accountName, _realmName, _charName));
+
+    private string SettingsPath => Path.Combine(CharDirectory, "settings.json");
+
+    private GlobalSessionData CreateSession()
+    {
+        var session = (GlobalSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GlobalSessionData));
+        var gameState = (GameSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GameSessionData));
+
+        var realm = new Realm();
+        realm.SetName(_realmName);
+
+        gameState.CurrentPlayerInfo = new OwnCharacterInfo { Name = _charName, Realm = realm };
+        session.GameState = gameState;
+        session.AccountMetaDataMgr = new AccountMetaDataManager(_accountName);
+        return session;
+    }
+
+    public void Dispose()
+    {
+        var accountDir = Path.GetFullPath(Path.Combine("AccountData", _accountName));
+        if (Directory.Exists(accountDir))
+            Directory.Delete(accountDir, recursive: true);
+    }
+
+    [Fact]
+    public void PlayerSettings_BeforeReload_DoesNotThrow()
+    {
+        var settings = new PlayerSettings(CreateSession());
+
+        // _internalStorage must carry a usable default; before the fix it was null! and
+        // every one of these reads was a NullReferenceException.
+        Assert.Null(settings.MultiActionBarsMask);
+
+        PlayerFlags flags = PlayerFlags.None;
+        settings.PatchFlags(ref flags);
+        Assert.Equal(PlayerFlags.None, flags & PlayerFlags.AutoDeclineGuild);
+    }
+
+    [Fact]
+    public void CurrentPlayerStorage_BeforeLoad_ExposesNoHalfBuiltState()
+    {
+        var storage = new CurrentPlayerStorage(CreateSession());
+
+        // Callers use `Settings?.` precisely because this is null until a player is loaded.
+        Assert.Null(storage.Settings);
+        Assert.Null(storage.CompletedQuests);
+    }
+
+    [Fact]
+    public void LoadCurrentPlayer_PublishesFullyLoadedInstances()
+    {
+        var storage = new CurrentPlayerStorage(CreateSession());
+        storage.LoadCurrentPlayer();
+
+        Assert.NotNull(storage.Settings);
+        Assert.NotNull(storage.CompletedQuests);
+        Assert.Null(storage.Settings.MultiActionBarsMask);
+        Assert.True(File.Exists(SettingsPath));
+    }
+
+    [Fact]
+    public void LoadCurrentPlayer_RoundTripsPersistedSettings()
+    {
+        var session = CreateSession();
+        var storage = new CurrentPlayerStorage(session);
+        storage.LoadCurrentPlayer();
+        storage.Settings.SetMultiActionBarsMask(0x0B);
+
+        var reloaded = new CurrentPlayerStorage(session);
+        reloaded.LoadCurrentPlayer();
+
+        Assert.Equal((byte)0x0B, reloaded.Settings.MultiActionBarsMask);
+    }
+
+    [Fact]
+    public void LoadCurrentPlayer_WhenLoadFails_LeavesPreviousStateIntact()
+    {
+        var storage = new CurrentPlayerStorage(CreateSession());
+        storage.LoadCurrentPlayer();
+        storage.Settings.SetMultiActionBarsMask(0x05);
+
+        PlayerSettings loaded = storage.Settings;
+        CompletedQuestTracker loadedQuests = storage.CompletedQuests;
+
+        // Corrupt the backing file so the next Reload throws partway through.
+        File.WriteAllText(SettingsPath, "{ this is not json", Encoding.UTF8);
+
+        Assert.ThrowsAny<JsonException>(() => storage.LoadCurrentPlayer());
+
+        // The failed load must not have published anything. Before the fix, the new
+        // half-built PlayerSettings was already visible with a null _internalStorage.
+        Assert.Same(loaded, storage.Settings);
+        Assert.Same(loadedQuests, storage.CompletedQuests);
+        Assert.Equal((byte)0x05, storage.Settings.MultiActionBarsMask);
+    }
+}

--- a/HermesProxy.Tests/World/UnmappedOpcodeTests.cs
+++ b/HermesProxy.Tests/World/UnmappedOpcodeTests.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+/// <summary>
+/// Many per-build opcode enums leave entries at 0 (no mapping for that client build).
+/// Building a packet for one of those used to hit a Trace.Assert, which aborts the process
+/// from a socket completion callback and bypasses every handler-level guard. It must throw
+/// a catchable exception instead so the packet is dropped and logged.
+/// </summary>
+public class UnmappedOpcodeTests
+{
+    private sealed class TestServerPacket : ServerPacket
+    {
+        public TestServerPacket(Opcode universalOpcode) : base(universalOpcode) { }
+        public override void Write() { }
+    }
+
+    private static Opcode FindUnmappedModernOpcode()
+    {
+        return System.Enum.GetValues<Opcode>()
+            .First(op => op != Opcode.MSG_NULL_ACTION && ModernVersion.GetCurrentOpcode(op) == 0);
+    }
+
+    [Fact]
+    public void ServerPacket_WithUnmappedOpcode_ThrowsInsteadOfAborting()
+    {
+        Opcode unmapped = FindUnmappedModernOpcode();
+
+        var ex = Assert.Throws<UnmappedOpcodeException>(() => new TestServerPacket(unmapped));
+
+        Assert.Equal(unmapped, ex.UniversalOpcode);
+        Assert.True(ex.IsModern);
+    }
+
+    [Fact]
+    public void ServerPacket_WithMappedOpcode_Succeeds()
+    {
+        var packet = new TestServerPacket(Opcode.SMSG_AUTH_RESPONSE);
+
+        Assert.NotEqual(0u, packet.GetOpcode());
+    }
+}

--- a/HermesProxy/BnetServer/Managers/BnetSessionTicketStorage.cs
+++ b/HermesProxy/BnetServer/Managers/BnetSessionTicketStorage.cs
@@ -2,46 +2,37 @@
 // Licensed under the GNU GENERAL PUBLIC LICENSE. See LICENSE file in the project root for full license information.
 
 using HermesProxy;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace BNetServer;
 
 public static class BnetSessionTicketStorage
 {
-    public static Dictionary<string, GlobalSessionData> SessionsByName = new();
-    public static Dictionary<string, GlobalSessionData> SessionsByTicket = new();
-    public static Dictionary<ulong, GlobalSessionData> SessionsByKey = new();
+    public static readonly ConcurrentDictionary<string, GlobalSessionData> SessionsByName = new();
+    public static readonly ConcurrentDictionary<string, GlobalSessionData> SessionsByTicket = new();
+    public static readonly ConcurrentDictionary<ulong, GlobalSessionData> SessionsByKey = new();
 
     public static void AddNewSessionByName(string name, GlobalSessionData session)
     {
-        if (SessionsByName.ContainsKey(name))
-        {
-            SessionsByName[name].OnDisconnect();
-            SessionsByName[name] = session;
-        }
-        else
-            SessionsByName.Add(name, session);
+        if (SessionsByName.TryGetValue(name, out var existing))
+            existing.OnDisconnect();
+
+        SessionsByName[name] = session;
     }
 
     public static void AddNewSessionByTicket(string loginTicket, GlobalSessionData session)
     {
-        if (SessionsByTicket.ContainsKey(loginTicket))
-        {
-            SessionsByTicket[loginTicket].OnDisconnect();
-            SessionsByTicket[loginTicket] = session;
-        }
-        else
-            SessionsByTicket.Add(loginTicket, session);
+        if (SessionsByTicket.TryGetValue(loginTicket, out var existing))
+            existing.OnDisconnect();
+
+        SessionsByTicket[loginTicket] = session;
     }
 
     public static void AddNewSessionByKey(ulong connectKey, GlobalSessionData session)
     {
-        if (SessionsByKey.ContainsKey(connectKey))
-        {
-            SessionsByKey[connectKey].OnDisconnect();
-            SessionsByKey[connectKey] = session;
-        }
-        else
-            SessionsByKey.Add(connectKey, session);
+        if (SessionsByKey.TryGetValue(connectKey, out var existing))
+            existing.OnDisconnect();
+
+        SessionsByKey[connectKey] = session;
     }
 }

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2737,7 +2737,7 @@ public partial class WorldClient
                     updateData.UnitData.PvpFlags == null)
                     updateData.UnitData.PvpFlags = ReadPvPFlags(updates);
             }
-            else if (updateData.Guid == GetSession().GameState.CurrentPlayerGuid && GetSession().GameState.CurrentPlayerStorage.Settings.NeedToForcePatchFlags)
+            else if (updateData.Guid == GetSession().GameState.CurrentPlayerGuid && (GetSession().GameState.CurrentPlayerStorage.Settings?.NeedToForcePatchFlags ?? false))
             { // If we did not patch the PlayerFlags the first time, we need to force include the field
                 PlayerFlags flags = GetSession().GameState.CurrentPlayerStorage.Settings.CreateNewFlags();
                 updateData.PlayerData.PlayerFlags = (uint) flags;

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -609,12 +609,16 @@ public partial class WorldClient
                         // Dump the whole packet, not a prefix. A parser that over-reads is
                         // usually wrong about a field well past the first few bytes, and this
                         // only fires on an exception so the volume is irrelevant.
+                        // GetSize is the real payload length; GetData can hand back a larger
+                        // ArrayPool rental, and reporting that length makes an over-read look
+                        // like it had spare bytes to read.
                         byte[] raw = packet.GetData();
-                        int hexLen = System.Math.Min(1024, raw.Length);
+                        int size = (int)packet.GetSize();
+                        int hexLen = System.Math.Min(1024, System.Math.Min(size, raw.Length));
                         string body = hexLen > 0 ? System.BitConverter.ToString(raw, 0, hexLen) : "<empty>";
                         Log.Print(LogType.Error,
                             $"C P<S | Unhandled exception in handler for {universalOpcode} ({packet.GetOpcode()}) " +
-                            $"[size={raw.Length} dumped={hexLen}]{System.Environment.NewLine}bytes={body}{System.Environment.NewLine}{handlerException}");
+                            $"[size={size} dumped={hexLen}]{System.Environment.NewLine}bytes={body}{System.Environment.NewLine}{handlerException}");
                     }
                 }
                 else

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -606,12 +606,15 @@ public partial class WorldClient
                     }
                     catch (Exception handlerException)
                     {
+                        // Dump the whole packet, not a prefix. A parser that over-reads is
+                        // usually wrong about a field well past the first few bytes, and this
+                        // only fires on an exception so the volume is irrelevant.
                         byte[] raw = packet.GetData();
-                        int hexLen = System.Math.Min(64, raw.Length);
-                        string head = hexLen > 0 ? System.BitConverter.ToString(raw, 0, hexLen) : "<empty>";
+                        int hexLen = System.Math.Min(1024, raw.Length);
+                        string body = hexLen > 0 ? System.BitConverter.ToString(raw, 0, hexLen) : "<empty>";
                         Log.Print(LogType.Error,
                             $"C P<S | Unhandled exception in handler for {universalOpcode} ({packet.GetOpcode()}) " +
-                            $"[size={raw.Length}]{System.Environment.NewLine}head={head}{System.Environment.NewLine}{handlerException}");
+                            $"[size={raw.Length} dumped={hexLen}]{System.Environment.NewLine}bytes={body}{System.Environment.NewLine}{handlerException}");
                     }
                 }
                 else

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -599,6 +599,11 @@ public partial class WorldClient
                     {
                         handler(packet);
                     }
+                    catch (UnmappedOpcodeException unmapped)
+                    {
+                        Log.Print(LogType.Warn,
+                            $"C P<S | Handling {universalOpcode} ({packet.GetOpcode()}): {unmapped.Message}");
+                    }
                     catch (Exception handlerException)
                     {
                         byte[] raw = packet.GetData();

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -436,11 +436,23 @@ public partial class WorldClient
                 }
             }
 
-            // block these packets until connected to instance
+            // Block these packets until connected to instance. Bounded: an unbounded spin
+            // here deadlocks the legacy read loop for the rest of the session if the client
+            // never completes the instance handshake (or if OnDisconnect clears the socket).
+            const int instanceWaitTimeoutMs = 30000;
+            int waitedMs = 0;
             while (GetSession().InstanceSocket == null)
             {
+                if (waitedMs >= instanceWaitTimeoutMs)
+                {
+                    Log.PrintNet(LogType.Error, LogNetDir.P2C,
+                        $"Gave up waiting {instanceWaitTimeoutMs}ms for the instance connection; dropping {packet.GetUniversalOpcode()} ({packet.GetOpcode()}).");
+                    return;
+                }
+
                 Log.PrintNet(LogType.Network, LogNetDir.P2C, $"Waiting to send {packet.GetUniversalOpcode()} ({packet.GetOpcode()}).");
                 System.Threading.Thread.Sleep(200);
+                waitedMs += 200;
             }
 
             var socket = GetSession().InstanceSocket;
@@ -512,7 +524,11 @@ public partial class WorldClient
     // 1.12 sending SMSG_WARDEN_DATA mid-auth (issue #62).
     private static bool IsIgnorableDuringHandshake(Opcode op)
     {
-        return op == Opcode.SMSG_WARDEN_DATA;
+        // SMSG_CACHE_VERSION is pushed unprompted right after connect by TC-derived cores
+        // (AzerothCore included); if it lands before SMSG_AUTH_RESPONSE it would otherwise
+        // flip _isSuccessful to false and abort an otherwise healthy handshake.
+        return op == Opcode.SMSG_WARDEN_DATA
+            || op == Opcode.SMSG_CACHE_VERSION;
     }
 
     private void HandlePacket(WorldPacket packet)
@@ -575,7 +591,23 @@ public partial class WorldClient
             default:
                 if (_packetHandlers.TryGetValue(universalOpcode, out var handler))
                 {
-                    handler(packet);
+                    // A throwing legacy handler used to escape into the read loop's catch,
+                    // which tears down the world connection (and previously the process).
+                    // The packet is already fully read off the socket, so dropping it here
+                    // cannot desync the stream, so keep the session alive instead.
+                    try
+                    {
+                        handler(packet);
+                    }
+                    catch (Exception handlerException)
+                    {
+                        byte[] raw = packet.GetData();
+                        int hexLen = System.Math.Min(64, raw.Length);
+                        string head = hexLen > 0 ? System.BitConverter.ToString(raw, 0, hexLen) : "<empty>";
+                        Log.Print(LogType.Error,
+                            $"C P<S | Unhandled exception in handler for {universalOpcode} ({packet.GetOpcode()}) " +
+                            $"[size={raw.Length}]{System.Environment.NewLine}head={head}{System.Environment.NewLine}{handlerException}");
+                    }
                 }
                 else
                 {

--- a/HermesProxy/World/Packet.cs
+++ b/HermesProxy/World/Packet.cs
@@ -90,7 +90,8 @@ public abstract class ServerPacket
         connectionType = ConnectionType.Realm;
 
         uint opcode = ModernVersion.GetCurrentOpcode(universalOpcode);
-        System.Diagnostics.Trace.Assert(opcode != 0);
+        if (opcode == 0)
+            throw new UnmappedOpcodeException(universalOpcode, isModern: true);
         _worldPacket = new WorldPacket(opcode);
     }
 
@@ -99,7 +100,8 @@ public abstract class ServerPacket
         connectionType = type;
 
         uint opcode = ModernVersion.GetCurrentOpcode(universalOpcode);
-        System.Diagnostics.Trace.Assert(opcode != 0);
+        if (opcode == 0)
+            throw new UnmappedOpcodeException(universalOpcode, isModern: true);
         _worldPacket = new WorldPacket(opcode);
     }
 
@@ -199,7 +201,8 @@ public class WorldPacket : ByteBuffer
     public WorldPacket(Opcode opcode)
     {
         this.opcode = LegacyVersion.GetCurrentOpcode(opcode);
-        System.Diagnostics.Trace.Assert(this.opcode != 0);
+        if (this.opcode == 0)
+            throw new UnmappedOpcodeException(opcode, isModern: false);
     }
 
     public WorldPacket(uint opcode, byte[] data) : base(data)

--- a/HermesProxy/World/Server/AccountDataManager.cs
+++ b/HermesProxy/World/Server/AccountDataManager.cs
@@ -217,31 +217,58 @@ public class AccountDataManager
         AccountData? data = null;
         string fileName = GetFullFileName(guid, type);
 
-        if (File.Exists(fileName))
+        if (!File.Exists(fileName))
+            return null;
+
+        // A stale, truncated or mismatched cache file must not be fatal. These were
+        // Trace.Asserts, which are compiled into Release and abort the process outright
+        // rather than throwing, so a single bad file on disk killed the proxy during
+        // login with nothing catchable. Discard the file instead: the client re-sends
+        // that slot and SaveData overwrites it.
+        try
         {
-            using (FileStream file = File.OpenRead(GetFullFileName(guid, type)))
+            using BinaryReader reader = new BinaryReader(File.OpenRead(fileName));
+
+            data = new();
+            ulong guidLow = reader.ReadUInt64();
+            ulong guidHigh = reader.ReadUInt64();
+            data.Guid = new WowGuid128(guidLow, guidHigh);
+
+            if (!IsGlobalDataType(type) && guid != data.Guid)
             {
-                using (BinaryReader reader = new BinaryReader(File.OpenRead(GetFullFileName(guid, type))))
-                {
-                    data = new();
-                    ulong guidLow = reader.ReadUInt64();
-                    ulong guidHigh = reader.ReadUInt64();
-                    data.Guid = new WowGuid128(guidLow, guidHigh);
-
-                    if (!IsGlobalDataType(type))
-                        System.Diagnostics.Trace.Assert(guid == data.Guid);
-
-                    data.Timestamp = reader.ReadInt64();
-                    data.Type = reader.ReadUInt32();
-                    System.Diagnostics.Trace.Assert(type == data.Type);
-                    data.UncompressedSize = reader.ReadUInt32();
-
-                    int compressedSize = reader.ReadInt32();
-                    data.CompressedData = reader.ReadBytes(compressedSize);
-                }
+                Log.Print(LogType.Warn,
+                    $"Account data '{fileName}' belongs to {data.Guid} but was loaded for {guid}, ignoring it.");
+                return null;
             }
+
+            data.Timestamp = reader.ReadInt64();
+            data.Type = reader.ReadUInt32();
+
+            if (type != data.Type)
+            {
+                Log.Print(LogType.Warn,
+                    $"Account data '{fileName}' holds type {data.Type} but type {type} was expected, ignoring it.");
+                return null;
+            }
+
+            data.UncompressedSize = reader.ReadUInt32();
+
+            int compressedSize = reader.ReadInt32();
+            if (compressedSize < 0 || compressedSize > reader.BaseStream.Length - reader.BaseStream.Position)
+            {
+                Log.Print(LogType.Warn,
+                    $"Account data '{fileName}' declares {compressedSize} compressed bytes but the file is shorter, ignoring it.");
+                return null;
+            }
+
+            data.CompressedData = reader.ReadBytes(compressedSize);
         }
-        
+        catch (Exception e)
+        {
+            Log.Print(LogType.Warn, $"Could not read account data '{fileName}', ignoring it: {e.Message}");
+            return null;
+        }
+
         return data;
     }
 

--- a/HermesProxy/World/Server/CurrentPlayerStorage.cs
+++ b/HermesProxy/World/Server/CurrentPlayerStorage.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Server.Packets;
 
@@ -15,18 +15,25 @@ public class CurrentPlayerStorage
         _globalSession = globalSession;
     }
 
+    // Build fully-loaded instances into locals and only then publish them. The modern
+    // client opens the instance socket on its own network thread while this runs, and
+    // its first packets (CMSG_SET_ACTION_BAR_TOGGLES, guild settings) touch these
+    // objects, and publishing a half-Reloaded instance is a live NullReferenceException.
     public void LoadCurrentPlayer()
     {
-        CompletedQuests = new CompletedQuestTracker(_globalSession);
-        Settings = new PlayerSettings(_globalSession);
-        CompletedQuests.Reload();
-        Settings.Reload();
+        var quests = new CompletedQuestTracker(_globalSession);
+        var settings = new PlayerSettings(_globalSession);
+        quests.Reload();
+        settings.Reload();
+
+        CompletedQuests = quests;
+        Settings = settings;
     }
 }
 
 public class PlayerSettings
 {
-    private InternalStorage _internalStorage = null!;
+    private InternalStorage _internalStorage = new();
     private PlayerFlags _lastCapturedFlags;
 
     public bool NeedToForcePatchFlags { get; private set; }

--- a/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/CharacterHandler.cs
@@ -137,6 +137,7 @@ public partial class WorldSocket
         if (!GetSession().GameState.CachedPlayers.TryGetValue(playerLogin.Guid, out var selectedChar))
         {
             Log.Print(LogType.Error, $"Player tried to log in with unknown char id: {playerLogin.Guid}");
+            AbortLogin(LoginFailureReason.NoCharacter);
             return;
         }
 
@@ -144,6 +145,7 @@ public partial class WorldSocket
         if (realm == null)
         {
             Log.Print(LogType.Error, $"Player tried to log in to unknown realm id: {GetSession().RealmId}");
+            AbortLogin(LoginFailureReason.NoWorld);
             return;
         }
 
@@ -152,11 +154,22 @@ public partial class WorldSocket
         if (GetSession().AuthClient != null)
             GetSession().AuthClient.Disconnect();
 
-        SendConnectToInstance(ConnectToSerial.WorldAttempt1);
-        GetSession().GameState.IsConnectedToInstance = true;
+        var ownCharacter = GetSession().GameState.OwnCharacters.FirstOrDefault(x => x.CharacterGuid == playerLogin.Guid);
+        if (ownCharacter == null)
+        {
+            Log.Print(LogType.Error, $"Player tried to log in with a char missing from the enumerated list: {playerLogin.Guid}");
+            AbortLogin(LoginFailureReason.NoCharacter);
+            return;
+        }
+
+        // All GameState must be published BEFORE the client is told to open the instance
+        // connection. The instance socket runs on its own network thread and the client
+        // starts pushing packets (CMSG_SET_ACTION_BAR_TOGGLES first) the moment it is up,
+        // so anything set after SendConnectToInstance is a live race. That race crashed
+        // the proxy with a NullReferenceException on every enter-world attempt.
         GetSession().GameState.IsFirstEnterWorld = true;
         GetSession().GameState.CurrentPlayerGuid = playerLogin.Guid;
-        GetSession().GameState.CurrentPlayerInfo = GetSession().GameState.OwnCharacters.Single(x => x.CharacterGuid == playerLogin.Guid);
+        GetSession().GameState.CurrentPlayerInfo = ownCharacter;
         GetSession().GameState.CurrentPlayerStorage.LoadCurrentPlayer();
 
         // V3_4_3-only: DKs need rune state in ActivePlayerData CREATE. Without it
@@ -168,6 +181,12 @@ public partial class WorldSocket
         {
             GetSession().GameState.RuneState = new RuneStateData();
         }
+
+        Log.Print(LogType.Server,
+            $"[Login] entering world as '{ownCharacter.Name}' ({ownCharacter.RaceId} {ownCharacter.ClassId} lvl {ownCharacter.Level}) " +
+            $"guid={playerLogin.Guid} realm='{realm.Name}': state published, opening instance connection");
+        SendConnectToInstance(ConnectToSerial.WorldAttempt1);
+        GetSession().GameState.IsConnectedToInstance = true;
 
         WorldPacket packet = new WorldPacket(Opcode.CMSG_PLAYER_LOGIN);
         packet.WriteGuid(playerLogin.Guid.To64());
@@ -319,7 +338,13 @@ public partial class WorldSocket
         // wiping the legacy DB). Only persist non-zero masks so the next login can
         // re-inject CVars matching the user's last real toggle.
         if (bars.Mask != 0)
-            GetSession().GameState.CurrentPlayerStorage.Settings.SetMultiActionBarsMask(bars.Mask);
+        {
+            var settings = GetSession().GameState.CurrentPlayerStorage.Settings;
+            if (settings != null)
+                settings.SetMultiActionBarsMask(bars.Mask);
+            else
+                Log.Print(LogType.Warn, "[Login] CMSG_SET_ACTION_BAR_TOGGLES arrived before the player was loaded, mask not persisted.");
+        }
 
         WorldPacket packet = new WorldPacket(Opcode.CMSG_SET_ACTION_BAR_TOGGLES);
         packet.WriteUInt8(bars.Mask);

--- a/HermesProxy/World/Server/PacketHandlers/GuildHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/GuildHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Framework.Constants;
+using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World;
 using HermesProxy.World.Enums;
@@ -202,11 +203,18 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_DECLINE_GUILD_INVITES)]
     void HandleDeclineGuildInvites(SetAutoDeclineGuildInvites packet)
     {
-        GetSession().GameState.CurrentPlayerStorage.Settings.SetAutoBlockGuildInvites(packet.GuildInvitesShouldGetBlocked);
+        var settings = GetSession().GameState.CurrentPlayerStorage.Settings;
+        if (settings == null)
+        {
+            Log.Print(LogType.Error, "CMSG_DECLINE_GUILD_INVITES received before the player was loaded, ignoring.");
+            return;
+        }
+
+        settings.SetAutoBlockGuildInvites(packet.GuildInvitesShouldGetBlocked);
 
         // Send update to client
         ObjectUpdate updateData = new ObjectUpdate(GetSession().GameState.CurrentPlayerGuid, UpdateTypeModern.Values, GetSession());
-        PlayerFlags flags = GetSession().GameState.CurrentPlayerStorage.Settings.CreateNewFlags();
+        PlayerFlags flags = settings.CreateNewFlags();
         updateData.PlayerData.PlayerFlags = (uint) flags;
         UpdateObject updatePacket = new UpdateObject(GetSession().GameState);
         updatePacket.ObjectUpdates.Add(updateData);

--- a/HermesProxy/World/Server/Packets/MiscPackets.cs
+++ b/HermesProxy/World/Server/Packets/MiscPackets.cs
@@ -22,6 +22,7 @@ using Framework.Constants;
 using Framework.GameMath;
 using Framework.IO;
 using HermesProxy.World.Enums;
+using Framework.Logging;
 using HermesProxy.World.Objects;
 
 namespace HermesProxy.World.Server.Packets;
@@ -32,7 +33,15 @@ public class EmptyClientPacket : ClientPacket
 
     public override void Read()
     {
-        System.Diagnostics.Trace.Assert(!_worldPacket.CanRead());
+        // Was a Trace.Assert, which is compiled into Release and aborts the process rather
+        // than throwing. This type backs a lot of client-facing handlers, so any client
+        // sending a payload we expect to be empty took the whole proxy down. Unread bytes
+        // mean our layout is wrong, which is worth knowing but never worth aborting for.
+        if (_worldPacket.CanRead())
+        {
+            Log.Print(LogType.Debug,
+                $"Expected an empty payload for opcode {_worldPacket.GetUniversalOpcode(isModern: true)} but {_worldPacket.Remaining()} bytes remain.");
+        }
     }
 }
 

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -446,12 +446,14 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
             return;
         }
 
+        // GetSize is the real payload length; GetData can hand back a larger ArrayPool rental.
         byte[] raw = packet.GetData();
-        int hexLen = Math.Min(64, raw.Length);
+        int size = (int)packet.GetSize();
+        int hexLen = Math.Min(64, Math.Min(size, raw.Length));
         string hex = hexLen > 0 ? BitConverter.ToString(raw, 0, hexLen) : "<empty>";
         Log.Print(LogType.Error,
             $"C>P S | Unhandled exception in handler for {universalOpcode} ({packet.GetOpcode()}) " +
-            $"[conn={_connectType} account='{account}' size={raw.Length}]{Environment.NewLine}" +
+            $"[conn={_connectType} account='{account}' size={size}]{Environment.NewLine}" +
             $"head={hex}{Environment.NewLine}{e}");
     }
 

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -436,6 +436,16 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
     private void LogHandlerException(Opcode universalOpcode, WorldPacket packet, Exception e)
     {
         string account = _globalSession != null ? GetSession().Username : "<no session>";
+
+        // An opcode with no per-build mapping is a known translation gap, not a defect in
+        // the handler. Log it as a one-liner so real failures keep their stack traces.
+        if (e is UnmappedOpcodeException unmapped)
+        {
+            Log.Print(LogType.Warn,
+                $"C>P S | Handling {universalOpcode} ({packet.GetOpcode()}) for account '{account}': {unmapped.Message}");
+            return;
+        }
+
         byte[] raw = packet.GetData();
         int hexLen = Math.Min(64, raw.Length);
         string hex = hexLen > 0 ? BitConverter.ToString(raw, 0, hexLen) : "<empty>";

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -257,8 +257,20 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
                     break; // Couldn't receive the whole data this time.
             }
 
-            // just received fresh new payload
-            ReadDataHandlerResult result = ReadData();
+            // just received fresh new payload. ReadData's own switch handles the auth /
+            // connect-to / encrypted-mode cases inline, i.e. outside HandlePacket's guard,
+            // and this runs on a socket completion callback where an escaping exception
+            // takes the whole process down. Contain it here too.
+            ReadDataHandlerResult result;
+            try
+            {
+                result = ReadData();
+            }
+            catch (Exception e)
+            {
+                Log.Print(LogType.Error, $"C>P S | Unhandled exception while reading a client packet [conn={_connectType}]{Environment.NewLine}{e}");
+                result = ReadDataHandlerResult.Error;
+            }
             _headerBuffer.Reset();
             if (result != ReadDataHandlerResult.Ok)
             {
@@ -387,7 +399,17 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
     {
         Opcode universalOpcode = packet.GetUniversalOpcode(isModern: true);
         var handler = GetHandler(universalOpcode);
-        if (handler != null)
+        if (handler == null)
+        {
+            WorldSocketLogMessages.NoHandlerForOpcode(_melLog, _sourceFile, _netDirRecv, universalOpcode, packet.GetOpcode());
+            return;
+        }
+
+        // A throwing handler used to escape all the way to AppDomain.UnhandledException and
+        // abort the whole proxy, taking the session with it. The packet is already fully
+        // read out of the socket buffer at this point, so swallowing here cannot desync the
+        // stream. Worst case one client packet is dropped and the session keeps running.
+        try
         {
             if (HermesProxy.Server.MetricsEnabled)
             {
@@ -400,8 +422,27 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
                 handler.Invoke(this, packet);
             }
         }
-        else
-            WorldSocketLogMessages.NoHandlerForOpcode(_melLog, _sourceFile, _netDirRecv, universalOpcode, packet.GetOpcode());
+        catch (Exception e)
+        {
+            LogHandlerException(universalOpcode, packet, e);
+
+            // Without this the client sits on the entering-world screen forever with no
+            // error, which is harder to diagnose than the crash this guard replaced.
+            if (universalOpcode == Opcode.CMSG_PLAYER_LOGIN)
+                AbortLogin(LoginFailureReason.NoWorld);
+        }
+    }
+
+    private void LogHandlerException(Opcode universalOpcode, WorldPacket packet, Exception e)
+    {
+        string account = _globalSession != null ? GetSession().Username : "<no session>";
+        byte[] raw = packet.GetData();
+        int hexLen = Math.Min(64, raw.Length);
+        string hex = hexLen > 0 ? BitConverter.ToString(raw, 0, hexLen) : "<empty>";
+        Log.Print(LogType.Error,
+            $"C>P S | Unhandled exception in handler for {universalOpcode} ({packet.GetOpcode()}) " +
+            $"[conn={_connectType} account='{account}' size={raw.Length}]{Environment.NewLine}" +
+            $"head={hex}{Environment.NewLine}{e}");
     }
 
     private void SendPacketToServer(WorldPacket packet, Opcode delayUntilOpcode = Opcode.MSG_NULL_ACTION)
@@ -574,7 +615,19 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
     void HandleAuthSession(AuthSession authSession)
     {
-        _globalSession = BnetSessionTicketStorage.SessionsByName[authSession.RealmJoinTicket];
+        // A stale or replayed realm-join ticket (client retry after a proxy restart, say)
+        // must not take the process down with a KeyNotFoundException. This runs outside
+        // HandlePacket's guard, straight off the socket completion callback.
+        if (!BnetSessionTicketStorage.SessionsByName.TryGetValue(authSession.RealmJoinTicket, out var session))
+        {
+            Log.Print(LogType.Error,
+                $"WorldSocket.HandleAuthSession: No BNet session for realm join ticket '{authSession.RealmJoinTicket}' from {GetRemoteIpAddress()}. Closing socket.");
+            SendAuthResponseError(BattlenetRpcErrorCode.Denied);
+            CloseSocket();
+            return;
+        }
+
+        _globalSession = session;
         _bnetRpc = new BnetServices.ServiceManager("WorldSocket", this, _globalSession);
         HandleAuthSessionCallback(authSession);
     }
@@ -722,7 +775,17 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
         ConnectToKey key = new();
         _key = key.Raw = authSession.Key;
 
-        _globalSession = BnetSessionTicketStorage.SessionsByKey[_key];
+        if (!BnetSessionTicketStorage.SessionsByKey.TryGetValue(_key, out var session))
+        {
+            Log.Print(LogType.Error,
+                $"WorldSocket.HandleAuthContinuedSession: No BNet session for instance connect key 0x{_key:X16} from {GetRemoteIpAddress()}. Closing socket.");
+            SendAuthResponseError(BattlenetRpcErrorCode.Denied);
+            CloseSocket();
+            return;
+        }
+
+        _globalSession = session;
+        Log.Print(LogType.Server, $"[Login] instance socket authenticated for account '{GetSession().Username}', key=0x{_key:X16}");
 
         uint accountId = key.AccountId;
         string login = GetSession().AccountInfo.Login;

--- a/HermesProxy/World/UnmappedOpcodeException.cs
+++ b/HermesProxy/World/UnmappedOpcodeException.cs
@@ -1,0 +1,25 @@
+using System;
+using HermesProxy.World.Enums;
+
+namespace HermesProxy.World;
+
+/// <summary>
+/// Thrown when a universal opcode has no numeric mapping for the configured build.
+/// Roughly 50 V3_4_3 SMSG opcodes are still unmapped (= 0u in the per-build enum), and the
+/// Trace.Assert that used to guard this aborted the whole process from a socket callback,
+/// bypassing every handler guard. Throwing instead lets the packet be dropped and logged.
+/// </summary>
+public sealed class UnmappedOpcodeException : Exception
+{
+    public Opcode UniversalOpcode { get; }
+
+    /// <summary>True when the missing mapping is on the modern-client side, false for the legacy server.</summary>
+    public bool IsModern { get; }
+
+    public UnmappedOpcodeException(Opcode universalOpcode, bool isModern)
+        : base($"No {(isModern ? ModernVersion.Build : LegacyVersion.Build)} opcode mapping for {universalOpcode}, packet dropped.")
+    {
+        UniversalOpcode = universalOpcode;
+        IsModern = isModern;
+    }
+}


### PR DESCRIPTION
Entering the world with any character crashed the proxy every time against an AzerothCore 3.3.5a backend on macOS. Two separate crashes, both fixed here, verified end to end with a 3.4.3.54261 client (character now loads and plays).

## Fixed

**1. Cross-thread publication race on `CurrentPlayerStorage`**

`HandlePlayerLogin` called `SendConnectToInstance` before it finished building the player state. The client opens the instance socket on its own network thread and its first packet is `CMSG_SET_ACTION_BAR_TOGGLES`, which landed after `Settings = new PlayerSettings(...)` but before `Settings.Reload()` had assigned `_internalStorage`, giving a `NullReferenceException` in `SetMultiActionBarsMask`. On loopback the window is hit essentially every time.

* `HandlePlayerLogin` publishes all `GameState` before `SendConnectToInstance`
* `LoadCurrentPlayer` builds into locals and publishes only fully loaded objects
* `PlayerSettings._internalStorage` defaults to `new()` instead of `null!`
* `OwnCharacters.Single` becomes `FirstOrDefault` with an explicit `AbortLogin`, and the unknown-char / unknown-realm paths abort the login instead of leaving the client on the loading screen

**2. `Trace.Assert(opcode != 0)` aborting the process on an unmapped opcode**

`Trace.Assert` is compiled into Release and aborts outright, so it fired from a socket completion callback and bypassed every handler guard. It triggered on `SMSG_CONQUEST_FORMULA_CONSTANTS`, which is `0u` in the V3_4_3 enum, as are 48 other SMSG entries including reachable ones like `SMSG_LOOT_MASTER_LIST`, `SMSG_UPDATE_COMBO_POINTS` and `SMSG_PARTY_MEMBER_STATS_FULL`. Replaced with a catchable `UnmappedOpcodeException` on both the modern and legacy construction paths, so the packet is dropped and logged by name.

No numeric opcode was guessed for `SMSG_CONQUEST_FORMULA_CONSTANTS`. A wrong value would corrupt the packet stream, and conquest points do not exist in WotLK.

## Crash containment

A single bad handler used to take down the whole process, which made the second crash much harder to find than it needed to be.

* `WorldSocket.HandlePacket` and the `WorldClient` legacy dispatch wrap handler invocation, logging opcode, hex head and stack. `CMSG_PLAYER_LOGIN` failures also send `CharacterLoginFailed` so the client sees an error rather than hanging
* `ReadData` is wrapped too, since the auth / connect-to / encrypted-mode cases run inline there, outside `HandlePacket`'s guard
* `SessionsByName` / `SessionsByKey` raw indexers become `TryGetValue`. A stale connect key was a `KeyNotFoundException` straight to process abort
* `BnetSessionTicketStorage` becomes `ConcurrentDictionary`; both socket-accept threads touch it during one login
* Bounded the unbounded instance-socket spin wait that could wedge the legacy read loop for the rest of the session
* `SMSG_CACHE_VERSION` added to the handshake ignore list. TC-derived cores push it unprompted and it would fail the handshake if it beat `SMSG_AUTH_RESPONSE`
* Remaining unguarded `CurrentPlayerStorage.Settings` call sites null-checked

## Tests

703 pass, 0 fail (7 new). `CurrentPlayerStorageTests` covers the non-null storage default, atomic publish, settings round-trip, and that a failed load leaves previously published state intact. `UnmappedOpcodeTests` covers throw-instead-of-abort. The new tests were verified to fail against the pre-fix code.

## Related issues

Partially addresses **#103 (`[3.4.3 AzerothCore] Solo queueing Dungeon Finder crashes proxy`)**. The log attached to that issue shows an `IndexOutOfRangeException` in `DFProposalResponsePkt.Read()` via `ByteBuffer.HasBit()`, thrown from `WorldSocket.HandlePacket`, on the same `cf43e6d` build. That is the dispatch path wrapped here, so the proxy no longer aborts and the session survives with a log line naming the opcode. The underlying read-layout bug is not fixed, so accepting the dungeon popup still will not work. Tracking that separately.

Possibly relevant to **#28** (missing stub handlers for modern client opcodes) and **#31** (master loot shows wrong item, and `SMSG_LOOT_MASTER_LIST` is one of the unmapped V3_4_3 opcodes), though neither has been confirmed against this change.
