### PR TITLE
feat(v3_4_3): make transports work — elevators, trams, zeppelins and boats (#96)

### DIFF
--- a/HermesProxy.Tests/World/PacketHandlerRegistrationTests.cs
+++ b/HermesProxy.Tests/World/PacketHandlerRegistrationTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using HermesProxy;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Client;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Server;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+/// <summary>
+/// A [PacketHandler] attribute binds to whatever declaration follows it, so inserting a
+/// method between the attribute and its handler silently moves the registration onto the
+/// new method and leaves the opcode unhandled. That happened to SMSG_UPDATE_OBJECT and
+/// only showed up as a startup log line, so these assert the wiring directly.
+/// </summary>
+public class PacketHandlerRegistrationTests
+{
+    static PacketHandlerRegistrationTests()
+    {
+        // Reflecting over the handler hosts touches LegacyVersion's static initializers,
+        // which refuse to run until a legacy build is chosen.
+        if (VersionBootstrap.LegacyBuild == ClientVersionBuild.Zero)
+            VersionBootstrap.LegacyBuild = ClientVersionBuild.V3_3_5a_12340;
+    }
+
+    private static IEnumerable<MethodInfo> DecoratedMethods(Type hostType) =>
+        hostType.GetMethods(BindingFlags.Instance | BindingFlags.Static |
+                            BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(m => m.GetCustomAttributes<PacketHandlerAttribute>().Any());
+
+    // WorldClient handlers take a raw WorldPacket; WorldSocket handlers take a deserialized
+    // ClientPacket subclass. Each registrar rejects anything else at startup with a log line.
+    [Fact]
+    public void EveryWorldClientHandlerTakesAWorldPacket()
+    {
+        var broken = DecoratedMethods(typeof(WorldClient))
+            .Where(m =>
+            {
+                var p = m.GetParameters();
+                return p.Length == 0 || p[0].ParameterType != typeof(WorldPacket);
+            })
+            .Select(m => m.Name)
+            .ToList();
+
+        Assert.True(broken.Count == 0,
+            $"[PacketHandler] on WorldClient methods that cannot be registered: {string.Join(", ", broken)}. " +
+            "The attribute most likely slipped onto the wrong declaration.");
+    }
+
+    [Fact]
+    public void EveryWorldSocketHandlerTakesAClientPacket()
+    {
+        var broken = DecoratedMethods(typeof(WorldSocket))
+            .Where(m =>
+            {
+                var p = m.GetParameters();
+                return p.Length == 0 || p[0].ParameterType.BaseType != typeof(ClientPacket);
+            })
+            .Select(m => m.Name)
+            .ToList();
+
+        Assert.True(broken.Count == 0,
+            $"[PacketHandler] on WorldSocket methods that cannot be registered: {string.Join(", ", broken)}. " +
+            "The attribute most likely slipped onto the wrong declaration.");
+    }
+
+    [Fact]
+    public void UpdateObjectOpcodesAreHandled()
+    {
+        var handled = DecoratedMethods(typeof(WorldClient))
+            .SelectMany(m => m.GetCustomAttributes<PacketHandlerAttribute>())
+            .Select(a => a.Opcode)
+            .ToHashSet();
+
+        Assert.Contains(Opcode.SMSG_UPDATE_OBJECT, handled);
+        Assert.Contains(Opcode.SMSG_COMPRESSED_UPDATE_OBJECT, handled);
+    }
+}

--- a/HermesProxy.Tests/World/TransportCreateOrderingTests.cs
+++ b/HermesProxy.Tests/World/TransportCreateOrderingTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Linq;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class TransportCreateOrderingTests
+{
+    private static WowGuid128 Transport(uint counter) =>
+        WowGuid128.Create(new WowGuid64(HighGuidTypeLegacy.MOTransport, counter), null!);
+
+    private static WowGuid128 Player(ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Player, counter);
+
+    private static WowGuid128 Creature(uint entry, ulong counter) =>
+        WowGuid128.Create(HighGuidType703.Creature, 0, entry, counter);
+
+    private static List<WowGuid128> Order(params WowGuid128[] guids) =>
+        TransportCreateOrdering.TransportsFirst(guids.ToList(), g => g);
+
+    [Fact]
+    public void TransportIsHoistedAheadOfThePlayerRidingIt()
+    {
+        var player = Player(1);
+        var ship = Transport(6);
+
+        var ordered = Order(player, ship);
+
+        Assert.Equal(ship, ordered[0]);
+        Assert.Equal(player, ordered[1]);
+    }
+
+    [Fact]
+    public void RelativeOrderOfNonTransportsIsPreserved()
+    {
+        var a = Creature(100, 1);
+        var b = Creature(200, 2);
+        var ship = Transport(6);
+        var c = Creature(300, 3);
+
+        var ordered = Order(a, b, ship, c);
+
+        Assert.Equal(ship, ordered[0]);
+        Assert.Equal(new[] { a, b, c }, ordered.Skip(1));
+    }
+
+    [Fact]
+    public void MultipleTransportsKeepTheirRelativeOrder()
+    {
+        var first = Transport(6);
+        var second = Transport(11);
+        var player = Player(1);
+
+        var ordered = Order(first, player, second);
+
+        Assert.Equal(new[] { first, second, player }, ordered);
+    }
+
+    [Fact]
+    public void ListWithoutTransportsIsUnchanged()
+    {
+        var a = Creature(100, 1);
+        var b = Creature(200, 2);
+
+        Assert.Equal(new[] { a, b }, Order(a, b));
+    }
+
+    [Fact]
+    public void ListOfOnlyTransportsIsUnchanged()
+    {
+        var a = Transport(6);
+        var b = Transport(11);
+
+        Assert.Equal(new[] { a, b }, Order(a, b));
+    }
+
+    [Fact]
+    public void CountsTransportsInTheBatch()
+    {
+        var batch = new List<WowGuid128> { Player(1), Transport(6), Creature(100, 2), Transport(11) };
+
+        Assert.Equal(2, TransportCreateOrdering.CountTransports(batch, g => g));
+    }
+}

--- a/HermesProxy.Tests/World/TransportGuidTests.cs
+++ b/HermesProxy.Tests/World/TransportGuidTests.cs
@@ -1,0 +1,60 @@
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class TransportGuidTests
+{
+    // The legacy server numbers its Transport and MOTransport spawn tables independently
+    // and embeds no entry in either guid, so the same counter shows up in both.
+    [Fact]
+    public void SameCounter_TransportAndMoTransport_ProduceDifferentModernGuids()
+    {
+        var elevator = new WowGuid64(HighGuidTypeLegacy.Transport, 0, 6);
+        var zeppelin = new WowGuid64(HighGuidTypeLegacy.MOTransport, 6);
+
+        var modernElevator = WowGuid128.Create(elevator, null!);
+        var modernZeppelin = WowGuid128.Create(zeppelin, null!);
+
+        Assert.NotEqual(modernElevator, modernZeppelin);
+    }
+
+    [Theory]
+    [InlineData(1u)]
+    [InlineData(6u)]
+    [InlineData(20u)]
+    public void MoTransportGuid_RoundTripsBackToMoTransport(uint counter)
+    {
+        var legacy = new WowGuid64(HighGuidTypeLegacy.MOTransport, counter);
+
+        var modern = WowGuid128.Create(legacy, null!);
+        var back = WowGuid64.Create(modern);
+
+        Assert.Equal(HighGuidTypeLegacy.MOTransport, back.GetHighGuidTypeLegacy());
+        Assert.Equal(counter, (uint)back.GetCounter());
+    }
+
+    [Theory]
+    [InlineData(1u)]
+    [InlineData(6u)]
+    public void TransportGuid_RoundTripsBackToTransport(uint counter)
+    {
+        var legacy = new WowGuid64(HighGuidTypeLegacy.Transport, 0, counter);
+
+        var modern = WowGuid128.Create(legacy, null!);
+        var back = WowGuid64.Create(modern);
+
+        Assert.Equal(HighGuidTypeLegacy.Transport, back.GetHighGuidTypeLegacy());
+        Assert.Equal(counter, (uint)back.GetCounter());
+    }
+
+    [Fact]
+    public void BothTransportKinds_StillDecodeAsTransportOnTheModernSide()
+    {
+        var zeppelin = WowGuid128.Create(new WowGuid64(HighGuidTypeLegacy.MOTransport, 6), null!);
+
+        Assert.Equal(HighGuidType.Transport, zeppelin.GetHighType());
+        Assert.True(zeppelin.IsTransport());
+    }
+}

--- a/HermesProxy/Configuration/Options/DiagnosticsOptions.cs
+++ b/HermesProxy/Configuration/Options/DiagnosticsOptions.cs
@@ -9,12 +9,11 @@ public sealed class DiagnosticsOptions
     public bool EnableVersionCheck { get; set; } = true;
 
     /// <summary>
-    /// Forward legacy TRANSPORT (gameobject type 11: elevators, subway cars, ICC sleds)
-    /// CreateObjects to a V3_4_3 client instead of filtering them. Off by default: the
-    /// filter was added because these creates caused a CMSG_OBJECT_UPDATE_FAILED retry
-    /// loop that blocked the loading screen. MO_TRANSPORT (type 15: zeppelins, boats) is
-    /// never forwarded regardless, since those entries are absent from the client's
-    /// TransportAnimation data. See upstream issue #96.
+    /// Forward legacy transport CreateObjects to a V3_4_3 client instead of filtering
+    /// them — both TRANSPORT (type 11: elevators, subway cars, ICC sleds) and
+    /// MO_TRANSPORT (type 15: zeppelins, boats). Off by default: the filter was added
+    /// because creates with a placeholder position caused a CMSG_OBJECT_UPDATE_FAILED
+    /// retry loop that blocked the loading screen. See upstream issue #96.
     /// </summary>
     public bool ForwardTransportsV343 { get; set; }
 }

--- a/HermesProxy/Configuration/Options/DiagnosticsOptions.cs
+++ b/HermesProxy/Configuration/Options/DiagnosticsOptions.cs
@@ -1,4 +1,4 @@
-namespace HermesProxy.Configuration.Options;
+﻿namespace HermesProxy.Configuration.Options;
 
 public sealed class DiagnosticsOptions
 {
@@ -7,4 +7,14 @@ public sealed class DiagnosticsOptions
     public bool EnableMetrics { get; set; }
 
     public bool EnableVersionCheck { get; set; } = true;
+
+    /// <summary>
+    /// Forward legacy TRANSPORT (gameobject type 11: elevators, subway cars, ICC sleds)
+    /// CreateObjects to a V3_4_3 client instead of filtering them. Off by default: the
+    /// filter was added because these creates caused a CMSG_OBJECT_UPDATE_FAILED retry
+    /// loop that blocked the loading screen. MO_TRANSPORT (type 15: zeppelins, boats) is
+    /// never forwarded regardless, since those entries are absent from the client's
+    /// TransportAnimation data. See upstream issue #96.
+    /// </summary>
+    public bool ForwardTransportsV343 { get; set; }
 }

--- a/HermesProxy/Configuration/Options/DiagnosticsOptions.cs
+++ b/HermesProxy/Configuration/Options/DiagnosticsOptions.cs
@@ -11,9 +11,10 @@ public sealed class DiagnosticsOptions
     /// <summary>
     /// Forward legacy transport CreateObjects to a V3_4_3 client instead of filtering
     /// them — both TRANSPORT (type 11: elevators, subway cars, ICC sleds) and
-    /// MO_TRANSPORT (type 15: zeppelins, boats). Off by default: the filter was added
-    /// because creates with a placeholder position caused a CMSG_OBJECT_UPDATE_FAILED
-    /// retry loop that blocked the loading screen. See upstream issue #96.
+    /// MO_TRANSPORT (type 15: zeppelins, boats). See upstream issue #96.
+    /// Creates carrying a placeholder position are still filtered regardless, which is
+    /// what the original blanket filter was protecting against. Set to false to restore
+    /// the old behaviour of hiding transports entirely.
     /// </summary>
-    public bool ForwardTransportsV343 { get; set; }
+    public bool ForwardTransportsV343 { get; set; } = true;
 }

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -129,6 +129,11 @@ public sealed class GameSessionData
     public uint CurrentTaxiNode;
     public List<byte> UsableTaxiNodes = [];
     public uint PendingTransferMapId;
+
+    // Non-zero while a pending map change is being driven by a transport the player is
+    // standing on. The legacy SMSG_NEW_WORLD that follows carries a transport-relative
+    // offset instead of an absolute position, so the position needs different handling.
+    public uint TransferPendingShipEntry;
     public uint LastEnteredAreaTrigger;
     public uint LastDispellSpellId;
     public string LeftChannelName = "";

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -166,7 +166,7 @@ public partial class WorldClient
             };
             GetSession().GameState.TransferPendingShipEntry = transfer.Ship.Id;
             Log.Print(LogType.Trace,
-                $"[TransportRide] SMSG_TRANSFER_PENDING on transport entry={transfer.Ship.Id} " +
+                $"[Transport] SMSG_TRANSFER_PENDING on transport entry={transfer.Ship.Id} " +
                 $"fromMap={transfer.Ship.OriginMapID} toMap={transfer.MapID}");
         }
         else

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -152,6 +152,26 @@ public partial class WorldClient
         TransferPending transfer = new TransferPending();
         transfer.MapID = GetSession().GameState.PendingTransferMapId = packet.ReadUInt32();
         transfer.OldMapPosition = Vector3.Zero;
+
+        // A map change driven by a transport carries the transport's entry and the map it
+        // is leaving (AzerothCore Player.cpp:1609-1613). Without it the modern client
+        // treats this as an ordinary teleport, so it detaches the player from the deck and
+        // they arrive in freefall.
+        if (packet.CanRead(8))
+        {
+            transfer.Ship = new TransferPending.ShipTransferPending
+            {
+                Id = packet.ReadUInt32(),
+                OriginMapID = packet.ReadInt32(),
+            };
+            GetSession().GameState.TransferPendingShipEntry = transfer.Ship.Id;
+            Log.Print(LogType.Trace,
+                $"[TransportRide] SMSG_TRANSFER_PENDING on transport entry={transfer.Ship.Id} " +
+                $"fromMap={transfer.Ship.OriginMapID} toMap={transfer.MapID}");
+        }
+        else
+            GetSession().GameState.TransferPendingShipEntry = 0;
+
         SendPacketToClient(transfer);
         GetSession().GameState.IsFirstEnterWorld = false;
         GetSession().GameState.IsWaitingForNewWorld = true;

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -231,12 +231,17 @@ public partial class WorldClient
 
                 if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
                     SendPacketToClient(new TimeSyncRequest());
-
-                ResumeToken resume = new();
-                resume.SequenceIndex = 3;
-                resume.Reason = 1;
-                SendPacketToClient(resume);
             }
+
+            // HandleTransferPending sends a SuspendToken for every transfer, so the resume
+            // has to be unconditional or the client stays suspended. It used to be nested
+            // in the MapID > 1 branch, which left the two continents unbalanced: riding a
+            // zeppelin to Northrend (571) arrived fine while the return trip to Tirisfal
+            // (0), and Orgrimmar (1), dropped the player through the deck on arrival.
+            ResumeToken resume = new();
+            resume.SequenceIndex = 3;
+            resume.Reason = 1;
+            SendPacketToClient(resume);
 
             WorldServerInfo info = new();
             if (teleport.MapID > 1)

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -67,6 +67,29 @@ public partial class WorldClient
         return true;
     }
 
+    // The modern client never sends CMSG_QUERY_GAME_OBJECT for a transport it is merely
+    // looking at, so it never learns gameobject_template.Data0 — the taxi path id a
+    // MO_TRANSPORT flies along. Ask the legacy server ourselves the first time we forward
+    // one; SMSG_QUERY_GAME_OBJECT_RESPONSE is relayed to the client unconditionally.
+    private static readonly HashSet<uint> _queriedTransportTemplates = [];
+
+    private void RequestTransportTemplate(uint entry)
+    {
+        if (entry == 0)
+            return;
+        lock (_queriedTransportTemplates)
+        {
+            if (!_queriedTransportTemplates.Add(entry))
+                return;
+        }
+
+        var query = new WorldPacket(Opcode.CMSG_QUERY_GAME_OBJECT);
+        query.WriteUInt32(entry);
+        query.WriteGuid(new WowGuid64(HighGuidTypeLegacy.GameObject, entry, 1));
+        SendPacketToServer(query);
+        Log.Print(LogType.Trace, $"[TransportTrace] requested gameobject template for transport entry={entry}");
+    }
+
     void HandleUpdateObject(WorldPacket packet)
     {
         var count = packet.ReadUInt32();
@@ -252,6 +275,8 @@ public partial class WorldClient
                                 legacyHigh == HighGuidTypeLegacy.MOTransport)
                             {
                                 filtered = !MayForwardTransport(legacyHigh, updateData);
+                                if (!filtered && legacyHigh == HighGuidTypeLegacy.MOTransport)
+                                    RequestTransportTemplate((uint)(updateData.ObjectData.EntryID ?? 0));
                                 Log.Print(LogType.Trace,
                                     $"{(filtered ? "Skipping" : "Forwarding")} {legacyHigh} for V3_4_3 guid={guid} entryID={updateData.ObjectData.EntryID?.ToString() ?? "null"}.");
                             }
@@ -314,6 +339,8 @@ public partial class WorldClient
                                 legacyHigh == HighGuidTypeLegacy.MOTransport)
                             {
                                 filtered = !MayForwardTransport(legacyHigh, updateData);
+                                if (!filtered && legacyHigh == HighGuidTypeLegacy.MOTransport)
+                                    RequestTransportTemplate((uint)(updateData.ObjectData.EntryID ?? 0));
                                 Log.Print(LogType.Trace,
                                     $"{(filtered ? "Skipping" : "Forwarding")} CreateObject2 for {legacyHigh} for V3_4_3 guid={guid} entryID={updateData.ObjectData.EntryID?.ToString() ?? "null"}.");
                             }

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -3812,13 +3812,19 @@ public partial class WorldClient
                     oldDynSource = stripHighBits ? "v343NoSeed" : "transport0";
                 }
 
-                GameObjectDynamicFlagsLegacy flags = (GameObjectDynamicFlagsLegacy)effectiveLegacyRaw;
+                // CastFlags remaps by enum name, so anything outside the named low-16
+                // bitmask is dropped. For a transport the high 16 bits are the path
+                // progress fraction the client animates from (AzerothCore
+                // GameObject.cpp:2835-2838 writes uint16 dynFlags then int16 pathProgress),
+                // so carry them across verbatim instead of losing them to the remap.
+                GameObjectDynamicFlagsLegacy flags = (GameObjectDynamicFlagsLegacy)(effectiveLegacyRaw & 0x0000FFFFu);
                 uint newLow = (uint)flags.CastFlags<GameObjectDynamicFlagsModern>();
-                updateData.ObjectData.DynamicFlags = (oldValue | newLow);
+                uint preservedHigh = guid.IsTransport() ? (effectiveLegacyRaw & 0xFFFF0000u) : 0u;
+                updateData.ObjectData.DynamicFlags = (oldValue | preservedHigh | newLow);
                 Log.Print(LogType.Trace,
                     $"[Trace][GO DYN_FLAGS] guid={guid} entry={updateData.ObjectData.EntryID} " +
                     $"legacyRaw=0x{legacyRaw:X8} effective=0x{effectiveLegacyRaw:X8} ({flags}) " +
-                    $"-> modernLow=0x{newLow:X8}, oldDyn=0x{oldValue:X8} oldDynSource={oldDynSource}, finalDyn=0x{updateData.ObjectData.DynamicFlags.Value:X8}");
+                    $"-> modernLow=0x{newLow:X8} high=0x{preservedHigh:X8}, oldDyn=0x{oldValue:X8} oldDynSource={oldDynSource}, finalDyn=0x{updateData.ObjectData.DynamicFlags.Value:X8}");
             }
             int GAMEOBJECT_FACTION = LegacyVersion.GetUpdateField(GameObjectField.GAMEOBJECT_FACTION);
             if (GAMEOBJECT_FACTION >= 0 && updateMaskArray[GAMEOBJECT_FACTION])

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -648,6 +648,19 @@ public partial class WorldClient
         // remaining Values reach the client.
         if (createsToSplit != null)
         {
+            // Transports have to be created before anything standing on them. The legacy
+            // batch orders the player ahead of the transport it is riding, which is fine
+            // in one envelope but not once the split turns it into separate packets: the
+            // client got "this player is on transport X" before it had X, dropped the
+            // attachment, and the player fell through the deck on arriving in a new map.
+            // Transports reference nothing themselves, so hoisting them is safe.
+            int transportCreates = TransportCreateOrdering.CountTransports(createsToSplit, u => u.Guid);
+            createsToSplit = TransportCreateOrdering.TransportsFirst(createsToSplit, u => u.Guid);
+
+            if (transportCreates != 0)
+                Log.Print(LogType.Trace,
+                    $"[UpdateObjectTrace] V3_4_3 CreateObject split: hoisted {transportCreates} transport create(s) ahead of {createsToSplit.Count - transportCreates} other create(s)");
+
             foreach (var create in createsToSplit)
             {
                 UpdateObject perCreate = new UpdateObject(GetSession().GameState);
@@ -807,6 +820,8 @@ public partial class WorldClient
                 SendPacketToClient(updateObject2);
 
             }
+            if (guid.IsTransport())
+                Log.Print(LogType.Trace, $"[TransportRide] destroy (out of range) for transport {guid}");
             updateObject.OutOfRangeGuids.Add(guid);
         }
     }
@@ -1512,6 +1527,14 @@ public partial class WorldClient
             var rotation = packet.ReadPackedQuaternion();
             if (moveInfo != null)
                 moveInfo.Rotation = rotation;
+        }
+
+        if (updateData != null && moveInfo != null
+            && guid == GetSession().GameState.CurrentPlayerGuid)
+        {
+            Log.Print(LogType.Trace,
+                $"[TransportRide] own movement block: transport={(moveInfo.TransportGuid == default ? "none" : moveInfo.TransportGuid.ToString())} " +
+                $"pos=({moveInfo.Position.X:F1},{moveInfo.Position.Y:F1},{moveInfo.Position.Z:F1})");
         }
 
         if (updateData != null && moveInfo != null)

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -42,6 +42,24 @@ public partial class WorldClient
     }
 
     [PacketHandler(Opcode.SMSG_UPDATE_OBJECT)]
+    /// <summary>
+    /// Whether a legacy transport CreateObject may reach a V3_4_3 client.
+    /// Legacy TRANSPORT (gameobject type 11: elevators, subway cars, ICC sleds) keeps its
+    /// entry ID in the 3.4.3 client's TransportAnimation data (verified: all 11 entries seen
+    /// in Undercity, 20649-20657 / 149045 / 149046, are present under their unchanged legacy
+    /// IDs), so those are forwardable behind the opt-in toggle. MO_TRANSPORT (type 15:
+    /// zeppelins, boats) is never forwardable: no type 15 entry appears in TransportAnimation
+    /// in either the 3.3.5a or the 3.4.3 client, because that category is driven by
+    /// gameobject_template.Data0 taxi paths instead. Upstream issue #96.
+    /// </summary>
+    private bool MayForwardTransport(HighGuidTypeLegacy legacyHigh)
+    {
+        if (legacyHigh == HighGuidTypeLegacy.MOTransport)
+            return false;
+
+        return GetSession().DiagnosticsOptions.ForwardTransportsV343;
+    }
+
     void HandleUpdateObject(WorldPacket packet)
     {
         var count = packet.ReadUInt32();
@@ -226,9 +244,9 @@ public partial class WorldClient
                             if (legacyHigh == HighGuidTypeLegacy.Transport ||
                                 legacyHigh == HighGuidTypeLegacy.MOTransport)
                             {
+                                filtered = !MayForwardTransport(legacyHigh);
                                 Log.Print(LogType.Trace,
-                                    $"Skipping {legacyHigh} for V3_4_3 (Position=0 placeholder; pending MOTransport position fix) guid={guid} entryID={updateData.ObjectData.EntryID?.ToString() ?? "null"}.");
-                                filtered = true;
+                                    $"{(filtered ? "Skipping" : "Forwarding")} {legacyHigh} for V3_4_3 guid={guid} entryID={updateData.ObjectData.EntryID?.ToString() ?? "null"}.");
                             }
                             else if (legacyHigh == HighGuidTypeLegacy.GameObject)
                             {
@@ -288,9 +306,9 @@ public partial class WorldClient
                             if (legacyHigh == HighGuidTypeLegacy.Transport ||
                                 legacyHigh == HighGuidTypeLegacy.MOTransport)
                             {
+                                filtered = !MayForwardTransport(legacyHigh);
                                 Log.Print(LogType.Trace,
-                                    $"Skipping CreateObject2 for {legacyHigh} for V3_4_3 (Position=0 placeholder; pending MOTransport position fix) guid={guid} entryID={updateData.ObjectData.EntryID?.ToString() ?? "null"}.");
-                                filtered = true;
+                                    $"{(filtered ? "Skipping" : "Forwarding")} CreateObject2 for {legacyHigh} for V3_4_3 guid={guid} entryID={updateData.ObjectData.EntryID?.ToString() ?? "null"}.");
                             }
                             else if (legacyHigh == HighGuidTypeLegacy.GameObject)
                             {

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -43,20 +43,13 @@ public partial class WorldClient
 
     [PacketHandler(Opcode.SMSG_UPDATE_OBJECT)]
     /// <summary>
-    /// Whether a legacy transport CreateObject may reach a V3_4_3 client.
-    /// Legacy TRANSPORT (gameobject type 11: elevators, subway cars, ICC sleds) keeps its
-    /// entry ID in the 3.4.3 client's TransportAnimation data (verified: all 11 entries seen
-    /// in Undercity, 20649-20657 / 149045 / 149046, are present under their unchanged legacy
-    /// IDs), so those are forwardable behind the opt-in toggle. MO_TRANSPORT (type 15:
-    /// zeppelins, boats) is never forwardable: no type 15 entry appears in TransportAnimation
-    /// in either the 3.3.5a or the 3.4.3 client, because that category is driven by
-    /// gameobject_template.Data0 taxi paths instead. Upstream issue #96.
+    /// Whether a legacy transport CreateObject may reach a V3_4_3 client. Covers both
+    /// legacy TRANSPORT (gameobject type 11: elevators, subway cars, ICC sleds) and
+    /// MO_TRANSPORT (type 15: zeppelins, boats). The V1_14 and V2_5 targets forward both
+    /// unconditionally; this filter exists only on the V3_4_3 path. Upstream issue #96.
     /// </summary>
     private bool MayForwardTransport(HighGuidTypeLegacy legacyHigh, ObjectUpdate updateData)
     {
-        if (legacyHigh == HighGuidTypeLegacy.MOTransport)
-            return false;
-
         if (!GetSession().DiagnosticsOptions.ForwardTransportsV343)
             return false;
 

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -382,7 +382,14 @@ public partial class WorldClient
             }
         }
 
+        // Destroys still have to reach the client mid-transfer. A transport that does not
+        // follow the player to the new map is destroyed by a batch carrying nothing but
+        // out-of-range guids (AzerothCore MovementHandler.cpp:132-138, "Client was never
+        // told to destroy its own transport / Destroy it now or it keeps a phantom copy of
+        // the transport on the new map") — swallowing it strands a ghost zeppelin.
         if (updateObject.ObjectUpdates.Count == 0 &&
+            updateObject.OutOfRangeGuids.Count == 0 &&
+            updateObject.DestroyedGuids.Count == 0 &&
             GetSession().GameState.IsWaitingForNewWorld)
             return;
 

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -52,12 +52,26 @@ public partial class WorldClient
     /// in either the 3.3.5a or the 3.4.3 client, because that category is driven by
     /// gameobject_template.Data0 taxi paths instead. Upstream issue #96.
     /// </summary>
-    private bool MayForwardTransport(HighGuidTypeLegacy legacyHigh)
+    private bool MayForwardTransport(HighGuidTypeLegacy legacyHigh, ObjectUpdate updateData)
     {
         if (legacyHigh == HighGuidTypeLegacy.MOTransport)
             return false;
 
-        return GetSession().DiagnosticsOptions.ForwardTransportsV343;
+        if (!GetSession().DiagnosticsOptions.ForwardTransportsV343)
+            return false;
+
+        // Gate on the condition the filter was actually written for. cMangos sends these
+        // creates with Position=(0,0,0) and defers the real position to GAMEOBJECT_POS_*
+        // deltas, and the client rejects a stationary GameObject at the origin with
+        // CMSG_OBJECT_UPDATE_FAILED, retrying forever and never finishing the loading
+        // screen. TrinityCore and AzerothCore use spawn-data position, so their creates
+        // carry a usable one. Testing the position rather than the backend keeps a
+        // placeholder create filtered wherever it comes from.
+        var position = updateData.CreateData?.MoveInfo?.Position;
+        if (position == null || (position.Value.X == 0f && position.Value.Y == 0f && position.Value.Z == 0f))
+            return false;
+
+        return true;
     }
 
     void HandleUpdateObject(WorldPacket packet)
@@ -244,7 +258,7 @@ public partial class WorldClient
                             if (legacyHigh == HighGuidTypeLegacy.Transport ||
                                 legacyHigh == HighGuidTypeLegacy.MOTransport)
                             {
-                                filtered = !MayForwardTransport(legacyHigh);
+                                filtered = !MayForwardTransport(legacyHigh, updateData);
                                 Log.Print(LogType.Trace,
                                     $"{(filtered ? "Skipping" : "Forwarding")} {legacyHigh} for V3_4_3 guid={guid} entryID={updateData.ObjectData.EntryID?.ToString() ?? "null"}.");
                             }
@@ -306,7 +320,7 @@ public partial class WorldClient
                             if (legacyHigh == HighGuidTypeLegacy.Transport ||
                                 legacyHigh == HighGuidTypeLegacy.MOTransport)
                             {
-                                filtered = !MayForwardTransport(legacyHigh);
+                                filtered = !MayForwardTransport(legacyHigh, updateData);
                                 Log.Print(LogType.Trace,
                                     $"{(filtered ? "Skipping" : "Forwarding")} CreateObject2 for {legacyHigh} for V3_4_3 guid={guid} entryID={updateData.ObjectData.EntryID?.ToString() ?? "null"}.");
                             }

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -41,7 +41,6 @@ public partial class WorldClient
         }
     }
 
-    [PacketHandler(Opcode.SMSG_UPDATE_OBJECT)]
     /// <summary>
     /// Whether a legacy transport CreateObject may reach a V3_4_3 client. Covers both
     /// legacy TRANSPORT (gameobject type 11: elevators, subway cars, ICC sleds) and
@@ -90,6 +89,7 @@ public partial class WorldClient
         Log.Print(LogType.Trace, $"[TransportTrace] requested gameobject template for transport entry={entry}");
     }
 
+    [PacketHandler(Opcode.SMSG_UPDATE_OBJECT)]
     void HandleUpdateObject(WorldPacket packet)
     {
         var count = packet.ReadUInt32();

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -86,7 +86,7 @@ public partial class WorldClient
         query.WriteUInt32(entry);
         query.WriteGuid(new WowGuid64(HighGuidTypeLegacy.GameObject, entry, 1));
         SendPacketToServer(query);
-        Log.Print(LogType.Trace, $"[TransportTrace] requested gameobject template for transport entry={entry}");
+        Log.Print(LogType.Trace, $"[Transport] requested gameobject template for transport entry={entry}");
     }
 
     [PacketHandler(Opcode.SMSG_UPDATE_OBJECT)]
@@ -821,7 +821,7 @@ public partial class WorldClient
 
             }
             if (guid.IsTransport())
-                Log.Print(LogType.Trace, $"[TransportRide] destroy (out of range) for transport {guid}");
+                Log.Print(LogType.Trace, $"[Transport] destroy (out of range) for transport {guid}");
             updateObject.OutOfRangeGuids.Add(guid);
         }
     }
@@ -1529,12 +1529,14 @@ public partial class WorldClient
                 moveInfo.Rotation = rotation;
         }
 
-        if (updateData != null && moveInfo != null
-            && guid == GetSession().GameState.CurrentPlayerGuid)
+        // Only when the object claims to be riding something — this is the state that
+        // decides whether a passenger ends up on the deck or on the ground.
+        if (updateData != null && moveInfo != null && moveInfo.TransportGuid != default)
         {
             Log.Print(LogType.Trace,
-                $"[TransportRide] own movement block: transport={(moveInfo.TransportGuid == default ? "none" : moveInfo.TransportGuid.ToString())} " +
-                $"pos=({moveInfo.Position.X:F1},{moveInfo.Position.Y:F1},{moveInfo.Position.Z:F1})");
+                $"[Transport] passenger create: guid={guid} transport={moveInfo.TransportGuid} " +
+                $"clientKnowsTransport={GetSession().GameState.ClientKnownGuids.Contains(moveInfo.TransportGuid)} " +
+                $"offset=({moveInfo.TransportOffset.X:F2},{moveInfo.TransportOffset.Y:F2},{moveInfo.TransportOffset.Z:F2}) seat={moveInfo.TransportSeat}");
         }
 
         if (updateData != null && moveInfo != null)

--- a/HermesProxy/World/Enums/GameObjectTypeModern.cs
+++ b/HermesProxy/World/Enums/GameObjectTypeModern.cs
@@ -1,0 +1,11 @@
+namespace HermesProxy.World.Enums;
+
+/// <summary>
+/// gameobject_template.type, identical across 3.3.5a and 3.4.3. Only the values the
+/// proxy actually branches on are listed.
+/// </summary>
+public enum GameObjectTypeModern : sbyte
+{
+    Transport = 11,
+    MOTransport = 15,
+}

--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -224,10 +224,14 @@ public partial class ObjectUpdateBuilder
 
         if (Has(CreateObjectBits.ServerTime))
         {
-            // TC343 writes GameTime::GetGameTimeMS() = server uptime in ms.
-            // Legacy 3.3.5a sends PathProgress (transport-specific counter), NOT game time.
-            // The 3.4.3 client expects server uptime for transport animation sync.
-            data.WriteUInt32((uint)Environment.TickCount);
+            // Legacy UPDATEFLAG_TRANSPORT carries Transport::GetPathProgress() — how far
+            // into its loop the transport is, in ms (AzerothCore Object.cpp:463-469). The
+            // client interpolates its own animation from that offset, so forwarding it is
+            // what keeps every client seeing the boat in the same place. Matches the V1_14
+            // and V2_5 builders. Only fall back to a local clock when the legacy server
+            // sent nothing (non-transport objects that still set the bit).
+            var pathProgress = _updateData.CreateData.MoveInfo.TransportPathTimer;
+            data.WriteUInt32(pathProgress != 0 ? pathProgress : (uint)Environment.TickCount);
         }
 
         if (Has(CreateObjectBits.Vehicle))

--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -147,6 +147,10 @@ public partial class ObjectUpdateBuilder
             _createBits |= CreateObjectBits.Vehicle;
         if (hasMoveInfo && _objectType == ObjectTypeBCC.GameObject)
             _createBits |= CreateObjectBits.Rotation;
+        // MO_TRANSPORT only. Ordinary gameobjects still must not set this (see below);
+        // a zeppelin without the block has no period/offset to animate from.
+        if (_updateData.GameObjectData?.TypeID == (sbyte)GameObjectTypeModern.MOTransport)
+            _createBits |= CreateObjectBits.GameObject;
         // CreateObjectBits.GameObject is NOT set unconditionally here — empirical
         // capture vs CypherCore (canonical V3_4_3 server) shows the bit must stay
         // false for typical GameObjects (transports, mailboxes, doodads). It writes
@@ -258,9 +262,42 @@ public partial class ObjectUpdateBuilder
 
         if (Has(CreateObjectBits.GameObject))
         {
-            data.WriteUInt32(0u);
-            data.WriteBit(false);
+            // TC343 Object::BuildMovementUpdate: WorldEffectID, then three bits
+            // (bit8, isTransport, hasPathProgress), then the transport sub-block.
+            // Only MO_TRANSPORT sets isTransport; type 11 rides on hasPathProgress,
+            // which the legacy server gives us no value for.
+            const bool bit8 = false;
+            bool isTransport = _updateData.GameObjectData?.TypeID == (sbyte)GameObjectTypeModern.MOTransport;
+
+            data.WriteUInt32(0u);                                  // WorldEffectID
+            data.WriteBit(bit8);
+            data.WriteBit(isTransport);
+            data.WriteBit(false);                                  // has PathProgress
             data.FlushBits();
+
+            if (isTransport)
+            {
+                uint period = (uint)(_updateData.GameObjectData!.Level ?? 0);
+                uint timeOffset = 0;
+                if (period != 0)
+                {
+                    // The client reconstructs the loop phase as (serverTime + TimeOffset)
+                    // mod period, so TimeOffset has to be expressed against the same clock
+                    // the ServerTime field carries.
+                    long delta = (long)_updateData.CreateData.MoveInfo.TransportPathTimer - (long)(uint)Environment.TickCount;
+                    timeOffset = (uint)(((delta % period) + period) % period);
+                }
+
+                // GO_STATE_READY on a moving transport means it is docked.
+                bool isStopped = _updateData.GameObjectData?.State == 1;
+
+                data.WriteUInt32(timeOffset);
+                data.WriteUInt32(0u);                              // NextStopTimestamp
+                data.WriteBit(false);                              // has NextStopTimestamp
+                data.WriteBit(isStopped);
+                data.WriteBit(false);
+                data.FlushBits();
+            }
         }
 
         if (Has(CreateObjectBits.ActivePlayer))

--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -147,10 +147,6 @@ public partial class ObjectUpdateBuilder
             _createBits |= CreateObjectBits.Vehicle;
         if (hasMoveInfo && _objectType == ObjectTypeBCC.GameObject)
             _createBits |= CreateObjectBits.Rotation;
-        // MO_TRANSPORT only. Ordinary gameobjects still must not set this (see below);
-        // a zeppelin without the block has no period/offset to animate from.
-        if (_updateData.GameObjectData?.TypeID == (sbyte)GameObjectTypeModern.MOTransport)
-            _createBits |= CreateObjectBits.GameObject;
         // CreateObjectBits.GameObject is NOT set unconditionally here — empirical
         // capture vs CypherCore (canonical V3_4_3 server) shows the bit must stay
         // false for typical GameObjects (transports, mailboxes, doodads). It writes
@@ -262,42 +258,9 @@ public partial class ObjectUpdateBuilder
 
         if (Has(CreateObjectBits.GameObject))
         {
-            // TC343 Object::BuildMovementUpdate: WorldEffectID, then three bits
-            // (bit8, isTransport, hasPathProgress), then the transport sub-block.
-            // Only MO_TRANSPORT sets isTransport; type 11 rides on hasPathProgress,
-            // which the legacy server gives us no value for.
-            const bool bit8 = false;
-            bool isTransport = _updateData.GameObjectData?.TypeID == (sbyte)GameObjectTypeModern.MOTransport;
-
-            data.WriteUInt32(0u);                                  // WorldEffectID
-            data.WriteBit(bit8);
-            data.WriteBit(isTransport);
-            data.WriteBit(false);                                  // has PathProgress
+            data.WriteUInt32(0u);
+            data.WriteBit(false);
             data.FlushBits();
-
-            if (isTransport)
-            {
-                uint period = (uint)(_updateData.GameObjectData!.Level ?? 0);
-                uint timeOffset = 0;
-                if (period != 0)
-                {
-                    // The client reconstructs the loop phase as (serverTime + TimeOffset)
-                    // mod period, so TimeOffset has to be expressed against the same clock
-                    // the ServerTime field carries.
-                    long delta = (long)_updateData.CreateData.MoveInfo.TransportPathTimer - (long)(uint)Environment.TickCount;
-                    timeOffset = (uint)(((delta % period) + period) % period);
-                }
-
-                // GO_STATE_READY on a moving transport means it is docked.
-                bool isStopped = _updateData.GameObjectData?.State == 1;
-
-                data.WriteUInt32(timeOffset);
-                data.WriteUInt32(0u);                              // NextStopTimestamp
-                data.WriteBit(false);                              // has NextStopTimestamp
-                data.WriteBit(isStopped);
-                data.WriteBit(false);
-                data.FlushBits();
-            }
         }
 
         if (Has(CreateObjectBits.ActivePlayer))

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -56,14 +56,6 @@ public partial class WorldSocket
         movement.MoveInfo.WriteMovementInfoLegacy(packet);
         SendPacketToServer(packet);
 
-        if (movement.MoveInfo.TransportGuid != default)
-        {
-            Log.Print(LogType.Trace,
-                $"[TransportRide] {opcodeName} modernTransport={movement.MoveInfo.TransportGuid} " +
-                $"legacyTransport={movement.MoveInfo.TransportGuid.To64()} " +
-                $"offset=({movement.MoveInfo.TransportOffset.X:F2},{movement.MoveInfo.TransportOffset.Y:F2},{movement.MoveInfo.TransportOffset.Z:F2}) " +
-                $"seat={movement.MoveInfo.TransportSeat} time={movement.MoveInfo.TransportTime}");
-        }
 
         CheckLegacyAreaTriggerProximity(movement.MoveInfo.Position);
     }
@@ -132,9 +124,6 @@ public partial class WorldSocket
         GetSession().GameState.IsWaitingForWorldPortAck = false;
         WorldPacket packet = new WorldPacket(Opcode.MSG_MOVE_WORLDPORT_ACK);
         SendPacketToServer(packet);
-        Log.Print(LogType.Trace,
-            $"[TransportRide] MSG_MOVE_WORLDPORT_ACK sent, map={GetSession().GameState.CurrentMapId} " +
-            $"shipEntry={GetSession().GameState.TransferPendingShipEntry}");
     }
 
     [PacketHandler(Opcode.CMSG_MOVE_FORCE_FLIGHT_BACK_SPEED_CHANGE_ACK)]

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -132,6 +132,9 @@ public partial class WorldSocket
         GetSession().GameState.IsWaitingForWorldPortAck = false;
         WorldPacket packet = new WorldPacket(Opcode.MSG_MOVE_WORLDPORT_ACK);
         SendPacketToServer(packet);
+        Log.Print(LogType.Trace,
+            $"[TransportRide] MSG_MOVE_WORLDPORT_ACK sent, map={GetSession().GameState.CurrentMapId} " +
+            $"shipEntry={GetSession().GameState.TransferPendingShipEntry}");
     }
 
     [PacketHandler(Opcode.CMSG_MOVE_FORCE_FLIGHT_BACK_SPEED_CHANGE_ACK)]

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -56,6 +56,15 @@ public partial class WorldSocket
         movement.MoveInfo.WriteMovementInfoLegacy(packet);
         SendPacketToServer(packet);
 
+        if (movement.MoveInfo.TransportGuid != default)
+        {
+            Log.Print(LogType.Trace,
+                $"[TransportRide] {opcodeName} modernTransport={movement.MoveInfo.TransportGuid} " +
+                $"legacyTransport={movement.MoveInfo.TransportGuid.To64()} " +
+                $"offset=({movement.MoveInfo.TransportOffset.X:F2},{movement.MoveInfo.TransportOffset.Y:F2},{movement.MoveInfo.TransportOffset.Z:F2}) " +
+                $"seat={movement.MoveInfo.TransportSeat} time={movement.MoveInfo.TransportTime}");
+        }
+
         CheckLegacyAreaTriggerProximity(movement.MoveInfo.Position);
     }
 

--- a/HermesProxy/World/Server/Packets/UpdatePackets.cs
+++ b/HermesProxy/World/Server/Packets/UpdatePackets.cs
@@ -201,7 +201,7 @@ public class ObjectUpdate
                 GameObjectData.Flags = (GameObjectData.Flags ?? 0) | ModernTransportFlag;
 
                 Framework.Logging.Log.Print(Framework.Logging.LogType.Trace,
-                    $"[TransportTrace] guid={Guid} entry={ObjectData.EntryID} typeID={GameObjectData.TypeID} " +
+                    $"[Transport] guid={Guid} entry={ObjectData.EntryID} typeID={GameObjectData.TypeID} " +
                     $"pathProgress={transportTimer} period={period} level={GameObjectData.Level} " +
                     $"dynFlags=0x{(ObjectData.DynamicFlags ?? 0):X8} goFlags={GameObjectData.Flags} " +
                     $"pos=({CreateData.MoveInfo!.Position.X:F1},{CreateData.MoveInfo.Position.Y:F1},{CreateData.MoveInfo.Position.Z:F1}) " +

--- a/HermesProxy/World/Server/Packets/UpdatePackets.cs
+++ b/HermesProxy/World/Server/Packets/UpdatePackets.cs
@@ -98,9 +98,10 @@ public class ObjectUpdate
     public DynamicObjectData DynamicObjectData = null!;
     public CorpseData CorpseData = null!;
 
-    // The bit the V3_4_3 client reads as "this gameobject is a transport". Combined with
-    // the legacy GAMEOBJECT_FLAGS value (0x28 for these objects) it reproduces the 1048616
-    // composite the previous code hardcoded.
+    // GO_FLAG_MAP_OBJECT: the object is a WMO map object, i.e. a MO_TRANSPORT. No
+    // equivalent exists in the 3.3.5a flag set. Combined with the legacy GAMEOBJECT_FLAGS
+    // value (0x28 for these objects) it reproduces the 1048616 composite the previous code
+    // hardcoded for CSV-listed entries.
     private const uint ModernTransportFlag = 0x100000u;
 
     public void InitializePlaceholders()
@@ -195,10 +196,13 @@ public class ObjectUpdate
                         : ((transportTimer % System.UInt16.MaxValue) << 16);
                 }
 
-                // Marks the object as a transport for the modern client. Previously only
-                // applied to entries present in the CSV, which left every transport the
-                // CSV does not list (e.g. 181689, the Undercity zeppelin) unflagged.
-                GameObjectData.Flags = (GameObjectData.Flags ?? 0) | ModernTransportFlag;
+                // MO_TRANSPORT only. GO_FLAG_MAP_OBJECT tells the client the object is a
+                // WMO map object; setting it on a type 11 elevator, which is an M2 doodad,
+                // makes the client load it as a WMO and render an untextured placeholder.
+                // The old code reached the same conclusion by accident, gating on presence
+                // in CSV/Transports*.csv — which only ever lists type 15 entries.
+                if (GameObjectData.TypeID == (sbyte)GameObjectTypeModern.MOTransport)
+                    GameObjectData.Flags = (GameObjectData.Flags ?? 0) | ModernTransportFlag;
 
                 Framework.Logging.Log.Print(Framework.Logging.LogType.Trace,
                     $"[Transport] guid={Guid} entry={ObjectData.EntryID} typeID={GameObjectData.TypeID} " +

--- a/HermesProxy/World/Server/Packets/UpdatePackets.cs
+++ b/HermesProxy/World/Server/Packets/UpdatePackets.cs
@@ -183,6 +183,13 @@ public class ObjectUpdate
                 }
                 else if (ObjectData.DynamicFlags == null)
                     ObjectData.DynamicFlags = ((transportTimer % System.UInt16.MaxValue) << 16);
+
+                Framework.Logging.Log.Print(Framework.Logging.LogType.Trace,
+                    $"[TransportTrace] guid={Guid} entry={ObjectData.EntryID} typeID={GameObjectData.TypeID} " +
+                    $"pathProgress={transportTimer} csvPeriod={period} level={GameObjectData.Level} " +
+                    $"dynFlags=0x{(ObjectData.DynamicFlags ?? 0):X8} goFlags={GameObjectData.Flags} " +
+                    $"pos=({CreateData.MoveInfo!.Position.X:F1},{CreateData.MoveInfo.Position.Y:F1},{CreateData.MoveInfo.Position.Z:F1}) " +
+                    $"o={CreateData.MoveInfo.Orientation:F3}");
             }
         }
         if (CorpseData != null)
@@ -432,6 +439,24 @@ public class UpdateObject : ServerPacket
             if (obj.DynamicFlags.HasValue) return false;
             if (obj.EntryID.HasValue) return false;
             if (obj.Scale.HasValue) return false;
+        }
+
+        // A moving transport's Values deltas carry GAMEOBJECT_LEVEL (the path period) and
+        // nothing else once GAMEOBJECT_DYNAMIC stops changing, so without this probe the
+        // filter classified them as empty and dropped them. Same for a door or chest whose
+        // only change is GAMEOBJECT_BYTES_1 (State/ArtKit).
+        var go = u.GameObjectData;
+        if (go != null)
+        {
+            if (go.Level.HasValue || go.State.HasValue || go.TypeID.HasValue) return false;
+            if (go.DisplayID.HasValue || go.Flags.HasValue || go.ArtKit.HasValue) return false;
+            if (go.FactionTemplate.HasValue || go.PercentHealth.HasValue) return false;
+            if (go.SpellVisualID.HasValue || go.StateSpellVisualID.HasValue) return false;
+            if (go.StateAnimID.HasValue || go.StateAnimKitID.HasValue || go.CustomParam.HasValue) return false;
+            if (go.CreatedBy != null || go.GuildGUID != null) return false;
+            if (go.ParentRotation != null)
+                for (int i = 0; i < go.ParentRotation.Length; i++)
+                    if (go.ParentRotation[i].HasValue) return false;
         }
 
         var unit = u.UnitData;

--- a/HermesProxy/World/Server/Packets/UpdatePackets.cs
+++ b/HermesProxy/World/Server/Packets/UpdatePackets.cs
@@ -98,6 +98,11 @@ public class ObjectUpdate
     public DynamicObjectData DynamicObjectData = null!;
     public CorpseData CorpseData = null!;
 
+    // The bit the V3_4_3 client reads as "this gameobject is a transport". Combined with
+    // the legacy GAMEOBJECT_FLAGS value (0x28 for these objects) it reproduces the 1048616
+    // composite the previous code hardcoded.
+    private const uint ModernTransportFlag = 0x100000u;
+
     public void InitializePlaceholders()
     {
         if (CreateData == null)
@@ -172,21 +177,32 @@ public class ObjectUpdate
             if (Guid.GetHighType() == HighGuidType.Transport)
             {
                 var transportTimer = CreateData.MoveInfo!.TransportPathTimer;
-                uint period = GameData.GetTransportPeriod((uint)ObjectData.EntryID!);
-                if (period != 0)
+                // A 3.3.5a backend puts the real loop period in GAMEOBJECT_LEVEL
+                // (AzerothCore Transport.h:81), which is authoritative. The CSV is the
+                // fallback for backends that leave the field unset.
+                uint period = GameObjectData.Level is > 0
+                    ? (uint)GameObjectData.Level.Value
+                    : GameData.GetTransportPeriod((uint)ObjectData.EntryID!);
+                if (period != 0 && GameObjectData.Level == null)
+                    GameObjectData.Level = (int)period;
+
+                // Only synthesize the path-progress fraction when the backend sent none;
+                // the legacy GAMEOBJECT_DYNAMIC high half already carries it otherwise.
+                if (ObjectData.DynamicFlags == null)
                 {
-                    if (GameObjectData.Level == null)
-                        GameObjectData.Level = (int)period;
-                    if (ObjectData.DynamicFlags == null)
-                        ObjectData.DynamicFlags = (((uint)(((float)(transportTimer % period) / (float)period) * System.UInt16.MaxValue)) << 16);
-                    GameObjectData.Flags = 1048616;
+                    ObjectData.DynamicFlags = period != 0
+                        ? (((uint)(((float)(transportTimer % period) / (float)period) * System.UInt16.MaxValue)) << 16)
+                        : ((transportTimer % System.UInt16.MaxValue) << 16);
                 }
-                else if (ObjectData.DynamicFlags == null)
-                    ObjectData.DynamicFlags = ((transportTimer % System.UInt16.MaxValue) << 16);
+
+                // Marks the object as a transport for the modern client. Previously only
+                // applied to entries present in the CSV, which left every transport the
+                // CSV does not list (e.g. 181689, the Undercity zeppelin) unflagged.
+                GameObjectData.Flags = (GameObjectData.Flags ?? 0) | ModernTransportFlag;
 
                 Framework.Logging.Log.Print(Framework.Logging.LogType.Trace,
                     $"[TransportTrace] guid={Guid} entry={ObjectData.EntryID} typeID={GameObjectData.TypeID} " +
-                    $"pathProgress={transportTimer} csvPeriod={period} level={GameObjectData.Level} " +
+                    $"pathProgress={transportTimer} period={period} level={GameObjectData.Level} " +
                     $"dynFlags=0x{(ObjectData.DynamicFlags ?? 0):X8} goFlags={GameObjectData.Flags} " +
                     $"pos=({CreateData.MoveInfo!.Position.X:F1},{CreateData.MoveInfo.Position.Y:F1},{CreateData.MoveInfo.Position.Z:F1}) " +
                     $"o={CreateData.MoveInfo.Orientation:F3}");

--- a/HermesProxy/World/TransportCreateOrdering.cs
+++ b/HermesProxy/World/TransportCreateOrdering.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace HermesProxy.World;
+
+/// <summary>
+/// Ordering rule for CreateObject batches split into one packet each.
+/// </summary>
+public static class TransportCreateOrdering
+{
+    /// <summary>
+    /// Moves transport creates to the front, preserving relative order otherwise.
+    /// Anything riding a transport names it by GUID, so the client has to be given the
+    /// transport first or it drops the attachment. Transports reference nothing
+    /// themselves, so hoisting them cannot break another dependency.
+    /// </summary>
+    public static List<T> TransportsFirst<T>(List<T> creates, Func<T, WowGuid128> guidOf)
+    {
+        var ordered = new List<T>(creates.Count);
+        foreach (var item in creates)
+            if (guidOf(item).IsTransport())
+                ordered.Add(item);
+
+        int transportCount = ordered.Count;
+        if (transportCount == 0 || transportCount == creates.Count)
+            return creates;
+
+        foreach (var item in creates)
+            if (!guidOf(item).IsTransport())
+                ordered.Add(item);
+
+        return ordered;
+    }
+
+    public static int CountTransports<T>(List<T> creates, Func<T, WowGuid128> guidOf)
+    {
+        int count = 0;
+        foreach (var item in creates)
+            if (guidOf(item).IsTransport())
+                count++;
+        return count;
+    }
+}

--- a/HermesProxy/World/WowGuid128.cs
+++ b/HermesProxy/World/WowGuid128.cs
@@ -20,7 +20,8 @@ public readonly record struct WowGuid128(ulong Low, ulong High)
     {
         HighGuidType.Player => Create(HighGuidType703.Player, guid.GetCounter()),
         HighGuidType.Item => Create(HighGuidType703.Item, guid.GetCounter()),
-        HighGuidType.Transport or HighGuidType.MOTransport => TransportCreate(guid.GetCounter(), guid.GetEntry()),
+        HighGuidType.Transport => TransportCreate(guid.GetCounter(), guid.GetEntry()),
+        HighGuidType.MOTransport => TransportCreate(guid.GetCounter() | MoTransportCounterFlag, guid.GetEntry()),
         HighGuidType.RaidGroup => Create(HighGuidType703.RaidGroup, guid.GetCounter()),
         HighGuidType.GameObject => Create(HighGuidType703.GameObject, gamestate.GetObjectSpawnCounter(guid), guid.GetEntry(), guid.GetCounter()),
         HighGuidType.Creature => Create(HighGuidType703.Creature, gamestate.GetObjectSpawnCounter(guid), guid.GetEntry(), guid.GetCounter()),
@@ -102,6 +103,17 @@ public readonly record struct WowGuid128(ulong Low, ulong High)
     // WorldClient receive loop → client disconnect. cMaNGOS MOTransport guids carry large
     // low values; TC's don't, which is why this only reproduced on cMaNGOS (issue #101).
     const ulong TransportCounterMask = 0xFFFFF; // 20 bits
+
+    // Legacy Transport (gameobject type 11: elevators, trams) and MOTransport (type 15:
+    // zeppelins, boats) are two separate spawn tables on the legacy server, each numbering
+    // its rows from 1, and neither embeds the gameobject entry in its guid — so both arrive
+    // here with entry 0 and a small counter. Collapsing them into one modern Transport guid
+    // made them collide: the Undercity zeppelin (transports row 6) and an Undercity elevator
+    // (spawn counter 6) both produced 0x1800018000000000, and whichever create landed second
+    // replaced the first in the client's world model. Reserving the top counter bit for
+    // MOTransport keeps the two namespaces apart, and gives WowGuid64.Create a reliable way
+    // to tell them apart on the way back (it used to test entry != 0, which is never true).
+    public const ulong MoTransportCounterFlag = 0x80000; // bit 19 of the 20-bit counter
 
     static WowGuid128 TransportCreate(ulong counter, uint entry)
     {

--- a/HermesProxy/World/WowGuid64.cs
+++ b/HermesProxy/World/WowGuid64.cs
@@ -26,9 +26,9 @@ public readonly record struct WowGuid64(ulong Low)
         HighGuidType.Uniq => WowGuid128.ConvertUniqGuid(guid),
         HighGuidType.Player => new WowGuid64(HighGuidTypeLegacy.Player, (uint)guid.GetCounter()),
         HighGuidType.Item => new WowGuid64(HighGuidTypeLegacy.Item, (uint)guid.GetCounter()),
-        HighGuidType.Transport => guid.GetEntry() != 0
-                            ? new WowGuid64(HighGuidTypeLegacy.Transport, guid.GetEntry(), (uint)guid.GetCounter())
-                            : new WowGuid64(HighGuidTypeLegacy.MOTransport, (uint)guid.GetCounter()),
+        HighGuidType.Transport => (guid.GetCounter() & WowGuid128.MoTransportCounterFlag) != 0
+                            ? new WowGuid64(HighGuidTypeLegacy.MOTransport, (uint)(guid.GetCounter() & ~WowGuid128.MoTransportCounterFlag))
+                            : new WowGuid64(HighGuidTypeLegacy.Transport, guid.GetEntry(), (uint)guid.GetCounter()),
         HighGuidType.RaidGroup => new WowGuid64(HighGuidTypeLegacy.Group, (uint)guid.GetCounter()),
         HighGuidType.GameObject => new WowGuid64(HighGuidTypeLegacy.GameObject, guid.GetEntry(), (uint)guid.GetCounter()),
         HighGuidType.Creature => new WowGuid64(HighGuidTypeLegacy.Creature, guid.GetEntry(), (uint)guid.GetCounter()),

--- a/HermesProxy/appsettings.json
+++ b/HermesProxy/appsettings.json
@@ -31,6 +31,6 @@
     "PacketsLog": true,
     "EnableMetrics": false,
     "EnableVersionCheck": true,
-    "ForwardTransportsV343": false
+    "ForwardTransportsV343": true
   }
 }

--- a/HermesProxy/appsettings.json
+++ b/HermesProxy/appsettings.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "ClientOptions": {
     "ClientBuild": "V2_5_2_40892",
     "SeedHex": "179D3DC3235629D07113A9B3867F97A7",
@@ -30,6 +30,7 @@
   "DiagnosticsOptions": {
     "PacketsLog": true,
     "EnableMetrics": false,
-    "EnableVersionCheck": true
+    "EnableVersionCheck": true,
+    "ForwardTransportsV343": false
   }
 }


### PR DESCRIPTION
Makes transports work on a V3_4_3 client: elevators and trams (gameobject type 11) and, for the first time, zeppelins and boats (type 15). Refs #96.

Previously every transport CreateObject was filtered out on the V3_4_3 path, so they were invisible but the client stayed stable. Lifting that filter is what #96 reports as crashing. It turned out the crash and the invisibility had several independent causes, each hiding the next.

## What was actually wrong

**`SMSG_UPDATE_OBJECT` had no handler.** The single biggest one, and the last found. A `[PacketHandler]` attribute binds to whatever declaration follows it, and a helper method had been placed between the attribute and `HandleUpdateObject`, so the registration bound to the helper. The proxy said so at startup and on every dropped packet:

```
E | Method: MayForwardTransport has wrong BaseType
W | No handler for opcode SMSG_UPDATE_OBJECT (169)
```

Large batches were unaffected because AzerothCore compresses them and `SMSG_COMPRESSED_UPDATE_OBJECT` kept its handler. Only small uncompressed updates were swallowed, which is exactly the traffic transports depend on: the single-object create broadcast when a transport arrives on a map (`Map::AddToMap<Transport>`) and the single-guid out-of-range block when it leaves (`Map::RemoveFromMap<Transport>`). Result: ships that never appeared, ghost ships that never despawned, and crew loading onto a ship the client did not have. A test now asserts every `[PacketHandler]` is actually registrable, since the only symptom was two log lines.

**Transport and MO_TRANSPORT collided on one GUID.** Both arrive with no entry embedded and a small counter from two independent spawn tables, so the Undercity zeppelin (transports row 6) and an Undercity elevator (spawn counter 6) both produced `0x1800018000000000`. The client holds one object per GUID, so whichever create landed second replaced the other. This also repaired `WowGuid64.Create`, which chose between the two kinds by testing `entry != 0` — never true.

**Path progress was discarded.** `GAMEOBJECT_DYNAMIC` packs dynamic flags in the low half and the path-progress fraction in the high half (`GameObject.cpp:2835-2838`). The translation ran the whole 32-bit value through `CastFlags`, which remaps by enum name and drops everything outside the named low-16 bitmask, so every transport reached the client with progress 0.

**The transport flag was CSV-gated.** Applied only to entries listed in `CSV/Transports*.csv`, leaving anything absent from it — including 181689, an Undercity zeppelin — sent as an ordinary gameobject. The loop period now prefers what the backend sends in `GAMEOBJECT_LEVEL` over the CSV value; AzerothCore reports 234433ms for entry 176310 where the CSV says 241780.

**The client was never told the taxi path.** It does not send `CMSG_QUERY_GAME_OBJECT` for a transport it is merely looking at, so it never learned `gameobject_template.Data0`. Type 15 has no `TransportAnimation.db2` rows in any client build, retail included, so that template is the only client-side source of the route. The proxy now fetches it on first forward.

**Passengers were created before their transport.** The V3_4_3 create split ships each create as its own packet to avoid a client OOM, and kept the legacy batch order, which puts the player ahead of the transport. Fine in one envelope, not as separate packets: the client was told "this player is on transport X" before it had X and silently dropped the attachment.

**A transport map change looked like an ordinary teleport.** The legacy server appends the transport entry and the map being left to `SMSG_TRANSFER_PENDING` (`Player.cpp:1609-1613`); the proxy read only the map id. The modern packet carries the same thing in `TransferPending.Ship`, which was never populated, so the client detached the player mid-crossing and dropped them out of the sky on arrival.

Also fixed along the way, not transport-specific: `HandleTransferPending` sends a `SuspendToken` for every transfer while the matching `ResumeToken` was nested inside the `MapID > 1` branch, so any transfer landing on Eastern Kingdoms or Kalimdor left the client suspended.

## On the theory in #96

The stated root cause there is that these entry IDs are missing from the client's `TransportAnimation.db2` and the fix is a legacy→modern remap table. The missing rows are real, but a remap table cannot be built: querying that table for 3.4.3.54261 and for current retail (12.1.0.69404) returns zero type-15 entries in either. Blizzard never put MO_TRANSPORT in it — type 15 is driven by taxi paths, and the type-11 rows are the only ones present. There is no valid ID to remap to. What the client actually needs is the taxi path id from the gameobject template, which is what this change sends.

## Testing

Verified manually against AzerothCore with a 3.4.3.54261 client. This was slow, hands-on work: each route is a real flight in real time, several minutes per attempt, waiting at towers for a ship to arrive, riding it, and watching what happens at the map boundary. Many of the bugs above only appear in one direction or on one route, so each fix meant flying every leg again.

Zeppelin routes, both directions, staying aboard across each map change:

- Undercity/Brill ↔ Orgrimmar (map 0 ↔ 1)
- Undercity/Brill ↔ Howling Fjord (map 0 ↔ 571)
- Orgrimmar ↔ Grom'gol, Stranglethorn Vale (map 1 ↔ 0)
- Multi-leg in one session: Orgrimmar → Brill → Howling Fjord → Brill
- Orgrimmar ↔ Thunder Bluff, which stays on Kalimdor and so covers arrival and departure without a map change

Also checked: ships arriving at and departing from towers while standing nearby, ships not being ridden animating along their correct paths, crew NPCs and deck gameobjects standing on the deck rather than falling to terrain, and boarding and walking around on a moving deck.

Ships now spawn and despawn the way they do on retail. Ghost transports — a ship left parked at a tower forever after flying to another map — were a symptom of the dead `SMSG_UPDATE_OBJECT` handler swallowing the single-guid out-of-range block, and are gone.

Boat routes, both directions, including the map change: Ratchet ↔ Booty Bay (The Maiden's Fancy, map 1 ↔ 0). Boats sit at sea level rather than hovering and have much larger decks, so they exercise the stationary-position and passenger-offset paths differently from zeppelins.

Elevators and trams, ridden up and down: Undercity (149045, 149046), Thunder Bluff, Deeprun Tram (152614), and Howling Fjord (186761/186762 and the Vrykul 190118).

One regression was found and fixed during this testing, worth calling out because it shows how the two transport types diverge: applying `GO_FLAG_MAP_OBJECT` to every transport rather than only type 15 made elevators render as untextured placeholders. That flag tells the client the object is a WMO map object, and a type 11 elevator is an M2 doodad. The original code got this right by accident, gating on presence in `CSV/Transports*.csv`, which only lists type 15 entries; it is now gated on the gameobject type. Verified fixed on the Thunder Bluff lifts and on both elevator families in Howling Fjord (`Doodad_HF_Elevator_Lift01` and the Vrykul `Doodad_VR_Elevator_Lift02`).

## Notes

`DiagnosticsOptions.ForwardTransportsV343` now defaults to **on** — the filter existed because transports were broken, and leaving it off would ship the fix to nobody. Set it to false to restore the old behaviour of hiding transports entirely.

The condition that filter was really guarding is unchanged and still applies regardless of the toggle: a create carrying a placeholder position, which the client rejects with `CMSG_OBJECT_UPDATE_FAILED` and then retries forever, is dropped. It tests the position rather than the backend, so it holds wherever such a create comes from.

Worth weighing when deciding on that default: everything above was verified against AzerothCore only. cMaNGOS and TrinityCore 3.3.5 have not been tested. The causes found here were all proxy-side rather than backend-specific, so they should hold generally, but if you would rather ship this off by default until another backend is exercised, that is a one-line change.

725 tests pass, including new coverage for the GUID split, create ordering and handler registration.
