### PR TITLE
fix: stop aborting the process on a bad account-data file or payload

### DIFF
--- a/HermesProxy/World/Server/AccountDataManager.cs
+++ b/HermesProxy/World/Server/AccountDataManager.cs
@@ -217,31 +217,58 @@ public class AccountDataManager
         AccountData? data = null;
         string fileName = GetFullFileName(guid, type);
 
-        if (File.Exists(fileName))
+        if (!File.Exists(fileName))
+            return null;
+
+        // A stale, truncated or mismatched cache file must not be fatal. These were
+        // Trace.Asserts, which are compiled into Release and abort the process outright
+        // rather than throwing, so a single bad file on disk killed the proxy during
+        // login with nothing catchable. Discard the file instead: the client re-sends
+        // that slot and SaveData overwrites it.
+        try
         {
-            using (FileStream file = File.OpenRead(GetFullFileName(guid, type)))
+            using BinaryReader reader = new BinaryReader(File.OpenRead(fileName));
+
+            data = new();
+            ulong guidLow = reader.ReadUInt64();
+            ulong guidHigh = reader.ReadUInt64();
+            data.Guid = new WowGuid128(guidLow, guidHigh);
+
+            if (!IsGlobalDataType(type) && guid != data.Guid)
             {
-                using (BinaryReader reader = new BinaryReader(File.OpenRead(GetFullFileName(guid, type))))
-                {
-                    data = new();
-                    ulong guidLow = reader.ReadUInt64();
-                    ulong guidHigh = reader.ReadUInt64();
-                    data.Guid = new WowGuid128(guidLow, guidHigh);
-
-                    if (!IsGlobalDataType(type))
-                        System.Diagnostics.Trace.Assert(guid == data.Guid);
-
-                    data.Timestamp = reader.ReadInt64();
-                    data.Type = reader.ReadUInt32();
-                    System.Diagnostics.Trace.Assert(type == data.Type);
-                    data.UncompressedSize = reader.ReadUInt32();
-
-                    int compressedSize = reader.ReadInt32();
-                    data.CompressedData = reader.ReadBytes(compressedSize);
-                }
+                Log.Print(LogType.Warn,
+                    $"Account data '{fileName}' belongs to {data.Guid} but was loaded for {guid}, ignoring it.");
+                return null;
             }
+
+            data.Timestamp = reader.ReadInt64();
+            data.Type = reader.ReadUInt32();
+
+            if (type != data.Type)
+            {
+                Log.Print(LogType.Warn,
+                    $"Account data '{fileName}' holds type {data.Type} but type {type} was expected, ignoring it.");
+                return null;
+            }
+
+            data.UncompressedSize = reader.ReadUInt32();
+
+            int compressedSize = reader.ReadInt32();
+            if (compressedSize < 0 || compressedSize > reader.BaseStream.Length - reader.BaseStream.Position)
+            {
+                Log.Print(LogType.Warn,
+                    $"Account data '{fileName}' declares {compressedSize} compressed bytes but the file is shorter, ignoring it.");
+                return null;
+            }
+
+            data.CompressedData = reader.ReadBytes(compressedSize);
         }
-        
+        catch (Exception e)
+        {
+            Log.Print(LogType.Warn, $"Could not read account data '{fileName}', ignoring it: {e.Message}");
+            return null;
+        }
+
         return data;
     }
 

--- a/HermesProxy/World/Server/Packets/MiscPackets.cs
+++ b/HermesProxy/World/Server/Packets/MiscPackets.cs
@@ -22,6 +22,7 @@ using Framework.Constants;
 using Framework.GameMath;
 using Framework.IO;
 using HermesProxy.World.Enums;
+using Framework.Logging;
 using HermesProxy.World.Objects;
 
 namespace HermesProxy.World.Server.Packets;
@@ -32,7 +33,15 @@ public class EmptyClientPacket : ClientPacket
 
     public override void Read()
     {
-        System.Diagnostics.Trace.Assert(!_worldPacket.CanRead());
+        // Was a Trace.Assert, which is compiled into Release and aborts the process rather
+        // than throwing. This type backs a lot of client-facing handlers, so any client
+        // sending a payload we expect to be empty took the whole proxy down. Unread bytes
+        // mean our layout is wrong, which is worth knowing but never worth aborting for.
+        if (_worldPacket.CanRead())
+        {
+            Log.Print(LogType.Debug,
+                $"Expected an empty payload for opcode {_worldPacket.GetUniversalOpcode(isModern: true)} but {_worldPacket.Remaining()} bytes remain.");
+        }
     }
 }
 


### PR DESCRIPTION
Independent of the other open PRs, no overlapping files.

`Trace.Assert` is compiled into Release builds and calls abort rather than throwing, so it bypasses every handler guard and kills the process outright. Two of them sit on paths reachable from ordinary play.

## AccountDataManager.LoadData

Asserted that a cache file's stored GUID and type matched what was requested. This runs for every account-data slot on every login, so a single stale, truncated or mismatched `.bin` on disk was a fatal login with nothing catchable to report it.

A bad file is now logged and discarded. The client re-sends that slot and `SaveData` overwrites it, so the recovery is automatic. Also added a length sanity check before `ReadBytes`, and fixed the file being opened twice: the outer `FileStream` was never used.

## EmptyClientPacket.Read

Asserted the payload was fully consumed. That type backs many client-facing handlers, so any client sending bytes where none are expected took the whole proxy down. Leftover bytes mean our layout is wrong, which is worth logging and never worth aborting for.

## Not changed

Three `Trace.Assert` calls remain, on lower-risk paths: static data load at startup, crypt initialisation, and an internal socket-type invariant in `WorldSocket.cs`. The last one was left alone only to keep this branch from overlapping another open PR that edits that file.

## Tests

702 pass, 0 fail.
