### PR TITLE
fix(v3_4_3): Dungeon Finder proposal crash (#103), invisible join errors, and silent hang on 3.4.3-only dungeons

### DIFF
--- a/HermesProxy.Tests/World/Server/DFProposalResponsePktTests.cs
+++ b/HermesProxy.Tests/World/Server/DFProposalResponsePktTests.cs
@@ -1,0 +1,55 @@
+using HermesProxy.World;
+using HermesProxy.World.Objects;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+/// <summary>
+/// Regression coverage for issue #103: DFProposalResponsePkt consumed the RideTicket
+/// trailing Unknown925 bit a second time after RideTicket.Read had already taken it,
+/// over-reading the buffer by a byte so the final Accepted bit threw
+/// IndexOutOfRangeException and crashed the proxy on every dungeon proposal reply.
+/// </summary>
+public class DFProposalResponsePktTests
+{
+    private const ulong InstanceId = 0x1122334455667788ul;
+    private const uint ProposalId = 0xDEADBEEFu;
+
+    /// <summary>
+    /// Builds the wire bytes a client sends for CMSG_DF_PROPOSAL_RESPONSE, matching
+    /// RideTicket.Read's layout for the build the test suite is pinned to.
+    /// </summary>
+    private static WorldPacket BuildPacket(bool accepted)
+    {
+        var payload = new WorldPacket(1u);
+        payload.WritePackedGuid128(WowGuid128.Empty); // RideTicket.RequesterGuid
+        payload.WriteUInt32(7u);                      // RideTicket.Id
+        payload.WriteUInt32(2u);                      // RideTicket.Type
+        payload.WriteInt64(1234567890L);              // RideTicket.Time
+        payload.WriteUInt64(InstanceId);
+        payload.WriteUInt32(ProposalId);
+        payload.WriteBit(accepted);
+        payload.FlushBits();
+
+        byte[] body = payload.GetData();
+        var framed = new byte[body.Length + 2];       // read ctor consumes a u16 opcode first
+        body.CopyTo(framed, 2);
+        return new WorldPacket(framed);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Read_ParsesWholePacketWithoutOverrunning(bool accepted)
+    {
+        using var packet = new DFProposalResponsePkt(BuildPacket(accepted));
+
+        packet.Read();
+
+        Assert.Equal(InstanceId, packet.InstanceID);
+        Assert.Equal(ProposalId, packet.ProposalID);
+        Assert.Equal(accepted, packet.Accepted);
+        Assert.Equal(7u, packet.Ticket.Id);
+    }
+}

--- a/HermesProxy.Tests/World/Server/LfgJoinResultsTests.cs
+++ b/HermesProxy.Tests/World/Server/LfgJoinResultsTests.cs
@@ -1,0 +1,45 @@
+using HermesProxy.World.Server;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+/// <summary>
+/// Legacy 3.3.5a and V3_4_3 number lfg::LfgJoinResult differently. Forwarding the raw legacy
+/// byte made every Dungeon Finder rejection invisible in the modern client.
+/// </summary>
+public class LfgJoinResultsTests
+{
+    [Theory]
+    [InlineData(0, 0x00)]   // OK
+    [InlineData(2, 0x1F)]   // group full
+    [InlineData(5, 0x22)]   // does not meet requirements
+    [InlineData(11, 0x27)]  // one or more dungeons was not valid
+    [InlineData(12, 0x28)]  // deserter debuff
+    [InlineData(14, 0x2A)]  // random dungeon cooldown
+    [InlineData(17, 0x2D)]  // using the battleground system
+    public void ToModern_MapsKnownLegacyCodes(byte legacy, byte expected)
+    {
+        Assert.Equal(expected, LfgJoinResults.ToModern(legacy));
+    }
+
+    [Fact]
+    public void ToModern_KeepsPartyRequirementsCodeUnchanged()
+    {
+        // The only value both enums happen to share.
+        Assert.Equal(6, LfgJoinResults.ToModern(6));
+    }
+
+    [Fact]
+    public void ToModern_WithUnknownCode_FallsBackToAnInternalError()
+    {
+        // Showing "Internal LFG Error" beats showing nothing at all.
+        Assert.Equal(LfgJoinResults.ModernNoLfgObject, LfgJoinResults.ToModern(200));
+    }
+
+    [Fact]
+    public void ToModern_NeverReturnsOkForAFailure()
+    {
+        for (byte legacy = 1; legacy < 60; legacy++)
+            Assert.NotEqual(LfgJoinResults.ModernOk, LfgJoinResults.ToModern(legacy));
+    }
+}

--- a/HermesProxy.Tests/World/Server/LfgSlotsTests.cs
+++ b/HermesProxy.Tests/World/Server/LfgSlotsTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using HermesProxy.World.Server;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+/// <summary>
+/// The V3_4_3 client offers Titan Rune Protocol dungeons (LFGDungeons 2447 / 2470 / 2485)
+/// that do not exist in 3.3.5a. Queueing for one made the legacy server drop CMSG_LFG_JOIN
+/// with no reply at all, leaving Dungeon Finder waiting forever with no error shown.
+/// </summary>
+public class LfgSlotsTests
+{
+    private const uint RandomDungeonType = 6u << 24;
+
+    private const uint RandomLichKingDungeon = RandomDungeonType | 261u;
+    private const uint RandomLichKingHeroic = RandomDungeonType | 262u;
+    private const uint TitanRuneGamma = RandomDungeonType | 2447u;
+
+    private static HashSet<uint> Known(params uint[] ids) => new(ids);
+
+    [Fact]
+    public void GetDungeonId_StripsTheTypeByte()
+    {
+        Assert.Equal(261u, LfgSlots.GetDungeonId(RandomLichKingDungeon));
+        Assert.Equal(2447u, LfgSlots.GetDungeonId(TitanRuneGamma));
+    }
+
+    [Fact]
+    public void TryFindUnknownDungeon_WithServiceableDungeon_ReturnsFalse()
+    {
+        Assert.False(LfgSlots.TryFindUnknownDungeon(
+            Known(261u, 262u), new[] { RandomLichKingDungeon }, out uint unknown));
+        Assert.Equal(0u, unknown);
+    }
+
+    [Fact]
+    public void TryFindUnknownDungeon_WithTitanRune_ReportsIt()
+    {
+        Assert.True(LfgSlots.TryFindUnknownDungeon(
+            Known(261u, 262u), new[] { TitanRuneGamma }, out uint unknown));
+        Assert.Equal(2447u, unknown);
+    }
+
+    [Fact]
+    public void TryFindUnknownDungeon_WithMixedRequest_ReportsTheUnserviceableOne()
+    {
+        Assert.True(LfgSlots.TryFindUnknownDungeon(
+            Known(261u, 262u), new[] { RandomLichKingHeroic, TitanRuneGamma }, out uint unknown));
+        Assert.Equal(2447u, unknown);
+    }
+
+    [Fact]
+    public void TryFindUnknownDungeon_BeforePlayerInfoArrives_AllowsTheJoin()
+    {
+        // An empty set means SMSG_LFG_PLAYER_INFO has not been seen yet. Rejecting on that
+        // would block every queue attempt, which is worse than the hang being fixed here.
+        Assert.False(LfgSlots.TryFindUnknownDungeon(
+            Known(), new[] { TitanRuneGamma }, out uint unknown));
+        Assert.Equal(0u, unknown);
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -306,6 +306,13 @@ public sealed class GameSessionData
     // cached copy AFTER the player Create so the V3_4_3 client sees TC's ordering.
     public InitWorldStates? LastInitWorldStates;
 
+    // Dungeon IDs (low 24 bits of an LFG slot) the legacy backend listed in
+    // SMSG_LFG_PLAYER_INFO, available and locked alike. The V3_4_3 client offers
+    // content that shipped after 3.3.5a (Titan Rune Protocol), and queueing for it
+    // makes the legacy server drop CMSG_LFG_JOIN without any reply, leaving the
+    // client waiting forever. Used to answer those joins ourselves.
+    public readonly HashSet<uint> LfgKnownDungeonIds = new();
+
     private GameSessionData()
     {
         

--- a/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
@@ -285,7 +285,8 @@ public partial class WorldClient
         {
             _lfgPlayerInfoLogged = true;
             Log.Print(LogType.Debug,
-                $"LFG[diag]: SMSG_LFG_PLAYER_INFO sent — Dungeons={info.Dungeons.Count} BlackListSlots={info.BlackList.Slots?.Count ?? 0} (one-shot)");
+                $"LFG[diag]: SMSG_LFG_PLAYER_INFO sent, Dungeons={info.Dungeons.Count} BlackListSlots={info.BlackList.Slots?.Count ?? 0} " +
+                $"offeredSlots=[{string.Join(", ", info.Dungeons.ConvertAll(x => x.Slot.ToString()))}] (one-shot)");
         }
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
@@ -279,6 +279,13 @@ public partial class WorldClient
         }
         info.BlackList = blackList;
 
+        // Both lists together are the full set of dungeons this backend understands.
+        var known = GetSession().GameState.LfgKnownDungeonIds;
+        foreach (var dungeon in info.Dungeons)
+            known.Add(dungeon.Slot & 0xFFFFFF);
+        foreach (var locked in blackList.Slots)
+            known.Add(locked.Slot & 0xFFFFFF);
+
         SendPacketToClient(info);
 
         if (!_lfgPlayerInfoLogged)

--- a/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
@@ -1,5 +1,7 @@
 using Framework.Logging;
+using HermesProxy.Enums;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Server;
 using HermesProxy.World.Server.Packets;
 using System;
 using System.Collections.Generic;
@@ -47,7 +49,12 @@ public partial class WorldClient
     {
         DFJoinResult result = new DFJoinResult();
         result.Ticket = MakeLfgTicket();
-        result.Result = (byte)packet.ReadUInt32();        // joinData.result
+        // The legacy and V3_4_3 LfgJoinResult enums do not share numbering, so forwarding the
+        // raw byte made every rejection invisible in the modern UI.
+        byte legacyResult = (byte)packet.ReadUInt32();    // joinData.result
+        result.Result = ModernVersion.Build == ClientVersionBuild.V3_4_3_54261
+            ? LfgJoinResults.ToModern(legacyResult)
+            : legacyResult;
         result.ResultDetail = (byte)packet.ReadUInt32();  // joinData.state
         if (packet.CanRead())
         {

--- a/HermesProxy/World/Server/LfgJoinResults.cs
+++ b/HermesProxy/World/Server/LfgJoinResults.cs
@@ -1,0 +1,55 @@
+namespace HermesProxy.World.Server;
+
+/// <summary>
+/// Legacy 3.3.5a and V3_4_3 number lfg::LfgJoinResult completely differently, and the proxy
+/// used to forward the legacy byte straight through. The V3_4_3 client does not recognise
+/// those values, so every Dungeon Finder rejection was silently swallowed and the UI just
+/// sat there. Sources: azerothcore-wotlk and TrinityCore/wotlk_classic,
+/// src/server/game/DungeonFinding/LFGMgr.h.
+/// </summary>
+public static class LfgJoinResults
+{
+    // V3_4_3 values.
+    public const byte ModernOk = 0x00;
+    public const byte ModernGroupFull = 0x1F;
+    public const byte ModernNoLfgObject = 0x21;
+    public const byte ModernNoSlots = 0x22;
+    public const byte ModernMismatchedSlots = 0x23;
+    public const byte ModernDifferentRealms = 0x24;
+    public const byte ModernMembersNotPresent = 0x25;
+    public const byte ModernGetInfoTimeout = 0x26;
+    public const byte ModernInvalidSlot = 0x27;
+    public const byte ModernDeserterPlayer = 0x28;
+    public const byte ModernDeserterParty = 0x29;
+    public const byte ModernRandomCooldownPlayer = 0x2A;
+    public const byte ModernRandomCooldownParty = 0x2B;
+    public const byte ModernTooManyMembers = 0x2C;
+    public const byte ModernCantUseDungeons = 0x2D;
+    public const byte ModernRoleCheckFailed = 0x2E;
+
+    /// <summary>
+    /// Translates a legacy 3.3.5a join result into the value a V3_4_3 client understands.
+    /// Unknown codes fall back to "internal LFG error" so the player still sees something.
+    /// </summary>
+    public static byte ToModern(byte legacyResult) => legacyResult switch
+    {
+        0 => ModernOk,                    // LFG_JOIN_OK
+        1 => ModernRoleCheckFailed,       // LFG_JOIN_FAILED (role check)
+        2 => ModernGroupFull,             // LFG_JOIN_GROUPFULL
+        4 => ModernNoLfgObject,           // LFG_JOIN_INTERNAL_ERROR
+        5 => ModernNoSlots,               // LFG_JOIN_NOT_MEET_REQS
+        6 => 6,                           // LFG_JOIN_PARTY_NOT_MEET_REQS, same value on both
+        7 => ModernMismatchedSlots,       // LFG_JOIN_MIXED_RAID_DUNGEON
+        8 => ModernDifferentRealms,       // LFG_JOIN_MULTI_REALM
+        9 => ModernMembersNotPresent,     // LFG_JOIN_DISCONNECTED
+        10 => ModernGetInfoTimeout,       // LFG_JOIN_PARTY_INFO_FAILED
+        11 => ModernInvalidSlot,          // LFG_JOIN_DUNGEON_INVALID
+        12 => ModernDeserterPlayer,       // LFG_JOIN_DESERTER
+        13 => ModernDeserterParty,        // LFG_JOIN_PARTY_DESERTER
+        14 => ModernRandomCooldownPlayer, // LFG_JOIN_RANDOM_COOLDOWN
+        15 => ModernRandomCooldownParty,  // LFG_JOIN_PARTY_RANDOM_COOLDOWN
+        16 => ModernTooManyMembers,       // LFG_JOIN_TOO_MUCH_MEMBERS
+        17 => ModernCantUseDungeons,      // LFG_JOIN_USING_BG_SYSTEM
+        _ => ModernNoLfgObject,
+    };
+}

--- a/HermesProxy/World/Server/LfgSlots.cs
+++ b/HermesProxy/World/Server/LfgSlots.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace HermesProxy.World.Server;
+
+/// <summary>
+/// An LFG queue slot packs the dungeon type into the high byte and the LFGDungeons ID into
+/// the low 24 bits.
+/// </summary>
+public static class LfgSlots
+{
+    private const uint DungeonIdMask = 0xFFFFFF;
+
+    public static uint GetDungeonId(uint slot) => slot & DungeonIdMask;
+
+    /// <summary>
+    /// Finds the first requested dungeon the legacy backend has never mentioned. The V3_4_3
+    /// client offers content that postdates 3.3.5a, and legacy servers drop a join naming an
+    /// unknown dungeon without replying at all, hanging the client's Dungeon Finder UI.
+    /// Returns false when <paramref name="knownDungeonIds"/> is empty, since an unpopulated
+    /// set means SMSG_LFG_PLAYER_INFO has not arrived yet rather than that nothing is valid.
+    /// </summary>
+    public static bool TryFindUnknownDungeon(HashSet<uint> knownDungeonIds, IEnumerable<uint> requestedSlots, out uint unknownDungeonId)
+    {
+        unknownDungeonId = 0;
+        if (knownDungeonIds.Count == 0)
+            return false;
+
+        foreach (uint slot in requestedSlots)
+        {
+            uint dungeonId = GetDungeonId(slot);
+            if (knownDungeonIds.Contains(dungeonId))
+                continue;
+
+            unknownDungeonId = dungeonId;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/HermesProxy/World/Server/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/LFGHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
@@ -44,11 +45,20 @@ public partial class WorldSocket
         //   uint8  needsCount (always 3)
         //   uint8  Needs[3]
         //   cstr   Comment
-        // 3.3.5a and V3_4_3 do not share LFGDungeons IDs. If the client queues for content
-        // that only exists in 3.4.3 (Titan Rune Protocol, say), the legacy server silently
-        // drops the join with no SMSG_LFG_JOIN_RESULT, so log what we forward.
         Log.Print(LogType.Debug,
-            $"LFG[diag]: CMSG_DF_JOIN roles=0x{packet.Roles:X8} slots=[{string.Join(", ", packet.Slots)}] forwarding as CMSG_LFG_JOIN");
+            $"LFG[diag]: CMSG_DF_JOIN roles=0x{packet.Roles:X8} slots=[{string.Join(", ", packet.Slots)}]");
+
+        // The V3_4_3 client offers dungeons that postdate 3.3.5a (Titan Rune Protocol
+        // Alpha/Beta/Gamma, IDs 2447/2470/2485). A legacy backend drops CMSG_LFG_JOIN for
+        // an unknown dungeon without sending SMSG_LFG_JOIN_RESULT, so the client sits on
+        // "Find Group" forever with no error. Answer for the backend instead.
+        if (LfgSlots.TryFindUnknownDungeon(GetSession().GameState.LfgKnownDungeonIds, packet.Slots, out uint unknownDungeonId))
+        {
+            Log.Print(LogType.Debug,
+                $"LFG[diag]: rejecting CMSG_DF_JOIN, dungeon {unknownDungeonId} is unknown to the {LegacyVersion.Build} backend");
+            SendDFJoinFailure(LfgJoinResult.DungeonInvalid);
+            return;
+        }
 
         WorldPacket legacy = new WorldPacket(Opcode.CMSG_LFG_JOIN);
         legacy.WriteUInt32(packet.Roles);
@@ -63,6 +73,31 @@ public partial class WorldSocket
         legacy.WriteUInt8(0);
         legacy.WriteCString(string.Empty);
         SendPacketToServer(legacy);
+    }
+
+    // Legacy 3.3.5a lfg::LfgJoinResult. The proxy forwards the backend's raw result byte
+    // straight through, so a synthesised failure has to use the same numbering.
+    // Source: azerothcore-wotlk src/server/game/DungeonFinding/LFGMgr.h.
+    private enum LfgJoinResult : byte
+    {
+        DungeonInvalid = 11, // "One or more dungeons was not valid"
+    }
+
+    private void SendDFJoinFailure(LfgJoinResult result)
+    {
+        DFJoinResult response = new DFJoinResult
+        {
+            Ticket = new RideTicket
+            {
+                RequesterGuid = GetSession().GameState.CurrentPlayerGuid,
+                Id = 1,
+                Type = RideType.Lfg,
+                Time = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            },
+            Result = (byte)result,
+            ResultDetail = 0,
+        };
+        SendPacket(response);
     }
 
     [PacketHandler(Opcode.CMSG_DF_LEAVE)]

--- a/HermesProxy/World/Server/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/LFGHandler.cs
@@ -56,7 +56,7 @@ public partial class WorldSocket
         {
             Log.Print(LogType.Debug,
                 $"LFG[diag]: rejecting CMSG_DF_JOIN, dungeon {unknownDungeonId} is unknown to the {LegacyVersion.Build} backend");
-            SendDFJoinFailure(LfgJoinResult.DungeonInvalid);
+            SendDFJoinFailure(LfgJoinResults.ModernInvalidSlot);
             return;
         }
 
@@ -75,15 +75,7 @@ public partial class WorldSocket
         SendPacketToServer(legacy);
     }
 
-    // Legacy 3.3.5a lfg::LfgJoinResult. The proxy forwards the backend's raw result byte
-    // straight through, so a synthesised failure has to use the same numbering.
-    // Source: azerothcore-wotlk src/server/game/DungeonFinding/LFGMgr.h.
-    private enum LfgJoinResult : byte
-    {
-        DungeonInvalid = 11, // "One or more dungeons was not valid"
-    }
-
-    private void SendDFJoinFailure(LfgJoinResult result)
+    private void SendDFJoinFailure(byte modernResult)
     {
         DFJoinResult response = new DFJoinResult
         {
@@ -94,7 +86,7 @@ public partial class WorldSocket
                 Type = RideType.Lfg,
                 Time = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
             },
-            Result = (byte)result,
+            Result = modernResult,
             ResultDetail = 0,
         };
         SendPacket(response);

--- a/HermesProxy/World/Server/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/LFGHandler.cs
@@ -1,3 +1,4 @@
+using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Server.Packets;
@@ -43,6 +44,12 @@ public partial class WorldSocket
         //   uint8  needsCount (always 3)
         //   uint8  Needs[3]
         //   cstr   Comment
+        // 3.3.5a and V3_4_3 do not share LFGDungeons IDs. If the client queues for content
+        // that only exists in 3.4.3 (Titan Rune Protocol, say), the legacy server silently
+        // drops the join with no SMSG_LFG_JOIN_RESULT, so log what we forward.
+        Log.Print(LogType.Debug,
+            $"LFG[diag]: CMSG_DF_JOIN roles=0x{packet.Roles:X8} slots=[{string.Join(", ", packet.Slots)}] forwarding as CMSG_LFG_JOIN");
+
         WorldPacket legacy = new WorldPacket(Opcode.CMSG_LFG_JOIN);
         legacy.WriteUInt32(packet.Roles);
         legacy.WriteUInt8(0); // NoPartialClear

--- a/HermesProxy/World/Server/Packets/LFG/CMSG/DFProposalResponsePkt.cs
+++ b/HermesProxy/World/Server/Packets/LFG/CMSG/DFProposalResponsePkt.cs
@@ -11,9 +11,11 @@ public class DFProposalResponsePkt : ClientPacket
 
     public override void Read()
     {
+        // RideTicket.Read owns the V3_4_3 trailing Unknown925 bit and the byte-align that
+        // follows it (see BattleGroundPackets.RideTicket). This used to consume a second
+        // one here, which over-read the buffer by a byte and made the final Accepted bit
+        // throw IndexOutOfRangeException, crashing the proxy on every proposal reply (#103).
         Ticket.Read(_worldPacket);
-        _worldPacket.HasBit(); // RideTicket trailing Unknown925
-        _worldPacket.ResetBitReader();
         InstanceID = _worldPacket.ReadUInt64();
         ProposalID = _worldPacket.ReadUInt32();
         Accepted = _worldPacket.HasBit();


### PR DESCRIPTION
Independent of #111, no overlapping files. Three Dungeon Finder fixes, all verified in game against AzerothCore + mod-playerbots with a 3.4.3.54261 client. A character now queues, gets a proposal, accepts it, is teleported into the dungeon, and sees a real error message when a queue is refused.

## Fixes #103, the proxy crash on accepting a proposal

Accepting a Dungeon Finder popup crashed the proxy with `IndexOutOfRangeException` in `ByteBuffer.HasBit` via `DFProposalResponsePkt.Read`.

`DFProposalResponsePkt` has consumed the RideTicket trailing `Unknown925` bit itself since the LFG layer was ported in `b57a81f`, back when `RideTicket.Read` did not. `28658bc` later moved that consumption into `RideTicket.Read` to fix the battleground popup (#102), which left `DFProposalResponsePkt` taking it twice. Each `HasBit` on a byte-aligned reader pulls a fresh byte, so the read ran one byte past the end and the trailing `Accepted` bit had nothing left to read.

`RideTicket.Read` is now the single owner of that bit, correctly gated to `V3_4_3_54261`. `BattlefieldPort` was already relying on it and is unaffected.

## Every LFG rejection was invisible in the modern client

Legacy 3.3.5a and V3_4_3 number `lfg::LfgJoinResult` completely differently, and `HandleLFGJoinResult` forwarded the legacy byte straight through. The V3_4_3 client does not recognise those values and silently discards the packet, so pressing Find Group when the backend refuses looked exactly like the button doing nothing.

| Meaning | 3.3.5a | V3_4_3 |
|---|---|---|
| One or more dungeons was not valid | 11 | 0x27 |
| You do not meet the requirements | 5 | 0x22 |
| Deserter debuff | 12 | 0x28 |
| Your group is already full | 2 | 0x1F |

The full enum is now mapped, with an "internal LFG error" fallback for unrecognised codes so the player sees something rather than nothing. Gated to `V3_4_3_54261`. Sources: azerothcore-wotlk and TrinityCore/wotlk_classic `src/server/game/DungeonFinding/LFGMgr.h`.

This affects deserter, group full, requirements, cooldown and role check alike, not just the case below.

## Silent hang when queueing for content 3.3.5a does not have

The V3_4_3 client offers Titan Rune Protocol Alpha/Beta/Gamma (`LFGDungeons` 2447/2470/2485), which shipped with WotLK Classic. Queueing for one sends a dungeon ID the legacy server has never heard of, and it drops `CMSG_LFG_JOIN` without any `SMSG_LFG_JOIN_RESULT` at all. Observed with slot `100665743`, which is `(6 << 24) | 2447`.

`SMSG_LFG_PLAYER_INFO` already enumerates every dungeon the backend understands, available and locked alike, so those IDs are recorded and an unserviceable join is answered locally with the modern `LFG_JOIN_INVALID_SLOT`. Joins are left alone until that packet has arrived, since an empty set means "not known yet" rather than "nothing is valid".

## Diagnostics

LFG failures are silent by nature, so the `SMSG_LFG_PLAYER_INFO` one-shot now lists the offered slots and `CMSG_DF_JOIN` logs roles plus requested slots. That is what made all three bugs above tractable.

## Tests

719 pass, 0 fail (13 new). `DFProposalResponsePktTests` builds the wire bytes and asserts the packet parses without overrunning; verified it fails against the pre-fix code. `LfgSlotsTests` covers the slot type-byte mask, a serviceable dungeon, Titan Rune, a mixed request, and the pre-`SMSG_LFG_PLAYER_INFO` case. `LfgJoinResultsTests` pins the enum mapping, the shared value, the unknown-code fallback, and that no failure ever maps to OK.
