### PR TITLE
fix(v3_4_3): send deck-relative position in SMSG_MOVE_TELEPORT

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -129,8 +129,20 @@ public partial class WorldClient
         moveInfo.ReadMovementInfoLegacy(packet, GetSession().GameState);
         moveInfo.Flags = (uint)(((MovementFlagWotLK)moveInfo.Flags).CastFlags<MovementFlagModern>());
         moveInfo.ValidateMovementInfo();
-        teleport.Position = moveInfo.Position;
-        teleport.Orientation = moveInfo.Orientation;
+        // A mover riding something expects deck-relative Pos/Facing, not world coords:
+        // Unit::SendTeleportPacket runs the position through CalculatePassengerOffset
+        // before filling MoveTeleport. Sending world coords makes the client add them
+        // to the transport's own position and strands the player off the map.
+        if (moveInfo.TransportGuid != default)
+        {
+            teleport.Position = moveInfo.TransportOffset;
+            teleport.Orientation = moveInfo.TransportOrientation;
+        }
+        else
+        {
+            teleport.Position = moveInfo.Position;
+            teleport.Orientation = moveInfo.Orientation;
+        }
         teleport.TransportGUID = moveInfo.TransportGuid;
         if (moveInfo.TransportSeat > 0)
         {


### PR DESCRIPTION
Follow-up to #114. Fixes a pre-existing proxy bug that #114 makes reachable for the first time.

## Symptom

Riding a zeppelin or boat whose two endpoints are on the **same map** drops the player out of the sky partway through. The transport keeps its NPC passengers, the arrival yell fires, and the server has the player correctly on the deck — but the client has them somewhere out over open ocean, drifting along the transport's path with the fatigue bar climbing. Reproduced every time on Grom'gol ↔ Brill, in both directions.

## Root cause

`HandleMoveTeleportAck` translates legacy `MSG_MOVE_TELEPORT_ACK` into modern `SMSG_MOVE_TELEPORT` and copied the position straight across:

```csharp
teleport.Position = moveInfo.Position;        // legacy WORLD coords
teleport.TransportGUID = moveInfo.TransportGuid;
```

Legacy `MovementInfo` keeps world coordinates in `Position` and the deck offset separately in `TransportOffset`. The modern packet wants `Pos` / `Facing` to be **transport-relative** whenever `TransportGUID` is set — `Unit::SendTeleportPacket` runs the position through `TransportBase::CalculatePassengerOffset` before filling `MoveTeleport`:

```cpp
if (TransportBase* transportBase = GetDirectTransport())
    transportBase->CalculatePassengerOffset(x, y, z, &o);

moveTeleport.Pos = Position(x, y, z);
moveTeleport.TransportGUID = GetTransGUID();
moveTeleport.Facing = o;
```

So the client was taking a world coordinate as a deck offset and adding it to the transport's own position, which lands the player thousands of yards away.

## Why it only shows on same-map routes

Every map-crossing ride hides it: `SMSG_NEW_WORLD` re-creates the player on the destination map and re-attaches them as a passenger, overwriting the bad teleport. Same-map rides have no transfer and no re-create, so the near-teleport is the only thing positioning the player — and it was wrong.

That is why transports looked fine in #114 testing. The map-crossing routes are the ones people ride most, and they mask this completely.

## The fix

Branch on `TransportGuid` and send `TransportOffset` / `TransportOrientation` when the mover is riding something. Non-transport teleports keep the previous behaviour exactly, and V1_14 / V2_5 never populate `TransportGuid`, so the new branch is unreachable there and no version gate is needed.

## Testing

TrinityCore 3.3.5a + NPCBots, 3.4.3.54261 client. Grom'gol ↔ Brill fell reproducibly before the change and rides cleanly after. Re-verified the rest of the transport matrix to confirm no regression on the paths #114 already covered — 13 routes across maps 0, 1, 369, 530 and 571, both gameobject types, both geometry classes (zeppelin decks hang below the balloon with negative passenger offsets; boats sit at sea level with positive ones), both directions on every route ridden back, plus a mid-voyage relog.

Three of those are same-map rides — two zeppelins and one boat, on both continents — and all three now arrive on the deck.

762 tests pass.
