### PR TITLE
fix(v3_4_3): Change Realm from the character list no longer dumps to login

### DIFF
--- a/HermesProxy.Tests/World/Server/ChangeRealmTicketResponseTests.cs
+++ b/HermesProxy.Tests/World/Server/ChangeRealmTicketResponseTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Buffers.Binary;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+using ByteBuffer = global::Framework.IO.ByteBuffer;
+
+namespace HermesProxy.Tests.World.Server;
+
+/// <summary>
+/// Native ChangeRealmTicketResponse writes Ticket only when Allow is set.
+/// Writing it on deny, plus an auth reconnect that AC rejects, is WOW51900300.
+/// </summary>
+public class ChangeRealmTicketResponseTests
+{
+    private const uint Token = 0x11223344;
+
+    [Fact]
+    public void Write_WhenDenied_OmitsTicket()
+    {
+        var packet = new ChangeRealmTicketResponse
+        {
+            Token = Token,
+            Allow = false,
+            Ticket = new ByteBuffer(new byte[] { 0xAB }),
+        };
+
+        packet.WritePacketData();
+        byte[] data = packet.GetData()!;
+
+        Assert.Equal(5, data.Length);
+        Assert.Equal(0x44, data[0]);
+        Assert.Equal(0x33, data[1]);
+        Assert.Equal(0x22, data[2]);
+        Assert.Equal(0x11, data[3]);
+        Assert.Equal(0x00, data[4]);
+    }
+
+    [Fact]
+    public void Write_WhenAllowed_WritesTicketAfterFlushedAllowBit()
+    {
+        var packet = new ChangeRealmTicketResponse
+        {
+            Token = Token,
+            Allow = true,
+            Ticket = new ByteBuffer(new byte[] { 0xAB }),
+        };
+
+        packet.WritePacketData();
+        byte[] data = packet.GetData()!;
+
+        Assert.Equal(10, data.Length);
+        Assert.Equal(0x80, data[4]);
+        Assert.Equal(1u, BinaryPrimitives.ReadUInt32LittleEndian(data.AsSpan(5, 4)));
+        Assert.Equal(0xAB, data[9]);
+    }
+}

--- a/HermesProxy.Tests/World/Server/LastSelectedCharacterTests.cs
+++ b/HermesProxy.Tests/World/Server/LastSelectedCharacterTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using HermesProxy.World.Server;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+public class LastSelectedCharacterTests : IDisposable
+{
+    private readonly string _accountName = "HermesTests_" + Guid.NewGuid().ToString("N");
+    private readonly AccountMetaDataManager _mgr;
+
+    public LastSelectedCharacterTests()
+    {
+        _mgr = new AccountMetaDataManager(_accountName);
+    }
+
+    private string FilePath =>
+        Path.GetFullPath(Path.Combine("AccountData", _accountName, "last_character.txt"));
+
+    public void Dispose()
+    {
+        var accountDir = Path.GetFullPath(Path.Combine("AccountData", _accountName));
+        if (Directory.Exists(accountDir))
+            Directory.Delete(accountDir, recursive: true);
+    }
+
+    [Fact]
+    public void SaveThenGet_RoundTripsRealmNameGuidAndTime()
+    {
+        _mgr.SaveLastSelectedCharacter("AzerothCore", "Brahand", 532, 1787593705);
+
+        var got = _mgr.GetLastSelectedCharacter();
+
+        Assert.True(got.HasValue);
+        Assert.Equal("AzerothCore", got.Value.realmName);
+        Assert.Equal("Brahand", got.Value.charName);
+        Assert.Equal(532ul, got.Value.charLowerGuid);
+        Assert.Equal(1787593705L, got.Value.lastLoginUnixSec);
+    }
+
+    [Fact]
+    public void Get_WithEmptyFile_ReturnsNull()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(FilePath)!);
+        File.WriteAllText(FilePath, "");
+
+        Assert.Null(_mgr.GetLastSelectedCharacter());
+    }
+
+    [Fact]
+    public void Invalidate_DeletesTheFile()
+    {
+        _mgr.SaveLastSelectedCharacter("AzerothCore", "Brahand", 532, 1);
+        _mgr.InvalidateLastSelectedCharacter();
+
+        Assert.False(File.Exists(FilePath));
+        Assert.Null(_mgr.GetLastSelectedCharacter());
+    }
+
+    [Fact]
+    public void RememberRealm_WithNoSave_PicksFirstCharacter()
+    {
+        _mgr.RememberRealmFromCharacterList("AzerothCore", new List<(string, ulong)>
+        {
+            ("Naria", 531),
+            ("Brahand", 532),
+        });
+
+        var got = _mgr.GetLastSelectedCharacter();
+        Assert.True(got.HasValue);
+        Assert.Equal("AzerothCore", got.Value.realmName);
+        Assert.Equal("Naria", got.Value.charName);
+        Assert.Equal(531ul, got.Value.charLowerGuid);
+    }
+
+    [Fact]
+    public void RememberRealm_KeepsPreviousCharacterIfStillOnTheList()
+    {
+        _mgr.SaveLastSelectedCharacter("AzerothCore", "Brahand", 532, 1);
+
+        _mgr.RememberRealmFromCharacterList("AzerothCore", new List<(string, ulong)>
+        {
+            ("Naria", 531),
+            ("Brahand", 532),
+        });
+
+        var got = _mgr.GetLastSelectedCharacter();
+        Assert.True(got.HasValue);
+        Assert.Equal("Brahand", got.Value.charName);
+        Assert.Equal(532ul, got.Value.charLowerGuid);
+    }
+}

--- a/HermesProxy/Auth/AuthClient.cs
+++ b/HermesProxy/Auth/AuthClient.cs
@@ -629,8 +629,15 @@ public partial class AuthClient
 
     public void WaitOrRequestRealmList()
     {
-        if (!_realmlistRequestIsPending || !_hasRealmlist.Task.Wait(TimeSpan.FromSeconds(2)))
+        if (_hasRealmlist != null && _hasRealmlist.Task.IsCompletedSuccessfully)
+            return;
+
+        if (!IsConnected())
+            return;
+
+        if (!_realmlistRequestIsPending)
             SendRealmListUpdateRequest();
-        _hasRealmlist.Task.ConfigureAwait(false).GetAwaiter().GetResult();
+
+        _hasRealmlist?.Task.Wait(TimeSpan.FromSeconds(2));
     }
 }

--- a/HermesProxy/BnetServer/Services/Services/GameUtilities.cs
+++ b/HermesProxy/BnetServer/Services/Services/GameUtilities.cs
@@ -150,8 +150,15 @@ public partial class BnetServices
         if (GetSession().GameAccountInfo == null)
             return BattlenetRpcErrorCode.UserServerBadWowAccount;
 
-        if (!GetSession().AuthClient.IsConnected())
-            return BattlenetRpcErrorCode.UtilServerMissingRealmList;
+        // Auth is closed after the first realm list. Change-realm must serve
+        // the cached list instead of demanding a live socket (or blocking
+        // forever in WaitOrRequestRealmList).
+        if (GetSession().RealmManager.GetRealms().Count == 0)
+        {
+            GetSession().AuthClient.WaitOrRequestRealmList();
+            if (GetSession().RealmManager.GetRealms().Count == 0)
+                return BattlenetRpcErrorCode.UtilServerMissingRealmList;
+        }
 
         string subRegionId = "";
         Variant? subRegion = Params.LookupByKey($"Command_RealmListRequest_v1_{GetCommandEndingForVersion()}");

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -223,6 +223,10 @@ public partial class WorldClient
             }
             Log.Print(LogType.Debug,
                 $"[CharEnum] applied order=[{string.Join(", ", charEnum.Characters.ConvertAll(c => $"{c.Name}:{c.ListPosition}"))}]");
+
+            GetSession().AccountMetaDataMgr.RememberRealmFromCharacterList(
+                realmName,
+                charEnum.Characters.ConvertAll(c => (c.Name!, c.Guid.Low)));
         }
 
         SendPacketToClient(charEnum);

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -52,6 +52,7 @@ public partial class WorldClient
 
     Socket _clientSocket = null!;
     bool? _isSuccessful;
+    bool _closing;
     uint _queuePosition;
     string _username = null!;
     Realm _realm = null!;
@@ -176,16 +177,20 @@ public partial class WorldClient
 
     public void Disconnect()
     {
+        _closing = true;
         StopKeepAliveTimer();
+
+        // Unhook before closing so the receive loop does not treat this as an
+        // unexpected drop and call OnDisconnect (that nulls AuthClient, which
+        // change-realm still needs for the next CMSG_AUTH_SESSION).
+        if (GetSession().WorldClient == this)
+            GetSession().WorldClient = null;
 
         if (!IsConnected())
             return;
 
         _clientSocket.Shutdown(SocketShutdown.Both);
         _clientSocket.Disconnect(false);
-
-        if (GetSession().WorldClient == this)
-            GetSession().WorldClient = null;
     }
 
     public bool IsConnected()
@@ -251,12 +256,14 @@ public partial class WorldClient
         if (_isSuccessful == null)
         {
             _isSuccessful = false;
+            return;
         }
-        else
-        {
-            Disconnect();
-            GetSession().OnDisconnect();
-        }
+
+        if (_closing || GetSession().WorldClient != this)
+            return;
+
+        Disconnect();
+        GetSession().OnDisconnect();
     }
 
     private async Task ReceiveLoop()
@@ -318,7 +325,7 @@ public partial class WorldClient
             WorldClientLogMessages.PacketReadError(_melLog, e, _sourceFile, _netDirRecv, e.Message);
             if (_isSuccessful == null)
                 _isSuccessful = false;
-            else
+            else if (!_closing && GetSession().WorldClient == this)
             {
                 Disconnect();
                 GetSession().OnDisconnect();
@@ -398,17 +405,17 @@ public partial class WorldClient
         var pendingLock = gameState.PendingUninstancedPacketsLock;
         if (packet.GetConnection() == ConnectionType.Realm)
         {
-            // Legacy backends (CMaNGOS / TrinityCore 3.3.5a) emit early-session Realm packets
-            // (SMSG_TUTORIAL_FLAGS, SMSG_CACHE_VERSION, etc.) as soon as the legacy world auth
-            // handshake completes. But on the modern-client side, the BNet→Realm socket
-            // handoff is still in flight — RealmSocket is null for a brief window.
-            // Mirror the InstanceSocket pattern below: queue and flush in
-            // WorldSocket.HandleEnterEncryptedModeAck when RealmSocket is assigned.
-            if (GetSession().RealmSocket == null)
+            // First login: RealmSocket is null until ENTER_ENCRYPTED_MODE_ACK.
+            // Change-realm: it still points at the old closed socket. Treat a
+            // dead socket like null so TUTORIAL_FLAGS queues instead of landing
+            // on the old connection and calling OnDisconnect.
+            var realmSocket = GetSession().RealmSocket;
+            if (realmSocket == null || !realmSocket.IsOpen())
             {
                 lock (gameState.PendingRealmPacketsLock)
                 {
-                    if (GetSession().RealmSocket == null)
+                    realmSocket = GetSession().RealmSocket;
+                    if (realmSocket == null || !realmSocket.IsOpen())
                     {
                         gameState.PendingRealmPackets.Enqueue(packet);
                         Log.PrintNet(LogType.Warn, LogNetDir.P2C, $"Can't send opcode {packet.GetUniversalOpcode()} ({packet.GetOpcode()}) before RealmSocket ready! Queue");
@@ -417,7 +424,7 @@ public partial class WorldClient
                 }
             }
 
-            GetSession().RealmSocket.SendPacket(packet);
+            realmSocket.SendPacket(packet);
         }
         else
         {
@@ -664,6 +671,13 @@ public partial class WorldClient
     public void SendAuthResponse(uint clientSeed, uint serverSeed)
     {
         uint zero = 0;
+        var authClient = GetSession().AuthClient;
+        if (authClient == null)
+        {
+            Log.Print(LogType.Error, "WorldClient.SendAuthResponse: AuthClient was torn down before world auth.");
+            _isSuccessful = false;
+            return;
+        }
 
         byte[] authResponse;
         {
@@ -672,7 +686,7 @@ public partial class WorldClient
             ih.AppendData(BitConverter.GetBytes(zero));
             ih.AppendData(BitConverter.GetBytes(clientSeed));
             ih.AppendData(BitConverter.GetBytes(serverSeed));
-            ih.AppendData(GetSession().AuthClient.GetSessionKey());
+            ih.AppendData(authClient.GetSessionKey());
             authResponse = ih.GetHashAndReset();
         }
 
@@ -714,7 +728,7 @@ public partial class WorldClient
 
         SendPacket(packet);
 
-        InitializeEncryption(GetSession().AuthClient.GetSessionKey());
+        InitializeEncryption(authClient.GetSessionKey());
     }
 
     private void HandleAuthResponse(WorldPacket packet)

--- a/HermesProxy/World/Server/AccountDataManager.cs
+++ b/HermesProxy/World/Server/AccountDataManager.cs
@@ -52,15 +52,20 @@ public class AccountMetaDataManager
         if (!File.Exists(path))
             return null;
 
-        var rawContent = File.ReadAllText(path, Encoding.UTF8);
+        var rawContent = File.ReadAllText(path, Encoding.UTF8).Trim();
+        if (rawContent.Length == 0)
+            return null;
+
         var content = rawContent.Split(',');
-        if (content.Length != 4)
+        if (content.Length != 4
+            || !ulong.TryParse(content[2], out ulong charLowerGuid)
+            || !long.TryParse(content[3], out long lastLoginUnixSec))
         {
-            Log.Print(LogType.Error, $"Invalid split size in 'GetLastSelectedCharacter' for account '{_accountName}'");
+            Log.Print(LogType.Error, $"Invalid last_character.txt for account '{_accountName}'");
             return null;
         }
-        
-        return (content[0], content[1], ulong.Parse(content[3]), long.Parse(content[2]));
+
+        return (content[0], content[1], charLowerGuid, lastLoginUnixSec);
     }
 
     public void SaveLastSelectedCharacter(string realmName, string charName, ulong charLowerGuid, long lastLoginUnixSec)
@@ -72,6 +77,25 @@ public class AccountMetaDataManager
         Log.Print(LogType.Debug, $"Saved last selected char in '{path}'");
     }
 
+    public void RememberRealmFromCharacterList(string realmName, IReadOnlyList<(string Name, ulong GuidLow)> characters)
+    {
+        if (string.IsNullOrEmpty(realmName) || characters.Count == 0)
+            return;
+
+        var existing = GetLastSelectedCharacter();
+        var pick = characters[0];
+        if (existing.HasValue)
+        {
+            var match = characters.FirstOrDefault(c =>
+                c.GuidLow == existing.Value.charLowerGuid
+                || string.Equals(c.Name, existing.Value.charName, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrEmpty(match.Name))
+                pick = match;
+        }
+
+        SaveLastSelectedCharacter(realmName, pick.Name, pick.GuidLow, Time.UnixTime);
+    }
+
     public void InvalidateLastSelectedCharacter()
     {
         var dir = GetAccountMetaDataDirectory();
@@ -80,7 +104,7 @@ public class AccountMetaDataManager
         if (!File.Exists(path))
             return;
 
-        File.WriteAllText(path, "");
+        File.Delete(path);
         Log.Print(LogType.Debug, $"Invalidated last selected character entry in '{path}'");
     }
 

--- a/HermesProxy/World/Server/PacketHandlers/SessionHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SessionHandler.cs
@@ -12,7 +12,6 @@ using Framework.Web;
 using Google.Protobuf;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Server.Packets;
-using AuthResult = HermesProxy.Auth.AuthResult;
 
 namespace HermesProxy.World.Server;
 
@@ -24,20 +23,19 @@ public partial class WorldSocket
         ChangeRealmTicketResponse response = new();
         response.Token = request.Token;
 
-        if (!GetSession().AuthClient.IsConnected() && GetSession().AuthClient.Reconnect() != AuthResult.SUCCESS)
+        // Native never re-auths here. The legacy auth socket is already closed
+        // after the first realm list; a full SRP login is rejected and Allow=false
+        // is WOW51900300. Realm list is served from cache.
+        if (_bnetRpc == null)
         {
-            Log.Print(LogType.Error, "Failed to reconnect to auth server.");
             response.Allow = false;
             SendPacket(response);
             return;
         }
-        // GetSession().AuthClient.SendRealmListUpdateRequest();
 
         _bnetRpc.SetClientSecret(request.Secret);
-
         response.Allow = true;
         response.Ticket = new ByteBuffer(new byte[1]);
-
         SendPacket(response);
     }
 

--- a/HermesProxy/World/Server/Packets/SessionPackets.cs
+++ b/HermesProxy/World/Server/Packets/SessionPackets.cs
@@ -91,6 +91,10 @@ class ChangeRealmTicketResponse : ServerPacket
     {
         _worldPacket.WriteUInt32(Token);
         _worldPacket.WriteBit(Allow);
+        _worldPacket.FlushBits();
+        if (!Allow)
+            return;
+
         _worldPacket.WriteUInt32(Ticket.GetSize());
         _worldPacket.WriteBytes(Ticket);
     }

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -360,10 +360,13 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
                 }
                 if (_connectType == ConnectionType.Realm)
                 {
-                    if (GetSession().AuthClient != null)
-                        GetSession().AuthClient.Disconnect();
-                    if (GetSession().WorldClient != null)
-                        GetSession().WorldClient!.Disconnect();
+                    // Change-realm sends this then a new AUTH_SESSION. Keep
+                    // AuthClient (SRP key) so the next WorldClient can log in.
+                    // Drop the stale RealmSocket pointer so early AC packets
+                    // queue instead of writing to this closing connection.
+                    GetSession().WorldClient?.Disconnect();
+                    if (GetSession().RealmSocket == this)
+                        GetSession().RealmSocket = null!;
                 }
                 if (GetSession().ModernSniff != null)
                 {
@@ -476,13 +479,13 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
         if (!IsOpen())
         {
             Log.PrintNet(LogType.Error, LogNetDir.P2C, $"Can't send {packet.GetUniversalOpcode()}, socket is closed!");
-            if (GetSession() != null)
+            var session = GetSession();
+            if (session != null)
             {
-                if (GetSession().RealmSocket == this)
-                    GetSession().RealmSocket = null!;
-                else if (GetSession().InstanceSocket == this)
-                    GetSession().InstanceSocket = null!;
-                GetSession().OnDisconnect();
+                if (session.RealmSocket == this)
+                    session.RealmSocket = null!;
+                else if (session.InstanceSocket == this)
+                    session.InstanceSocket = null!;
             }
             return;
         }
@@ -908,7 +911,15 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
         _worldCrypt.Initialize(_encryptKey);
         if (_connectType == ConnectionType.Realm)
         {
-            SendAuthResponse(BattlenetRpcErrorCode.Ok, GetSession().WorldClient!.GetQueuePosition());
+            var worldClient = GetSession().WorldClient;
+            if (worldClient == null)
+            {
+                Log.Print(LogType.Error, "HandleEnterEncryptedModeAck: WorldClient is gone, aborting realm login");
+                CloseSocket();
+                return;
+            }
+
+            SendAuthResponse(BattlenetRpcErrorCode.Ok, worldClient.GetQueuePosition());
             SendSetTimeZoneInformation();
             SendFeatureSystemStatusGlueScreen();
             SendClientCacheVersion(0);


### PR DESCRIPTION
3.4.3.54261 client on AzerothCore 3.3.5a: **Change Realm** on the character list showed `WOW51900300`. OK did nothing. Picking a realm then bounced back to the login screen (and wiped last-selected character).

## Cause

Three session-teardown bugs stacked.

### 1. Ticket was denied because auth reconnect failed

`HandleChangeRealmTicket` did a full SRP login to the legacy auth socket. AzerothCore (and Trinity) already closed that socket after the first realm list. The reconnect came back `FAIL_UNKNOWN_ACCOUNT`, we sent `Allow=false`, the client showed WOW51900300.

Native 3.4.3 never re-auths here. It stores the client secret and allows the ticket. The realm list is already in the proxy.

### 2. `CMSG_LOG_DISCONNECT` reason 12 nulled `AuthClient`

After Allow=true, picking a realm closes the old world socket. That receive loop treated the close as an unexpected drop and called `OnDisconnect()`, which sets `AuthClient = null`. The next `WorldClient` then NRE'd on `GetSessionKey()`.

### 3. Early AC packets went to the old closed RealmSocket

AC sends `SMSG_TUTORIAL_FLAGS` as soon as world auth succeeds. First login queues those until `ENTER_ENCRYPTED_MODE_ACK` assigns `RealmSocket`. Change-realm left a **stale closed** pointer, so the packet was written to the old connection. `SendPacket` on a closed socket called `OnDisconnect()` again and aborted the new handshake.

That also invalidated `last_character.txt` to an empty file. Combined with last-realm only being written on `PLAYER_LOGIN`, the next full login asked for a realm again.

## Change

- Allow the change-realm ticket from cache. No auth reconnect.
- Ticket write matches native: `FlushBits`, ticket bytes only when `Allow`.
- `GetRealmList` / `WaitOrRequestRealmList` serve the cached list when auth is already down. Do not block the world thread forever.
- Intentional world-socket close (change-realm) does not tear down `AuthClient`.
- Closed / missing `RealmSocket` queues early packets like first login. Sending on a closed socket no longer calls `OnDisconnect`.
- Remember the realm when the character list is shown (keep the previous character if they are still on it). Empty `last_character.txt` is treated as missing; invalidate deletes the file. Guid/time are read in the same order they are written.

## Testing

AzerothCore + 3.4.3.54261, play-tested end to end:

- Change Realm from the character list opens the realm list (no WOW51900300)
- Pick AzerothCore → character list
- Enter world with a character
- Repeat the flow
- Log out to the login screen after landing on the character list; the next login skips the realm picker

773+ tests pass, including `ChangeRealmTicketResponse` wire tests and last-character save/load tests.

Not retested on TrinityCore or cMangos. The ticket write is the native shape for every modern build; the session keep-alive is proxy-local.