### PR TITLE
fix(v3_4_3): show Dueling isn't allowed here after CAST_FAILED

### DIFF
--- a/HermesProxy.Tests/World/Server/SpellCastResultMappingTests.cs
+++ b/HermesProxy.Tests/World/Server/SpellCastResultMappingTests.cs
@@ -1,0 +1,20 @@
+using System;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+public class SpellCastResultMappingTests
+{
+    [Fact]
+    public void WotLK_NoDueling_MapsToV343_NoDueling()
+    {
+        // AC EffectDuel sends SPELL_FAILED_NO_DUELING (79). The V3_4_3
+        // client has that string at 102. Name-map must not land on NeedMoreItems (79).
+        Assert.Equal(79u, (uint)SpellCastResultWotLK.NoDueling);
+        Assert.Equal(102u, (uint)SpellCastResultV343.NoDueling);
+        Assert.Equal(
+            SpellCastResultV343.NoDueling,
+            SpellCastResultWotLK.NoDueling.CastEnum<SpellCastResultV343>());
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -216,6 +216,10 @@ public sealed class GameSessionData
     public ConcurrentQueue<ClientCastRequest> PendingNormalCasts = new();  // regular spell casts (queue for proper FIFO handling)
     public ClientCastRequest? CurrentClientNextMeleeCast; // next melee spells (Raptor Strike, Heroic Strike, etc.)
     public ClientCastRequest? CurrentClientAutoRepeatCast; // auto repeat spells (Auto Shot, Shoot, etc.)
+    // SPELL_GO dequeues the pending cast. AC EffectDuel (and other hit-time
+    // checks) then send SMSG_CAST_FAILED. Keep the last completed one so that
+    // fail can still be forwarded instead of disappearing.
+    public ClientCastRequest? LastCompletedNormalCast;
     public ConcurrentQueue<ClientCastRequest> PendingPetCasts = new();  // pet spell casts (queue for proper FIFO handling)
     public WowGuid64 LastLootTargetGuid;
     public List<WowGuid128>? MasterLootCandidates;

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -224,6 +224,21 @@ public partial class WorldClient
             failed.FailedArg2 = arg2;
             SendPacketToClient(failed);
         }
+        // AC EffectDuel (SPELL_FAILED_NO_DUELING) and similar hit-time checks
+        // send CAST_FAILED after SPELL_GO already dequeued the pending cast.
+        else if (GetSession().GameState.LastCompletedNormalCast is { } completed &&
+                 (completed.SpellId == spellId || (completed.LegacySpellId != 0 && completed.LegacySpellId == spellId)))
+        {
+            CastFailed failed = new();
+            failed.SpellID = completed.SpellId;
+            failed.SpellXSpellVisualID = completed.SpellXSpellVisualId;
+            failed.Reason = LegacyVersion.ConvertSpellCastResult(reason);
+            failed.CastID = completed.ServerGUID;
+            failed.FailedArg1 = arg1;
+            failed.FailedArg2 = arg2;
+            SendPacketToClient(failed);
+            GetSession().GameState.LastCompletedNormalCast = null;
+        }
     }
 
     [PacketHandler(Opcode.SMSG_PET_CAST_FAILED, ClientVersionBuild.Zero, ClientVersionBuild.V2_0_1_6180)]
@@ -448,6 +463,8 @@ public partial class WorldClient
                 });
                 pendingCast.PrepareSent = true;
             }
+
+            GetSession().GameState.LastCompletedNormalCast = pendingCast;
         }
         else if (GetSession().GameState.CurrentPlayerGuid == spell.Cast.CasterUnit &&
             GetSession().GameState.CurrentClientNextMeleeCast != null &&


### PR DESCRIPTION
3.4.3.54261 client on AzerothCore 3.3.5a: **Duel** in Stormwind (or any zone without `AREA_FLAG_ALLOW_DUELS`) did nothing. No flag, no error. Outside a city it worked.

## Cause

The modern client sends `CMSG_CAN_DUEL` first. The proxy answers `Result=true` (no legacy equivalent). The client then casts Duel (spell 7266).

AzerothCore `Spell::EffectDuel` runs **after** `SMSG_SPELL_START` / `SMSG_SPELL_GO`. In a no-duel zone it sends `SMSG_CAST_FAILED` with `SPELL_FAILED_NO_DUELING` (79, "Dueling isn't allowed here").

`HandleSpellGo` already dequeued the pending cast, so `HandleCastFailed` found nothing and dropped the packet. Live log:

```
C>P S | CMSG_CAN_DUEL
C<P S | SMSG_CAN_DUEL_RESULT
C>P S | CMSG_CAST_SPELL
C P>S | CMSG_CAST_SPELL
C P<S | SMSG_SPELL_START
C P<S | SMSG_SPELL_GO
C P<S | SMSG_CAST_FAILED
        (never forwarded)
```

## Change

- Remember the last cast dequeued by `SPELL_GO`
- If `CAST_FAILED` arrives for that same spell id, forward it with the matching `CastID`
- Map WotLK `NoDueling` (79) → V3_4_3 `NoDueling` (102)

## Testing

AzerothCore + 3.4.3.54261, play-tested:

- Duel a bot in Stormwind → red **Dueling isn't allowed here**
- Duel outside the city still opens the flag / request

Unit test that WotLK 79 name-maps to V3_4_3 102, not `NeedMoreItems`.

Not retested on TrinityCore or cMangos. Same `EffectDuel` / `SPELL_FAILED_NO_DUELING` path exists on TrinityCore.