### PR TITLE
fix(v3_4_3): battleground scoreboard (#106) and two legacy packet over-reads

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -38,9 +38,26 @@ public partial class WorldClient
         ushort cooldownCount = packet.ReadUInt16();
         if (cooldownCount != 0)
         {
+            // AzerothCore declares this count as m_spellCooldowns.size() up front and then
+            // skips entries whose needSendToClient is false without correcting it, so the
+            // count can exceed what is actually on the wire. (Its spell block just above
+            // back-patches the real count; the cooldown block never does.) Trusting the
+            // declared count read past the end and threw, losing every cooldown including
+            // the ones that had already parsed. Bound each entry on the real payload instead.
+            int entrySize = 2 + 4 + 4; // category + recoveryTime + categoryRecoveryTime
+            entrySize += LegacyVersion.AddedInVersion(ClientVersionBuild.V3_1_0_9767) ? 4 : 2;  // spellId
+            entrySize += LegacyVersion.AddedInVersion(ClientVersionBuild.V4_2_2_14545) ? 4 : 2; // itemId
+
             SendSpellHistory histories = new SendSpellHistory();
             for (ushort i = 0; i < cooldownCount; i++)
             {
+                if (!packet.CanRead(entrySize))
+                {
+                    Log.Print(LogType.Warn,
+                        $"SMSG_SEND_KNOWN_SPELLS declared {cooldownCount} cooldowns but only {histories.Entries.Count} are present; keeping those.");
+                    break;
+                }
+
                 SpellHistoryEntry history = new SpellHistoryEntry();
 
                 uint spellId;
@@ -63,7 +80,8 @@ public partial class WorldClient
 
                 histories.Entries.Add(history);
             }
-            SendPacketToClient(histories, Opcode.SMSG_SEND_UNLEARN_SPELLS);
+            if (histories.Entries.Count > 0)
+                SendPacketToClient(histories, Opcode.SMSG_SEND_UNLEARN_SPELLS);
         }
 
         // These packets don't exist in Vanilla.

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -539,21 +539,56 @@ public partial class WorldClient
 
         if (isSpellGo)
         {
+            // A short or malformed SMSG_SPELL_GO declares more hit/miss targets than it
+            // actually carries, and the loops then read past the end (issue #105). The
+            // parser's field layout matches AzerothCore, TrinityCore and cMaNGOS exactly,
+            // so the malformed packet comes from the backend, not from us. Bound each entry
+            // on the real payload and keep what parsed, which also names the offending
+            // spell in the log instead of leaving only a raw hex dump.
             var hitCount = packet.ReadUInt8();
             for (var i = 0; i < hitCount; i++)
             {
+                if (!packet.CanRead(8)) // raw guid
+                {
+                    Log.Print(LogType.Warn,
+                        $"[SpellGo] spell {dbdata.SpellID} declared {hitCount} hit targets but only {i} are present, truncating parse.");
+                    return dbdata;
+                }
+
                 WowGuid128 hitTarget = packet.ReadGuid().To128(GetSession().GameState);
                 dbdata.HitTargets.Add(hitTarget);
+            }
+
+            if (!packet.CanRead(1))
+            {
+                Log.Print(LogType.Warn, $"[SpellGo] spell {dbdata.SpellID} ended before the miss-target count, truncating parse.");
+                return dbdata;
             }
 
             var missCount = packet.ReadUInt8();
             for (var i = 0; i < missCount; i++)
             {
+                if (!packet.CanRead(9)) // raw guid + miss reason
+                {
+                    Log.Print(LogType.Warn,
+                        $"[SpellGo] spell {dbdata.SpellID} declared {missCount} miss targets but only {i} are present, truncating parse.");
+                    return dbdata;
+                }
+
                 WowGuid128 missTarget = packet.ReadGuid().To128(GetSession().GameState);
                 SpellMissInfo missType = (SpellMissInfo)packet.ReadUInt8();
                 SpellMissInfo reflectType = SpellMissInfo.None;
                 if (missType == SpellMissInfo.Reflect)
+                {
+                    if (!packet.CanRead(1))
+                    {
+                        Log.Print(LogType.Warn,
+                            $"[SpellGo] spell {dbdata.SpellID} reflect target is missing its status byte, truncating parse.");
+                        return dbdata;
+                    }
+
                     reflectType = (SpellMissInfo)packet.ReadUInt8();
+                }
 
                 dbdata.MissTargets.Add(missTarget);
                 dbdata.MissStatus.Add(new SpellMissStatus(missType, reflectType));

--- a/HermesProxy/World/Enums/V3_4_3_54261/Opcode.cs
+++ b/HermesProxy/World/Enums/V3_4_3_54261/Opcode.cs
@@ -1,4 +1,4 @@
-namespace HermesProxy.World.Enums.V3_4_3_54261;
+﻿namespace HermesProxy.World.Enums.V3_4_3_54261;
 
 public enum Opcode : uint
 {
@@ -771,6 +771,7 @@ public enum Opcode : uint
 	SMSG_PLAYER_SKINNED = 12294u,
 	SMSG_PRINT_NOTIFICATION = 9674u,
 	SMSG_PVP_CREDIT = 10570u,
+	SMSG_PVP_MATCH_STATISTICS = 10548u,
 	SMSG_RAID_INSTANCE_MESSAGE = 11188u,
 	SMSG_READY_CHECK_COMPLETED = 9720u,
 	SMSG_READY_CHECK_RESPONSE = 9719u,

--- a/HermesProxy/World/Server/Packets/BattleGroundPackets.cs
+++ b/HermesProxy/World/Server/Packets/BattleGroundPackets.cs
@@ -507,12 +507,19 @@ public class PVPMatchStatisticsMessage : ServerPacket
 
     public override void Write()
     {
+        // V3_4_3 dropped the arena team name block from this packet, and its opcode slot is
+        // the old SMSG_PVP_LOG_DATA (0x2934) rather than retail's SMSG_PVP_MATCH_STATISTICS
+        // (0x2933, which is what Classic Era and TBC Classic use). Wrathion, a native
+        // 3.4.3.54261 server, hardcodes the HasNames bit to false with the comment
+        // "ArenaTeams no longer in 3.4.3".
+        bool writeArenaTeams = ArenaTeams != null && ModernVersion.Build != ClientVersionBuild.V3_4_3_54261;
+
         _worldPacket.WriteBit(Ratings != null);
-        _worldPacket.WriteBit(ArenaTeams != null);
+        _worldPacket.WriteBit(writeArenaTeams);
         _worldPacket.WriteBit(Winner != null);
 
-        if (ArenaTeams != null)
-            ArenaTeams.Write(_worldPacket);
+        if (writeArenaTeams)
+            ArenaTeams!.Write(_worldPacket);
 
         _worldPacket.WriteInt32(Statistics.Count);
 
@@ -597,7 +604,11 @@ public class PVPMatchStatisticsMessage : ServerPacket
             data.WriteUInt32(HealingDone);
             data.WriteInt32(Stats.Count);
             data.WriteInt32(PrimaryTalentTree);
-            data.WriteUInt32((uint)Sex);
+            // 3.4.3 narrows Sex to a single byte; wider writes shift every following field.
+            if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+                data.WriteInt8((sbyte)Sex);
+            else
+                data.WriteUInt32((uint)Sex);
             data.WriteUInt32((uint)PlayerRace);
             data.WriteUInt32((uint)PlayerClass);
             data.WriteInt32(CreatureID);


### PR DESCRIPTION
Independent of #111 and #112, no overlapping files. All three fixes verified in game against AzerothCore + mod-playerbots with a 3.4.3.54261 client.

## Fixes #106: the battleground scoreboard was always empty

The proxy logged `No V3_4_3_54261 opcode mapping for SMSG_PVP_MATCH_STATISTICS, packet dropped`, so the missing mapping looked like the bug. It was a symptom.

`SMSG_PVP_MATCH_STATISTICS` as retail numbers it (`0x2933`) does not exist in WotLK Classic at all. Wrathion, a native 3.4.3.54261 server, defines it as its `0xBADD` not-implemented sentinel, and TrinityCore's `wotlk_classic` marks it `UNKNOWN_OPCODE`. 3.4.3 still carries the WotLK-era packet in the `SMSG_PVP_LOG_DATA` slot, `0x2934` (10548), and Wrathion's class is literally declared `ServerPacket(SMSG_PVP_LOG_DATA)`. The client asks with `CMSG_PVP_LOG_DATA`, which this build already maps as 12671 and matches Wrathion's `0x317F`, confirming the source lines up with this exact build.

Two body differences came with it, both gated to `V3_4_3_54261` so Classic Era and TBC Classic keep the `0x2933` layout they already use:

- the arena team name block is gone in 3.4.3, where the HasNames bit is hardcoded false ("ArenaTeams no longer in 3.4.3")
- `Sex` is `int8`, not `uint32`. The wider write shifted every following per-player field, so this alone would have garbled the scoreboard even once the opcode was right

Field order otherwise matches Wrathion byte for byte. Verified in game: names, class icons, faction colours, killing blows, deaths, honorable kills, damage, healing, bases assaulted and honor all render correctly.

## Fixes an over-read on AzerothCore's SMSG_INITIAL_SPELLS

Leaving a battleground threw `ArgumentOutOfRangeException` out of `HandleSendKnownSpells`, losing the player's entire cooldown list.

`Player::SendInitialSpells` writes the cooldown count as `m_spellCooldowns.size()` before the write loop, then `continue`s past any entry whose `needSendToClient` is false without correcting it. The spell block immediately above it does back-patch its real count via `data.put<uint16>(countPos, spellCount)`, so the omission below is an oversight rather than intent. The declared count can exceed what is on the wire.

Field sizes were all correct and match AzerothCore byte for byte; only the loop bound was wrong. Each entry is now bounded on the remaining payload, keeping whatever parsed. Observed live:

    SMSG_SEND_KNOWN_SPELLS declared 10 cooldowns but only 1 are present; keeping those.

## Bounds the SMSG_SPELL_GO target loops (#105)

Issue #105 reports combat disconnects from an over-read in the hit and miss target loops, and hypothesises that a cast-flag-dependent field is misplaced. **That hypothesis is not supported.** The parser's field order, sizes and gating were compared against AzerothCore, TrinityCore 3.3.5 and cMaNGOS and match all three exactly. The reporter's own follow-up found 328 clean packets over a 30 minute session, and two full battlegrounds here produced none either.

So the malformed packet originates on the backend. One candidate is mod-playerbots' `DebugAction::FakeSpell`, which hand-writes `SMSG_SPELL_GO` with the cast-count byte missing, `CastFlags` as `uint16` rather than `uint32`, and no timestamp, leaving the reader to take the hit count from the middle of another field. That is a candidate, not a confirmed trigger.

Whatever the source, trusting a declared count is the wrong shape, so each target is now bounded on the remaining payload. **This does not fix #105's root cause and the issue should stay open**; the value is that a malformed cast now names its spell in the log instead of leaving raw hex to decode.

Not version gated: a bounds check cannot harm a well-formed packet.

## Tests

702 pass, 0 fail. No new unit tests here: all three changes are wire-format work against a live legacy backend, and the meaningful verification was in game rather than anything a unit test could assert.
