### PR TITLE
fix(v3_4_3): hide Titan Rune in the party DF Type dropdown

### DIFF
--- a/HermesProxy.Tests/World/Server/LfgPartyInfoTests.cs
+++ b/HermesProxy.Tests/World/Server/LfgPartyInfoTests.cs
@@ -1,0 +1,49 @@
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using HermesProxy.World.Server;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+public class LfgPartyInfoTests
+{
+    private static readonly WowGuid128 Player = WowGuid128.Create(HighGuidType703.Player, 42);
+
+    [Fact]
+    public void Write_EmitsSoftLockInsteadOfZero()
+    {
+        var info = new LFGPartyInfo();
+        info.Players.Add(new LFGBlackListEntry
+        {
+            PlayerGuid = Player,
+            Locks =
+            {
+                new LFGLockInfoData
+                {
+                    Slot = LfgSlots.PackSlot(LfgSlots.LfgTypeRandom, LfgSlots.TitanRuneGammaHeaderId),
+                    LockStatus = (uint)LFGLockStatus.NotInSeason,
+                    SoftLock = (uint)LFGSoftLock.Unk2,
+                }
+            }
+        });
+
+        info.WritePacketData();
+        byte[] body = info.GetData()!;
+
+        var framed = new byte[body.Length + 2];
+        body.CopyTo(framed, 2);
+        using var packet = new WorldPacket(framed);
+
+        Assert.Equal(1u, packet.ReadUInt32());
+        Assert.True(packet.HasBit());
+        Assert.Equal(1u, packet.ReadUInt32());
+        Assert.Equal(Player, packet.ReadPackedGuid128());
+        Assert.Equal(LfgSlots.PackSlot(LfgSlots.LfgTypeRandom, LfgSlots.TitanRuneGammaHeaderId), packet.ReadUInt32());
+        Assert.Equal((uint)LFGLockStatus.NotInSeason, packet.ReadUInt32());
+        Assert.Equal(0, packet.ReadInt32());
+        Assert.Equal(0, packet.ReadInt32());
+        Assert.Equal((uint)LFGSoftLock.Unk2, packet.ReadUInt32());
+    }
+}

--- a/HermesProxy.Tests/World/Server/LfgSlotsTests.cs
+++ b/HermesProxy.Tests/World/Server/LfgSlotsTests.cs
@@ -88,4 +88,16 @@ public class LfgSlotsTests
         Assert.DoesNotContain(TitanRuneChild, slots);
         Assert.Equal(42, slots.Count);
     }
+
+    [Theory]
+    [InlineData(1u, 2u)]   // InsufficientExpansion
+    [InlineData(2u, 2u)]   // TooLowLevel
+    [InlineData(3u, 2u)]   // TooHighLevel
+    [InlineData(1031u, 2u)] // NotInSeason
+    [InlineData(0u, 0u)]
+    [InlineData(6u, 0u)]   // RaidLocked stays visible
+    public void ToSoftLock_HidesExpansionLevelAndSeason(uint lockStatus, uint expected)
+    {
+        Assert.Equal(expected, LfgSlots.ToSoftLock(lockStatus));
+    }
 }

--- a/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
@@ -255,13 +255,27 @@ public partial class WorldClient
             LFGBlackListEntry entry = new LFGBlackListEntry();
             entry.PlayerGuid = packet.ReadGuid().To128(GetSession().GameState);
             uint lockCount = packet.ReadUInt32();
+            var alreadyListed = new HashSet<uint>((int)lockCount);
             for (uint j = 0; j < lockCount; j++)
             {
                 LFGLockInfoData li = new LFGLockInfoData();
                 li.Slot = packet.ReadUInt32();
                 li.LockStatus = packet.ReadUInt32();
+                li.SoftLock = LfgSlots.ToSoftLock(li.LockStatus);
                 entry.Locks.Add(li);
+                alreadyListed.Add(LfgSlots.GetDungeonId(li.Slot));
                 GetSession().GameState.RememberLfgSlot(li.Slot);
+            }
+            // Party Type dropdown reads this list, not PLAYER_INFO. Same
+            // hide-rows as solo or Titan Rune / out-of-range randoms stay greyed.
+            foreach (uint packed in LfgSlots.GetTitanRuneHideSlots(alreadyListed))
+            {
+                entry.Locks.Add(new LFGLockInfoData
+                {
+                    Slot = packed,
+                    LockStatus = (uint)LFGLockStatus.NotInSeason,
+                    SoftLock = (uint)LFGSoftLock.Unk2,
+                });
             }
             info.Players.Add(entry);
         }
@@ -334,14 +348,7 @@ public partial class WorldClient
             slot.Reason = packet.ReadUInt32();
             // Map legacy LFGLockStatus → modern LFGSoftLock per TC
             // wotlk_classic LFGMgr.cpp:1807-1823.
-            slot.SoftLock = (uint)((LFGLockStatus)slot.Reason switch
-            {
-                LFGLockStatus.InsufficientExpansion
-                or LFGLockStatus.TooLowLevel
-                or LFGLockStatus.TooHighLevel
-                or LFGLockStatus.NotInSeason => LFGSoftLock.Unk2,
-                _ => LFGSoftLock.None,
-            });
+            slot.SoftLock = LfgSlots.ToSoftLock(slot.Reason);
             blackList.Slots.Add(slot);
         }
 

--- a/HermesProxy/World/Server/LfgSlots.cs
+++ b/HermesProxy/World/Server/LfgSlots.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using HermesProxy.World.Server.Packets;
 
 namespace HermesProxy.World.Server;
 
@@ -55,6 +56,20 @@ public static class LfgSlots
         for (uint id = TitanRuneAlphaHeaderId; id <= TitanRuneAlphaLastDungeonId; id++)
             yield return id;
     }
+
+    /// <summary>
+    /// V3_4_3 hides a row when SoftLock is Unk2. Same mapping the player-info
+    /// path already uses. Party-info used to write 0, which left Titan Rune /
+    /// out-of-range randoms greyed in the Type dropdown instead of gone.
+    /// </summary>
+    public static uint ToSoftLock(uint lockStatus) => (LFGLockStatus)lockStatus switch
+    {
+        LFGLockStatus.InsufficientExpansion
+        or LFGLockStatus.TooLowLevel
+        or LFGLockStatus.TooHighLevel
+        or LFGLockStatus.NotInSeason => (uint)LFGSoftLock.Unk2,
+        _ => (uint)LFGSoftLock.None,
+    };
 
     /// <summary>
     /// Packed slots to inject as SoftLock hide-rows so the 3.4.3 client drops the

--- a/HermesProxy/World/Server/Packets/LFG/SMSG/LFGPartyInfo.cs
+++ b/HermesProxy/World/Server/Packets/LFG/SMSG/LFGPartyInfo.cs
@@ -10,6 +10,7 @@ public class LFGLockInfoData
     public uint LockStatus;
     public uint SubReason1;
     public uint SubReason2;
+    public uint SoftLock;
 }
 
 public class LFGBlackListEntry
@@ -41,7 +42,7 @@ public class LFGPartyInfo : ServerPacket
                 _worldPacket.WriteUInt32(l.LockStatus);
                 _worldPacket.WriteInt32((int)l.SubReason1);
                 _worldPacket.WriteInt32((int)l.SubReason2);
-                _worldPacket.WriteUInt32(0); // SoftLock
+                _worldPacket.WriteUInt32(l.SoftLock);
             }
         }
     }


### PR DESCRIPTION
3.4.3.54261 client on AzerothCore 3.3.5a: **Titan Rune Protocol Alpha / Beta / Gamma** stay in the Dungeon Finder Type dropdown when grouped. Solo they are gone. Follow-up to #127.

<img width="1236" height="633" alt="Type dropdown in a party still listing Titan Rune Alpha / Beta / Gamma" src="https://github.com/user-attachments/assets/4976c0a4-cd7e-4849-baac-c7493097f11d" />

## Cause

#127 injected SoftLock=`Unk2` hide-rows on `SMSG_LFG_PLAYER_INFO` only. That is the solo path.

In a party the client also sends `CMSG_DF_GET_SYSTEM_INFO` → `CMSG_LFG_PARTY_LOCK_INFO_REQUEST`. The Type dropdown reads `SMSG_LFG_PARTY_INFO`. Live session:

- solo `SMSG_LFG_PLAYER_INFO`: 117 blacklist slots (73 real + 44 Titan Rune hides)
- party `SMSG_LFG_PARTY_INFO`: 73 locks, no hides, SoftLock hardcoded to `0`

The three 3.4.3-only randoms (and greyed BC / Classic at 80) came back from the local `LFGDungeons.db2`.

## Change

- Inject the same 44 Titan Rune hide-rows on every party member
- Map expansion / level / season locks to SoftLock=`Unk2` on the party path (same mapping as player info)
- Write `LFGLockInfoData.SoftLock` instead of `0`

Random Lich King / Random Lich King Heroic are unchanged.

## Testing

AzerothCore + 3.4.3.54261, play-tested in a party:

- Type dropdown no longer lists Titan Rune Alpha / Beta / Gamma
- Random Lich King Heroic / Random Lich King Dungeon still there
- Specific Dungeons still queues

Unit tests for `ToSoftLock` and for `LFGPartyInfo` emitting SoftLock on the wire.

Not retested on TrinityCore or cMangos. Hide inject is proxy-local.