### PR TITLE
fix(v3_4_3): Specific Dungeons queue says dungeon is not valid

### DIFF
--- a/HermesProxy.Tests/World/Server/LfgSlotsTests.cs
+++ b/HermesProxy.Tests/World/Server/LfgSlotsTests.cs
@@ -1,36 +1,47 @@
-using System.Collections.Generic;
 using HermesProxy.World.Server;
 using Xunit;
 
 namespace HermesProxy.Tests.World.Server;
 
 /// <summary>
-/// The V3_4_3 client offers Titan Rune Protocol dungeons (LFGDungeons 2447 / 2470 / 2485)
-/// that do not exist in 3.3.5a. Queueing for one made the legacy server drop CMSG_LFG_JOIN
-/// with no reply at all, leaving Dungeon Finder waiting forever with no error shown.
+/// The V3_4_3 client offers Titan Rune Protocol dungeons (LFGDungeons 2447 / 2470 / 2485
+/// and remapped children in the 2400s) that do not exist in 3.3.5a. Queueing for one
+/// made the legacy server drop CMSG_LFG_JOIN with no reply at all. Real 3.3.5 specifics
+/// (issue #103) must still be forwarded — they never appear in SMSG_LFG_PLAYER_INFO.
 /// </summary>
 public class LfgSlotsTests
 {
     private const uint RandomDungeonType = 6u << 24;
+    private const uint SpecificDungeonType = 1u << 24;
 
     private const uint RandomLichKingDungeon = RandomDungeonType | 261u;
     private const uint RandomLichKingHeroic = RandomDungeonType | 262u;
+    private const uint GundrakHeroic = SpecificDungeonType | 219u;
     private const uint TitanRuneGamma = RandomDungeonType | 2447u;
-
-    private static HashSet<uint> Known(params uint[] ids) => new(ids);
+    private const uint TitanRuneChild = SpecificDungeonType | 2458u;
 
     [Fact]
     public void GetDungeonId_StripsTheTypeByte()
     {
         Assert.Equal(261u, LfgSlots.GetDungeonId(RandomLichKingDungeon));
         Assert.Equal(2447u, LfgSlots.GetDungeonId(TitanRuneGamma));
+        Assert.Equal(219u, LfgSlots.GetDungeonId(GundrakHeroic));
     }
 
     [Fact]
     public void TryFindUnknownDungeon_WithServiceableDungeon_ReturnsFalse()
     {
         Assert.False(LfgSlots.TryFindUnknownDungeon(
-            Known(261u, 262u), new[] { RandomLichKingDungeon }, out uint unknown));
+            new[] { RandomLichKingDungeon }, out uint unknown));
+        Assert.Equal(0u, unknown);
+    }
+
+    [Fact]
+    public void TryFindUnknownDungeon_WithLegacySpecific_ReturnsFalse()
+    {
+        // Eligible specifics are implicit on 3.3.5 — they are not in PLAYER_INFO.
+        Assert.False(LfgSlots.TryFindUnknownDungeon(
+            new[] { GundrakHeroic }, out uint unknown));
         Assert.Equal(0u, unknown);
     }
 
@@ -38,25 +49,43 @@ public class LfgSlotsTests
     public void TryFindUnknownDungeon_WithTitanRune_ReportsIt()
     {
         Assert.True(LfgSlots.TryFindUnknownDungeon(
-            Known(261u, 262u), new[] { TitanRuneGamma }, out uint unknown));
+            new[] { TitanRuneGamma }, out uint unknown));
         Assert.Equal(2447u, unknown);
+    }
+
+    [Fact]
+    public void TryFindUnknownDungeon_WithTitanRuneChild_ReportsIt()
+    {
+        Assert.True(LfgSlots.TryFindUnknownDungeon(
+            new[] { TitanRuneChild }, out uint unknown));
+        Assert.Equal(2458u, unknown);
     }
 
     [Fact]
     public void TryFindUnknownDungeon_WithMixedRequest_ReportsTheUnserviceableOne()
     {
         Assert.True(LfgSlots.TryFindUnknownDungeon(
-            Known(261u, 262u), new[] { RandomLichKingHeroic, TitanRuneGamma }, out uint unknown));
+            new[] { GundrakHeroic, RandomLichKingHeroic, TitanRuneGamma }, out uint unknown));
         Assert.Equal(2447u, unknown);
     }
 
     [Fact]
-    public void TryFindUnknownDungeon_BeforePlayerInfoArrives_AllowsTheJoin()
+    public void GetTitanRuneHideSlots_CoversHeadersAndChildren()
     {
-        // An empty set means SMSG_LFG_PLAYER_INFO has not been seen yet. Rejecting on that
-        // would block every queue attempt, which is worse than the hang being fixed here.
-        Assert.False(LfgSlots.TryFindUnknownDungeon(
-            Known(), new[] { TitanRuneGamma }, out uint unknown));
-        Assert.Equal(0u, unknown);
+        var slots = LfgSlots.GetTitanRuneHideSlots(System.Array.Empty<uint>());
+        Assert.Contains(TitanRuneGamma, slots);
+        Assert.Contains(TitanRuneChild, slots);
+        Assert.Equal(44, slots.Count);
+        Assert.DoesNotContain(GundrakHeroic, slots);
+        Assert.DoesNotContain(RandomLichKingHeroic, slots);
+    }
+
+    [Fact]
+    public void GetTitanRuneHideSlots_SkipsIdsAlreadyListed()
+    {
+        var slots = LfgSlots.GetTitanRuneHideSlots(new[] { 2447u, 2458u });
+        Assert.DoesNotContain(TitanRuneGamma, slots);
+        Assert.DoesNotContain(TitanRuneChild, slots);
+        Assert.Equal(42, slots.Count);
     }
 }

--- a/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
@@ -327,6 +327,23 @@ public partial class WorldClient
             });
             blackList.Slots.Add(slot);
         }
+
+        // Titan Rune Alpha/Beta/Gamma live only in the 3.4.3 LFGDungeons.db2.
+        // SoftLock=Unk2 hides a row; without these the three categories stay
+        // visible and every click on them is InvalidSlot.
+        var alreadyListed = new HashSet<uint>(blackList.Slots.Count);
+        foreach (var existing in blackList.Slots)
+            alreadyListed.Add(LfgSlots.GetDungeonId(existing.Slot));
+        foreach (uint packed in LfgSlots.GetTitanRuneHideSlots(alreadyListed))
+        {
+            blackList.Slots.Add(new LFGBlackListSlot
+            {
+                Slot = packed,
+                Reason = (uint)LFGLockStatus.NotInSeason,
+                SoftLock = (uint)LFGSoftLock.Unk2,
+            });
+        }
+
         info.BlackList = blackList;
 
         // Both lists together are the full set of dungeons this backend understands.

--- a/HermesProxy/World/Server/LfgSlots.cs
+++ b/HermesProxy/World/Server/LfgSlots.cs
@@ -10,25 +10,69 @@ public static class LfgSlots
 {
     private const uint DungeonIdMask = 0xFFFFFF;
 
+    // 3.3.5a LFGDungeons.dbc tops out well below this. V3_4_3 added Titan Rune Protocol
+    // (2447 / 2470 / 2485) and remapped those headers' children into the 2400s. A legacy
+    // backend drops CMSG_LFG_JOIN for those IDs with no reply, hanging the DF UI.
+    //
+    // Do not whitelist against SMSG_LFG_PLAYER_INFO: that packet only lists randoms +
+    // locks. Eligible specific dungeons are implicit, so a "not in that set" check
+    // rejected every Specific Dungeons queue (issue #103).
+    public const uint MaxLegacyDungeonId = 512;
+
+    public const uint LfgTypeDungeon = 1;
+    public const uint LfgTypeRandom = 6;
+
     public static uint GetDungeonId(uint slot) => slot & DungeonIdMask;
 
+    public static uint PackSlot(uint type, uint dungeonId) => (type << 24) | (dungeonId & DungeonIdMask);
+
+    public static bool IsLegacyDungeon(uint dungeonId) => dungeonId <= MaxLegacyDungeonId;
+
+    public static uint TypeForUnserviceable(uint dungeonId) =>
+        dungeonId is 2447 or 2470 or 2485 ? LfgTypeRandom : LfgTypeDungeon;
+
+    // Titan Rune Gamma 2447-2463, Beta 2470-2483, Alpha 2485-2497. The only
+    // LFGDungeons.db2 rows above MaxLegacyDungeonId on 3.4.3.54261.
+    public static IEnumerable<uint> EnumerateUnserviceableDungeonIds()
+    {
+        for (uint id = 2447; id <= 2463; id++)
+            yield return id;
+        for (uint id = 2470; id <= 2483; id++)
+            yield return id;
+        for (uint id = 2485; id <= 2497; id++)
+            yield return id;
+    }
+
     /// <summary>
-    /// Finds the first requested dungeon the legacy backend has never mentioned. The V3_4_3
-    /// client offers content that postdates 3.3.5a, and legacy servers drop a join naming an
-    /// unknown dungeon without replying at all, hanging the client's Dungeon Finder UI.
-    /// Returns false when <paramref name="knownDungeonIds"/> is empty, since an unpopulated
-    /// set means SMSG_LFG_PLAYER_INFO has not arrived yet rather than that nothing is valid.
+    /// Packed slots to inject as SoftLock hide-rows so the 3.4.3 client drops the
+    /// Titan Rune Protocol categories from Specific Dungeons. Skips IDs already
+    /// present in <paramref name="alreadyListedDungeonIds"/>.
     /// </summary>
-    public static bool TryFindUnknownDungeon(HashSet<uint> knownDungeonIds, IEnumerable<uint> requestedSlots, out uint unknownDungeonId)
+    public static List<uint> GetTitanRuneHideSlots(IEnumerable<uint> alreadyListedDungeonIds)
+    {
+        var have = alreadyListedDungeonIds as HashSet<uint> ?? new HashSet<uint>(alreadyListedDungeonIds);
+        var extra = new List<uint>();
+        foreach (uint id in EnumerateUnserviceableDungeonIds())
+        {
+            if (have.Contains(id))
+                continue;
+            extra.Add(PackSlot(TypeForUnserviceable(id), id));
+        }
+        return extra;
+    }
+
+    /// <summary>
+    /// First requested dungeon the 3.3.5a backend cannot serve. Titan Rune / other
+    /// post-3.3.5 LFGDungeons IDs belong here. Real 3.3.5 specifics (Utgarde, Gundrak,
+    /// …) do not, even when they never appeared in SMSG_LFG_PLAYER_INFO.
+    /// </summary>
+    public static bool TryFindUnknownDungeon(IEnumerable<uint> requestedSlots, out uint unknownDungeonId)
     {
         unknownDungeonId = 0;
-        if (knownDungeonIds.Count == 0)
-            return false;
-
         foreach (uint slot in requestedSlots)
         {
             uint dungeonId = GetDungeonId(slot);
-            if (knownDungeonIds.Contains(dungeonId))
+            if (IsLegacyDungeon(dungeonId))
                 continue;
 
             unknownDungeonId = dungeonId;

--- a/HermesProxy/World/Server/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/LFGHandler.cs
@@ -48,11 +48,11 @@ public partial class WorldSocket
         Log.Print(LogType.Debug,
             $"LFG[diag]: CMSG_DF_JOIN roles=0x{packet.Roles:X8} slots=[{string.Join(", ", packet.Slots)}]");
 
-        // The V3_4_3 client offers dungeons that postdate 3.3.5a (Titan Rune Protocol
-        // Alpha/Beta/Gamma, IDs 2447/2470/2485). A legacy backend drops CMSG_LFG_JOIN for
-        // an unknown dungeon without sending SMSG_LFG_JOIN_RESULT, so the client sits on
-        // "Find Group" forever with no error. Answer for the backend instead.
-        if (LfgSlots.TryFindUnknownDungeon(GetSession().GameState.LfgKnownDungeonIds, packet.Slots, out uint unknownDungeonId))
+        // Titan Rune / other post-3.3.5 LFGDungeons IDs. A legacy backend drops
+        // CMSG_LFG_JOIN for those with no SMSG_LFG_JOIN_RESULT, so the client sits
+        // on Find Group forever. Answer for the backend instead. Real 3.3.5
+        // specifics are forwarded even if they were never listed in PLAYER_INFO.
+        if (LfgSlots.TryFindUnknownDungeon(packet.Slots, out uint unknownDungeonId))
         {
             Log.Print(LogType.Debug,
                 $"LFG[diag]: rejecting CMSG_DF_JOIN, dungeon {unknownDungeonId} is unknown to the {LegacyVersion.Build} backend");


### PR DESCRIPTION
3.4.3.54261 client on AzerothCore 3.3.5a: Random Dungeon Finder queues, but **Specific Dungeons** always pops **One or more dungeons is not valid**, solo or in a group. Reported on #103 after the crash / roles work landed.

## 1. The reject was a proxy whitelist, not AzerothCore

`HandleDFJoin` called `TryFindUnknownDungeon` against `LfgKnownDungeonIds`, which is filled only from `SMSG_LFG_PLAYER_INFO`. That packet lists **randoms + locks**. Eligible specific dungeons are implicit on 3.3.5 and never appear there.

Live session (lvl 80, Wrath heroic):

- `SMSG_LFG_PLAYER_INFO` offered only `[100663557, 100663558]` = type 6, ids 261 / 262 (Random LK / Random LK Heroic)
- Specific join `CMSG_DF_JOIN` slots `[16777435, …]` = type 1, id **219** (Ahn'kahet heroic) — a real 3.3.5 `LFGDungeons` row
- Proxy answered `SMSG_LFG_JOIN_RESULT = 0x27` (`LFG_JOIN_DUNGEON_INVALID`) and **never** forwarded `CMSG_LFG_JOIN`

The reporter's capture is the same shape with dungeon **216** (Gundrak normal). Titan Rune Gamma clicks sent **2458+**, which *are* unknown to 3.3.5.

## 2. Titan Rune categories are 3.4.3-only rows

`LFGDungeons.db2` 3.4.3.54261 adds Alpha / Beta / Gamma (ids 2447–2497, groups 174–176). 3.3.5a `LFGDungeons.dbc` stops well below 512. Forwarding those IDs makes the backend drop the join with no reply (the hang this whitelist was written to stop). They stay rejected.

The three headers were still painted from the client's db2. `SMSG_LFG_PLAYER_INFO` now injects SoftLock=`Unk2` hide-rows for those 44 ids so the categories leave the Specific Dungeons list. Random LK / Random LK Heroic / Wrath heroic are unchanged.

## Testing

Ridden on AzerothCore + 3.4.3.54261:

- Specific Dungeons → Wrath of the Lich King Heroic (Ahn'kahet, Azjol-Nerub, Gundrak, …) queues
- Random Lich King Heroic / Random Lich King Dungeon still in the Type dropdown and still queue
- Titan Rune Alpha / Beta / Gamma gone from the list
- Unit tests in `LfgSlotsTests` cover legacy-specific allow, Titan Rune reject, and the 44 hide slots

Not retested on TrinityCore or cMangos. The join filter and hide inject are proxy-local and version-gated only by the 3.3.5 dungeon-id ceiling.

Fixes #103