### PR TITLE
fix(build): stop clobbering TRACE on Windows, disarm remaining process aborts

### DIFF
--- a/HermesProxy/HermesProxy.csproj
+++ b/HermesProxy/HermesProxy.csproj
@@ -71,9 +71,24 @@
     <TrimmerRootAssembly Include="Serilog" />
   </ItemGroup>
 
+  <!-- _WINDOWS gates the Windows-only console/CTRL-handler blocks in Program.cs.
+       APPEND to $(DefineConstants) — never assign. A plain assignment here silently
+       discarded the SDK-provided TRACE define, so every Trace.Assert compiled away on
+       Windows while staying live (and process-fatal) on macOS/Linux. That divergence
+       hid the opcode-0 abort reported in #111 from every Windows contributor for as
+       long as the line existed. -->
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <DefineConstants>_WINDOWS</DefineConstants>
+    <DefineConstants>$(DefineConstants);_WINDOWS</DefineConstants>
   </PropertyGroup>
+
+  <!-- Regression guard for the above: TRACE must survive into the final DefineConstants on
+       every platform and configuration. If it is missing, someone assigned over it again —
+       fail loudly at build time rather than shipping a binary whose assertions are no-ops
+       on one OS and fatal on another. -->
+  <Target Name="VerifyTraceDefine" BeforeTargets="CoreCompile">
+    <Error Condition="!$(DefineConstants.Contains('TRACE'))"
+           Text="DefineConstants lost TRACE (got '$(DefineConstants)'). Write &lt;DefineConstants&gt;%24(DefineConstants);YOUR_SYMBOL&lt;/DefineConstants&gt; — append, never assign." />
+  </Target>
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild">

--- a/HermesProxy/World/Client/LegacyWorldCrypt.cs
+++ b/HermesProxy/World/Client/LegacyWorldCrypt.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Security.Cryptography;
 
 namespace HermesProxy.World.Client;
@@ -18,7 +17,11 @@ public class VanillaWorldCrypt : LegacyWorldCrypt
 
     public void Initialize(ReadOnlySpan<byte> sessionKey)
     {
-        Trace.Assert(sessionKey.Length != 0);
+        // Was a Trace.Assert, which aborts the process outright wherever TRACE is defined.
+        // An empty session key means the auth handshake went wrong; throw so the caller's
+        // handler guard can log it and drop the session instead of taking the proxy down.
+        if (sessionKey.Length == 0)
+            throw new ArgumentException("Session key is empty; cannot initialize world crypt.", nameof(sessionKey));
 
         m_key = sessionKey.ToArray();
         m_send_i = m_send_j = m_recv_i = m_recv_j = 0;

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -1006,7 +1006,14 @@ public static partial class GameData
                 if (mapId != 0)
                     bg.MapIds.Add(mapId);
             }
-            System.Diagnostics.Trace.Assert(bg.MapIds.Count != 0);
+            // Was a Trace.Assert. A malformed CSV row is a data problem, not a reason to
+            // abort the process during startup — skip the row and say which one it was.
+            if (bg.MapIds.Count == 0)
+            {
+                Log.Print(LogType.Error,
+                    $"LoadBattlegrounds: battleground {bgId} has no map IDs in {path}, skipping row.");
+                continue;
+            }
             dict.Add(bgId, bg);
         }
         Battlegrounds = dict.ToFrozenDictionary();

--- a/HermesProxy/World/Packet.cs
+++ b/HermesProxy/World/Packet.cs
@@ -208,7 +208,14 @@ public class WorldPacket : ByteBuffer
     public WorldPacket(uint opcode, byte[] data) : base(data)
     {
         this.opcode = opcode;
-        System.Diagnostics.Trace.Assert(this.opcode != 0);
+
+        // Was a Trace.Assert. Both callers are legacy *receive* paths — SMSG_COMPRESSED_MOVES
+        // reads this opcode straight off the wire, and Inflate() copies it from the parent
+        // packet — so a zero here means corrupt or misaligned input, not a programming error.
+        // Aborting the process on malformed server data is the worst possible response; log it
+        // and let the dispatcher drop it as an unknown opcode.
+        if (this.opcode == 0)
+            Log.Print(LogType.Warn, "Constructed a legacy packet with opcode 0 from received data; it will be dropped as unknown.");
     }
 
     public WorldPacket(byte[] data) : base(data)

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -1270,7 +1270,15 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
     public void SendAccountDataTimes()
     {
-        System.Diagnostics.Trace.Assert(_connectType == ConnectionType.Realm);
+        // Was a Trace.Assert. Account data belongs on the realm socket; if this ever runs
+        // on the instance socket the packet would go to the wrong connection, but that is
+        // still not worth aborting the process from a socket callback.
+        if (_connectType != ConnectionType.Realm)
+        {
+            Log.Print(LogType.Error,
+                $"SendAccountDataTimes called on a {_connectType} socket, expected {ConnectionType.Realm}. Skipping.");
+            return;
+        }
 
         WowGuid128 guid = GetSession().GameState.CurrentPlayerGuid;
         GetSession().AccountDataMgr.LoadAllData(guid);


### PR DESCRIPTION
Follow-up to #111, stacked on it deliberately (see *Ordering* below).

Found while reproducing @rursache's enter-world crash: the reason nobody here ever saw that crash is a build-configuration bug of ours that predates the report by a long way.

## The bug

`HermesProxy/HermesProxy.csproj` **assigned** `DefineConstants` instead of appending to it:

```xml
<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
  <DefineConstants>_WINDOWS</DefineConstants>
</PropertyGroup>
```

That discards whatever the SDK already put there — including `TRACE`. Measured with `dotnet msbuild -getProperty:DefineConstants`:

| Config | Windows (before) | Windows (after) | macOS |
|---|---|---|---|
| Debug | `_WINDOWS;DEBUG` | `TRACE;_WINDOWS;DEBUG` | `TRACE;DEBUG` |
| Release | `_WINDOWS;RELEASE` | `TRACE;_WINDOWS;RELEASE` | `TRACE;RELEASE` |

`Trace.Assert` is `[Conditional("TRACE")]`, so **every assertion in the codebase was a no-op on Windows and live, process-fatal, on macOS and Linux.**

That is exactly what hid #111. Same commit, same AzerothCore backend, same 3.4.3.54261 client:

* Windows — `Sending opcode "MSG_NULL_ACTION" (0)`, session continues, an opcode-`0` packet goes out on the wire
* macOS — `Assertion Failed / opcode != 0`, process terminated from a socket callback

Two practical consequences. Every Windows contributor has been running with assertions disabled for as long as that line existed, and an unmapped opcode on Windows fails silently into a malformed packet rather than loudly.

## What this changes

**1. Append, don't assign**, plus a regression guard:

```xml
<Target Name="VerifyTraceDefine" BeforeTargets="CoreCompile">
  <Error Condition="!$(DefineConstants.Contains('TRACE'))" Text="DefineConstants lost TRACE …" />
</Target>
```

Verified both directions: fails a simulated clobber (`-p:DefineConstants=_WINDOWS`), passes a normal build.

**2. Disarm the assertions #111 left behind.** Restoring `TRACE` arms them on Windows, so shipping the build fix alone would introduce new Windows aborts. A network daemon should never abort from a socket callback on untrusted input, so each remaining site becomes non-fatal:

| Site | Before | After |
|---|---|---|
| `Packet.cs` `WorldPacket(uint, byte[])` | `Trace.Assert(opcode != 0)` | log + let dispatch drop it |
| `GameData.cs:1009` | `Trace.Assert(bg.MapIds.Count != 0)` | log the bg id, skip the CSV row |
| `WorldSocket.cs` `SendAccountDataTimes` | `Trace.Assert(_connectType == Realm)` | log and return |
| `LegacyWorldCrypt.cs` `Initialize` | `Trace.Assert(sessionKey.Length != 0)` | `ArgumentException` (catchable by #111's guards) |

The `Packet.cs` one is the site #111 missed — it converted the three sibling constructors but not this one. Both of its callers are legacy *receive* paths: `SMSG_COMPRESSED_MOVES` reads the opcode straight off the wire, and `Inflate()` copies it from the parent packet. A zero there is corrupt or misaligned input, not a programming error, so it logs rather than throws and the dispatcher drops it as an unknown opcode.

## Ordering

This is stacked on #111 rather than landing first, and that is load-bearing. Fixing the csproj on its own would have armed assertions while `Packet.cs` and `EmptyClientPacket` still aborted — turning today's silent Windows behaviour into precisely the crash that was reported. Same reason this shouldn't go to `master` standalone: `master` carries the identical clobber and the identical assert sites but none of #111's conversions, so a build-define-only change there would regress every Windows user on Classic Era / TBC. `master` picks this up when `feature/wotlk-classic-v3.4.3` merges down, with the conversions attached.

## Testing

* `709/709` tests pass — with assertions armed on Windows for the first time
* Clean `Release` build on Windows and macOS (arm64)
* Manual: WotLK V3_4_3 client → AzerothCore 3.3.5a (mod-playerbots), proxy on macOS, character enters the world and plays; the `CMSG_REQUEST_CONQUEST_FORMULA_CONSTANTS` that killed the pre-#111 build is now a dropped packet with a named log line

Credit to @rursache — this was found by pulling on the thread they handed us in #111.
