### PR TITLE
fix(v3_4_3): clear the LFG eye when the association ends

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -336,6 +336,31 @@ public sealed class GameSessionData
     // only signal the proxy has that the association is over.
     public bool LastGroupWasLfg;
 
+    // TC creates exactly one RideTicket per queue in LFGMgr::JoinLfg (Id = GetQueueId,
+    // Time = GameTime::GetGameTime()), stores it per player and reuses it for every subsequent
+    // LFG packet via GetTicket(). The proxy used to stamp Time with UtcNow on every call, so
+    // each packet carried a different ticket and nothing the client received could be tied back
+    // to the queue it actually knew about.
+    private RideTicket? _lfgTicket;
+
+    /// <summary>
+    /// The session's stable LFG ride ticket, created on first use and reused until the LFG
+    /// association ends.
+    /// </summary>
+    public RideTicket GetOrCreateLfgTicket(WowGuid128 requesterGuid, long unixTime)
+    {
+        return _lfgTicket ??= new RideTicket
+        {
+            RequesterGuid = requesterGuid,
+            Id = 1,
+            Type = RideType.Lfg,
+            Time = unixTime,
+        };
+    }
+
+    /// <summary>Forgets the ticket so the next queue gets a fresh one.</summary>
+    public void ResetLfgTicket() => _lfgTicket = null;
+
     /// <summary>
     /// Records the type byte carried by a full LFG slot so bare dungeon IDs can be widened later.
     /// </summary>

--- a/HermesProxy/World/Client/PacketHandlers/GroupHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/GroupHandler.cs
@@ -372,6 +372,28 @@ public partial class WorldClient
     /// </summary>
     private void SendLfgAssociationEnded()
     {
+        Log.Print(LogType.Debug, "LFG[diag]: group dropped its LFG flag, synthesising REMOVED_FROM_QUEUE");
+
+        // The client tracks party-scoped and player-scoped LFG state separately, so a removal
+        // has to be announced for BOTH or the half that was not told keeps the minimap eye
+        // alive. Legacy servers do exactly this: on REMOVED_FROM_QUEUE, AC sends
+        // SendLfgUpdateParty followed by SendLfgUpdatePlayer (LFGMgr.cpp 939 / 953) and TC 3.4.3
+        // calls SendLfgUpdateStatus with party=true then party=false (LFGMgr.cpp 676 / 687).
+        //
+        // Sending only the party variant looked like it worked because leaving from INSIDE a
+        // dungeon is followed by a teleport, and the world transfer reloads client state and
+        // clears the eye as a side effect. Leaving from outside produces no teleport, and the
+        // stale player-scoped state was then plainly visible.
+        SendLfgAssociationEnded(isParty: true);
+        SendLfgAssociationEnded(isParty: false);
+
+        // Both removals must carry the ticket the client has been seeing, so only forget it
+        // afterwards — the next queue then mints a fresh one, as TC does per JoinLfg.
+        GetSession().GameState.ResetLfgTicket();
+    }
+
+    private void SendLfgAssociationEnded(bool isParty)
+    {
         bool isV343 = ModernVersion.Build == ClientVersionBuild.V3_4_3_54261;
 
         DFUpdateStatus status = new DFUpdateStatus();
@@ -379,12 +401,11 @@ public partial class WorldClient
         status.SubType = isV343 ? LfgUpdateTypes.ModernQueueDungeon : (byte)0;
         status.Reason = isV343 ? LfgUpdateTypes.ModernRemovedFromQueue : (byte)0;
         status.NotifyUI = true;
-        status.IsParty = true;
+        status.IsParty = isParty;
         status.Joined = false;
         status.LfgJoined = false;
         status.Queued = false;
 
-        Log.Print(LogType.Debug, "LFG[diag]: group dropped its LFG flag, synthesising REMOVED_FROM_QUEUE");
         SendPacketToClient(status);
     }
 

--- a/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
@@ -21,13 +21,11 @@ public partial class WorldClient
 
     private RideTicket MakeLfgTicket()
     {
-        return new RideTicket
-        {
-            RequesterGuid = GetSession().GameState.CurrentPlayerGuid,
-            Id = 1,
-            Type = RideType.Lfg,
-            Time = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
-        };
+        // Must stay stable for the lifetime of the queue — see GetOrCreateLfgTicket. Minting a
+        // fresh Time per packet gave every LFG message a different ticket.
+        return GetSession().GameState.GetOrCreateLfgTicket(
+            GetSession().GameState.CurrentPlayerGuid,
+            DateTimeOffset.UtcNow.ToUnixTimeSeconds());
     }
 
     [PacketHandler(Opcode.SMSG_LFG_DISABLED)]


### PR DESCRIPTION
Follow-up to #117. The minimap LFG eye stayed up on "paused" after leaving a dungeon group, long after the group was gone server-side.

## Root cause: the RideTicket was never stable

`MakeLfgTicket()` stamped `Time` with `UtcNow` **on every call**, so every LFG packet the proxy sent carried a different `RideTicket`. TC creates exactly one ticket per queue in `LFGMgr::JoinLfg` and reuses it for every subsequent packet:

```cpp
ticket.Id   = GetQueueId(gguid);
ticket.Type = WorldPackets::LFG::RideType::Lfg;
ticket.Time = int32(GameTime::GetGameTime());
...
SetTicket(guid, ticket);        // reused later via GetTicket()
```

With a ticket the client had never seen, it could not tie the removal back to the queue it knew about, and ignored it. The ticket is now created once and held until the association ends, then discarded so the next queue mints a fresh one.

## Also: the removal was only announced party-scoped

The client tracks party-scoped and player-scoped LFG state separately, and legacy servers announce **both** on `REMOVED_FROM_QUEUE`:

- AC — `SendLfgUpdateParty` then `SendLfgUpdatePlayer` (`LFGMgr.cpp` 939 / 953)
- TC 3.4.3 — `SendLfgUpdateStatus(..., party: true)` then `party: false` (`LFGMgr.cpp` 676 / 687)

Both are now sent. This alone did not fix the eye — the ticket did — but sending only half of what the server sends was wrong regardless.

## Why this took two attempts

Leaving from **inside** a dungeon is followed by a teleport, and the resulting world transfer reloads client state and clears the eye as a side effect. That masked the defect and produced a false pass in earlier testing on #117. Leaving from **outside** produces no `SMSG_NEW_WORLD`, and the stale state was then plainly visible.

Both paths are now verified explicitly:

| path | teleport after leave | eye |
|---|---|---|
| leave from inside the dungeon | yes (`SMSG_NEW_WORLD`) | cleared |
| leave from outside the dungeon | **none** | cleared |

The second row is the one that never passed before, and it is the only one that proves anything, since nothing can mask the result.

## Related

* #103

## Tests

746 pass, unchanged — this is behavioural on the wire and covered by the live verification above rather than by new unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCnS9FPB2hzTZqmf14qbKB

