### PR TITLE
fix(v3_4_3): Dungeon Finder Leave Queue greyed out — echo requested roles

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -352,6 +352,12 @@ public sealed class GameSessionData
     // content that shipped after 3.3.5a (Titan Rune Protocol), and queueing for it
     // makes the legacy server drop CMSG_LFG_JOIN without any reply, leaving the
     // client waiting forever. Used to answer those joins ourselves.
+    // Roles the client asked for in CMSG_DF_JOIN / CMSG_DF_SET_ROLES. Legacy
+    // SMSG_LFG_UPDATE_PLAYER carries no roles, but the modern DF frame checks
+    // RequestedRoles against the queued dungeons: at 0 it greys out Leave Queue
+    // with "Role unavailable for some dungeons". Native 3.4.3 echoes the stored
+    // roles back (LFGHandler.cpp: sLFGMgr->GetRoles).
+    public byte LfgRequestedRoles;
     public readonly HashSet<uint> LfgKnownDungeonIds = new();
 
     // Dungeon ID -> the full LFG slot (dungeon ID with the type in the high byte) the legacy

--- a/HermesProxy/World/Client/PacketHandlers/GroupHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/GroupHandler.cs
@@ -398,6 +398,7 @@ public partial class WorldClient
 
         DFUpdateStatus status = new DFUpdateStatus();
         status.Ticket = MakeLfgTicket();
+        status.RequestedRoles = GetSession().GameState.LfgRequestedRoles;
         status.SubType = isV343 ? LfgUpdateTypes.ModernQueueDungeon : (byte)0;
         status.Reason = isV343 ? LfgUpdateTypes.ModernRemovedFromQueue : (byte)0;
         status.NotifyUI = true;
@@ -405,6 +406,10 @@ public partial class WorldClient
         status.Joined = false;
         status.LfgJoined = false;
         status.Queued = false;
+
+        Log.Print(LogType.Debug,
+            $"LFG[diag]: DFUpdateStatus(removed) subType={status.SubType} reason={status.Reason} " +
+            $"requestedRoles=0x{status.RequestedRoles:X2} isParty={status.IsParty}");
 
         SendPacketToClient(status);
     }

--- a/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
@@ -92,6 +92,7 @@ public partial class WorldClient
         DFUpdateStatus status = new DFUpdateStatus();
         status.Ticket = MakeLfgTicket();
         status.IsParty = isParty;
+        status.RequestedRoles = GetSession().GameState.LfgRequestedRoles;
 
         byte legacyUpdateType = packet.ReadUInt8();
         bool isV343 = ModernVersion.Build == ClientVersionBuild.V3_4_3_54261;
@@ -140,6 +141,12 @@ public partial class WorldClient
             if (!isParty)
                 status.Joined = true;
         }
+
+        Log.Print(LogType.Debug,
+            $"LFG[diag]: DFUpdateStatus(player/party) subType={status.SubType} reason={status.Reason} " +
+            $"requestedRoles=0x{status.RequestedRoles:X2} slots=[{string.Join(", ", status.Slots)}] " +
+            $"isParty={status.IsParty} joined={status.Joined} lfgJoined={status.LfgJoined} queued={status.Queued}");
+
         SendPacketToClient(status);
     }
 

--- a/HermesProxy/World/Server/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/LFGHandler.cs
@@ -48,6 +48,8 @@ public partial class WorldSocket
         Log.Print(LogType.Debug,
             $"LFG[diag]: CMSG_DF_JOIN roles=0x{packet.Roles:X8} slots=[{string.Join(", ", packet.Slots)}]");
 
+        GetSession().GameState.LfgRequestedRoles = (byte)(packet.Roles & 0xFF);
+
         // Titan Rune / other post-3.3.5 LFGDungeons IDs. A legacy backend drops
         // CMSG_LFG_JOIN for those with no SMSG_LFG_JOIN_RESULT, so the client sits
         // on Find Group forever. Answer for the backend instead. Real 3.3.5
@@ -134,6 +136,9 @@ public partial class WorldSocket
             return;
 
         WorldPacket legacy = new WorldPacket(Opcode.CMSG_LFG_SET_ROLES);
+        Log.Print(LogType.Debug, $"LFG[diag]: CMSG_DF_SET_ROLES roles=0x{packet.Roles:X2}");
+
+        GetSession().GameState.LfgRequestedRoles = packet.Roles;
         legacy.WriteUInt8(packet.Roles);
         SendPacketToServer(legacy);
     }


### PR DESCRIPTION
Fixes #129 (follow-up to #103).

Queueing through the Dungeon Finder worked after #127, but the window's **Leave Queue** button stayed greyed out with *"Role unavailable for some dungeons"* — the queue could only be left through the minimap eye.

## Cause

`SMSG_LFG_UPDATE_STATUS` carries `RequestedRoles`, and the modern DF frame checks it against the queued dungeons before enabling its buttons. The proxy never populated it, so it always went out as `0` — no role selected, so no dungeon in the queue could be satisfied.

Legacy `SMSG_LFG_UPDATE_PLAYER` / `SMSG_LFG_UPDATE_PARTY` carry no roles, which is why the field sat at its default. The value was already in hand: the client sends it in `CMSG_DF_JOIN` / `CMSG_DF_SET_ROLES` and we forward it upstream without keeping a copy. Native 3.4.3 echoes its stored roles back:

```cpp
// 3.4.3_Source/src/server/game/Handlers/LFGHandler.cpp:271
lfgUpdateStatus.RequestedRoles = sLFGMgr->GetRoles(_player->GetGUID());
```

## Change

- `GameSessionData.LfgRequestedRoles` remembers what the client asked for
- stored on `CMSG_DF_JOIN` (low byte) and `CMSG_DF_SET_ROLES`
- stamped onto both `DFUpdateStatus` senders, including the removed-from-queue one

Not gated to V3_4_3: returning the roles the client itself just sent is closer to native for every build than sending 0.

## Testing

TrinityCore 3.3.5a, 3.4.3.54261 client. Instrumented the synthesized status packet — before:

```
CMSG_DF_JOIN roles=0x00000008 slots=[100663554]
DFUpdateStatus subType=1 reason=6 requestedRoles=0x00 slots=[100663554]
                isParty=False joined=True lfgJoined=True queued=True
```

Everything except `requestedRoles` was already correct. After:

```
CMSG_DF_JOIN roles=0x00000008 -> requestedRoles=0x08
CMSG_DF_JOIN roles=0x00000009 -> requestedRoles=0x09   (Leader + Damage)
CMSG_DF_LEAVE                 -> reason=8, roles retained, queue flags cleared
```

Leave Queue in the DF window is clickable, the tooltip is gone, role changes track, and leave / re-queue cycles keep the selection. 777 tests pass.

The `LFG[diag]` lines that made this diagnosable are kept, matching the existing `CMSG_DF_JOIN` and `SMSG_LFG_PLAYER_INFO` tracing in these handlers.
