### PR TITLE
fix(v3_4_3): translate item links between modern and legacy chat formats

### DIFF
--- a/HermesProxy.Tests/World/Chat/ItemLinkTranslatorTests.cs
+++ b/HermesProxy.Tests/World/Chat/ItemLinkTranslatorTests.cs
@@ -1,0 +1,166 @@
+using System.Text;
+using HermesProxy.World.Chat;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Chat;
+
+// Codec-level tests. These exercise the parse/format pair directly rather than going
+// through ItemLinkTranslator, because the translator picks its legacy codec from
+// LegacyVersion.ExpansionVersion, which is process-wide static state established at
+// startup and not settable per test.
+//
+// Every modern sample here is a real capture taken from a play session against a live
+// backend, not a hand-written string — the empty-field pattern and the trailing group are
+// easy to get subtly wrong by hand.
+public class ItemLinkTranslatorTests
+{
+    private static string Format(IItemLinkCodec codec, in ItemLinkFields fields)
+    {
+        var builder = new StringBuilder();
+        codec.Format(fields, builder);
+        return builder.ToString();
+    }
+
+    [Theory]
+    // Captured from a 3.4.3.54261 client. Seven empty fields, player level at index 7,
+    // then nine more empty fields.
+    [InlineData("33447::::::::80:::::::::", 33447, 80)]
+    [InlineData("2592::::::::80:::::::::", 2592, 80)]
+    [InlineData("6948::::::::80:::::::::", 6948, 80)]
+    [InlineData("49778::::::::80:::::::::", 49778, 80)]
+    public void ModernCodec_ParsesRealCaptures(string body, int expectedItemId, int expectedLevel)
+    {
+        Assert.True(ModernItemLinkCodec.Instance.TryParse(body, out var fields));
+        Assert.Equal(expectedItemId, fields.ItemId);
+        Assert.Equal(expectedLevel, fields.LinkLevel);
+        Assert.Equal(0, fields.EnchantId);
+        Assert.Equal(0, fields.RandomPropertyId);
+    }
+
+    [Fact]
+    public void ModernToWotLk_PlainItem_ProducesNineNumericTokens()
+    {
+        // The exact shape TrinityCore's LinkTags::item::StoreTo requires: nine tokens,
+        // gem4 zero, nothing trailing.
+        Assert.True(ModernItemLinkCodec.Instance.TryParse("6948::::::::80:::::::::", out var fields));
+
+        string legacy = Format(WotLkItemLinkCodec.Instance, fields);
+
+        Assert.Equal("6948:0:0:0:0:0:0:0:80", legacy);
+        Assert.Equal(9, legacy.Split(':').Length);
+    }
+
+    [Fact]
+    public void WotLkCodec_RoundTripsItsOwnOutput()
+    {
+        Assert.True(ModernItemLinkCodec.Instance.TryParse("33447::::::::80:::::::::", out var fromModern));
+        string legacy = Format(WotLkItemLinkCodec.Instance, fromModern);
+
+        Assert.True(WotLkItemLinkCodec.Instance.TryParse(legacy, out var reparsed));
+        Assert.Equal(fromModern, reparsed);
+    }
+
+    [Fact]
+    public void WotLkCodec_RejectsModernLink()
+    {
+        // A modern link starts with nine parsable-looking fields, so the trailing-token
+        // check is what actually distinguishes the two formats. Without it, inbound
+        // translation would happily "parse" outbound strings.
+        Assert.False(WotLkItemLinkCodec.Instance.TryParse("33447::::::::80:::::::::", out _));
+    }
+
+    [Fact]
+    public void WotLkCodec_ParsesCMaNGOSDocumentedExample()
+    {
+        // |cffa335ee|Hitem:812:0:0:0:0:0:0:0:70|h[Glowing Brightwood Staff]|h|r
+        // from mangos-wotlk/src/game/Chat/Chat.cpp — nine tokens, level 70.
+        Assert.True(WotLkItemLinkCodec.Instance.TryParse("812:0:0:0:0:0:0:0:70", out var fields));
+        Assert.Equal(812, fields.ItemId);
+        Assert.Equal(70, fields.LinkLevel);
+    }
+
+    [Fact]
+    public void PositiveRandomProperty_KeepsItsSign()
+    {
+        // Regression test for a real rejection. Bloodstrike Dagger (15247) has
+        // RandomProperty=5324 / RandomSuffix=0, so TrinityCore only accepts a positive id
+        // for it — `if (randomPropertyId < 0) { if (!val.Item->RandomSuffix) return false; }`.
+        // A 3.4.3 client linking "Bloodstrike Dagger of Healing" sends +2042. Negating it
+        // produced Hitem:15247:0:0:0:0:0:-2042:0:80, which the server discarded.
+        // Six colons after the itemID: five empty fields, then the value at index 5.
+        Assert.True(ModernItemLinkCodec.Instance.TryParse("15247::::::2042::80", out var fields));
+        Assert.Equal(2042, fields.RandomPropertyId);
+
+        Assert.Equal("15247:0:0:0:0:0:2042:0:80", Format(WotLkItemLinkCodec.Instance, fields));
+    }
+
+    [Fact]
+    public void NegativeRandomProperty_KeepsItsSign()
+    {
+        // Captured from a 2.5.3.42328 client. The modern client signs the field itself, so a
+        // negative value means ItemRandomSuffix.dbc and must survive untouched.
+        Assert.True(ModernItemLinkCodec.Instance.TryParse("25148::::::-1", out var fields));
+        Assert.Equal(-1, fields.RandomPropertyId);
+
+        Assert.Equal("25148:0:0:0:0:0:-1:0:0", Format(WotLkItemLinkCodec.Instance, fields));
+    }
+
+    [Fact]
+    public void RandomProperty_RoundTripsBothSignsUnchanged()
+    {
+        foreach (int value in new[] { -2042, -1, 0, 1, 2042 })
+        {
+            string legacy = $"15479:0:0:0:0:0:{value}:0:80";
+            Assert.True(WotLkItemLinkCodec.Instance.TryParse(legacy, out var fields));
+            Assert.Equal(value, fields.RandomPropertyId);
+
+            string modern = Format(ModernItemLinkCodec.Instance, fields);
+            Assert.Equal($"15479:0:0:0:0:0:{value}:0:80:0:0:0", modern);
+
+            Assert.True(ModernItemLinkCodec.Instance.TryParse(modern, out var reparsed));
+            Assert.Equal(fields, reparsed);
+        }
+    }
+
+    [Fact]
+    public void ModernGem4_IsDroppedBecauseLegacyRequiresZero()
+    {
+        // StoreTo ends with `&& !dummy`, so a non-zero gem4 fails validation outright.
+        // enchant, three gems, gem4=4, then empty suffix and uniqueID, level at index 7.
+        Assert.True(ModernItemLinkCodec.Instance.TryParse("40000:100:1:2:3:4:::80", out var fields));
+        Assert.Equal(4, fields.Gem4);
+
+        string legacy = Format(WotLkItemLinkCodec.Instance, fields);
+        Assert.Equal("40000:100:1:2:3:0:0:0:80", legacy);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("notanumber")]
+    [InlineData("0::::::::80")]        // itemId 0 is not a real item
+    [InlineData("-5::::::::80")]
+    public void ModernCodec_RejectsMalformedBodies(string body)
+    {
+        Assert.False(ModernItemLinkCodec.Instance.TryParse(body, out _));
+    }
+
+    [Theory]
+    [InlineData("812:0:0:0:0:0:0:0")]          // too few
+    [InlineData("812:0:0:0:0:0:0:0:70:0")]     // too many
+    [InlineData("812:0:0:0:0:0:0:0:x")]        // non-numeric
+    public void WotLkCodec_RejectsWrongTokenCounts(string body)
+    {
+        Assert.False(WotLkItemLinkCodec.Instance.TryParse(body, out _));
+    }
+
+    [Fact]
+    public void EnchantAndGems_SurviveTranslation()
+    {
+        Assert.True(ModernItemLinkCodec.Instance.TryParse("32837:3789:41398:41398:0:0:0:0:80", out var fields));
+        Assert.Equal(3789, fields.EnchantId);
+        Assert.Equal(41398, fields.Gem1);
+        Assert.Equal(41398, fields.Gem2);
+
+        Assert.Equal("32837:3789:41398:41398:0:0:0:0:80", Format(WotLkItemLinkCodec.Instance, fields));
+    }
+}

--- a/HermesProxy/World/Chat/ItemLinkCodecs.cs
+++ b/HermesProxy/World/Chat/ItemLinkCodecs.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Text;
+
+namespace HermesProxy.World.Chat;
+
+// Item-hyperlink field translation between modern and legacy itemstring formats.
+//
+// The modern client emits an itemstring the legacy server's chat validator does not
+// accept. TrinityCore's `LinkTags::item::StoreTo` requires exactly nine numeric tokens,
+// forbids trailing fields, and requires the gem4 slot to be zero; the modern client sends
+// seventeen tokens, most of them empty. A message carrying such a link is discarded
+// silently — `ValidateHyperlinksAndMaybeKick` returns false and `HandleMessagechatOpcode`
+// returns without broadcasting. See issue 139.
+//
+// mangos-family servers only parse per-tag fields at ChatStrictLinkChecking.Severity 3,
+// so they accept the modern string as-is at typical settings. Translation is therefore
+// not required for them, but emitting the native legacy format is still correct: it is
+// exactly what those servers generate themselves.
+//
+// Rather than N*M direct conversions, every format parses into `ItemLinkFields` and is
+// emitted from it. Adding an era is one codec, not a new conversion pair.
+
+/// <summary>
+/// Version-neutral item-link payload. Field semantics follow the *legacy* convention,
+/// because it is the stricter of the two: <see cref="RandomPropertyId"/> is signed, with
+/// negative values indexing ItemRandomSuffix.dbc and positive values ItemRandomProperties.dbc.
+/// </summary>
+public readonly record struct ItemLinkFields(
+    int ItemId,
+    int EnchantId,
+    int Gem1,
+    int Gem2,
+    int Gem3,
+    int Gem4,
+    int RandomPropertyId,
+    int RandomSuffixSeed,
+    int LinkLevel);
+
+/// <summary>
+/// Parses and formats the portion of an item hyperlink between <c>|Hitem:</c> and <c>|h</c>.
+/// </summary>
+public interface IItemLinkCodec
+{
+    /// <summary>Parses a link body. Returns false when the body does not match this format.</summary>
+    bool TryParse(ReadOnlySpan<char> body, out ItemLinkFields fields);
+
+    /// <summary>Appends a link body in this format. Does not write the surrounding tags.</summary>
+    void Format(in ItemLinkFields fields, StringBuilder builder);
+}
+
+/// <summary>
+/// Modern itemstring, as sent by 1.14 / 2.5.x / 3.4.3 clients:
+/// <c>itemID:enchant:gem1:gem2:gem3:gem4:suffix:unique:linkLevel:spec:upgrade:context:numBonusIDs[:...]</c>
+/// <para>
+/// Only the first eight indices are read. The trailing groups (specialization, upgrade,
+/// item context, bonus and modifier lists) vary in count between builds and have no legacy
+/// representation, so one codec covers every modern build we support.
+/// </para>
+/// </summary>
+public sealed class ModernItemLinkCodec : IItemLinkCodec
+{
+    public static readonly ModernItemLinkCodec Instance = new();
+
+    // Indices after itemID.
+    private const int IdxEnchant = 0;
+    private const int IdxGem1 = 1;
+    private const int IdxGem2 = 2;
+    private const int IdxGem3 = 3;
+    private const int IdxGem4 = 4;
+    private const int IdxSuffix = 5;
+    private const int IdxLinkLevel = 7;
+
+    public bool TryParse(ReadOnlySpan<char> body, out ItemLinkFields fields)
+    {
+        fields = default;
+
+        var tokens = new ItemLinkTokenizer(body);
+        if (!tokens.TryNext(out int itemId) || itemId <= 0)
+            return false;
+
+        Span<int> values = stackalloc int[IdxLinkLevel + 1];
+        for (int i = 0; i < values.Length; i++)
+        {
+            // Modern links leave unused fields empty rather than zero, and short links are
+            // legal — a missing trailing field is simply absent, not malformed.
+            if (!tokens.TryNext(out int value))
+                value = 0;
+            values[i] = value;
+        }
+
+        fields = new ItemLinkFields(
+            ItemId: itemId,
+            EnchantId: values[IdxEnchant],
+            Gem1: values[IdxGem1],
+            Gem2: values[IdxGem2],
+            Gem3: values[IdxGem3],
+            Gem4: values[IdxGem4],
+            RandomPropertyId: values[IdxSuffix],
+            // ITEM_FIELD_PROPERTY_SEED has no modern equivalent. Suffix stat values are
+            // derived from it server-side, so a rewritten link renders the suffix name but
+            // not its rolled magnitude.
+            RandomSuffixSeed: 0,
+            LinkLevel: values[IdxLinkLevel]);
+        return true;
+    }
+
+    public void Format(in ItemLinkFields fields, StringBuilder builder)
+    {
+        // Emitted with the trailing spec/upgrade/context group zeroed rather than empty.
+        // The modern client parses positionally and accepts both, and explicit zeros keep
+        // the output unambiguous when it appears in a log.
+        builder.Append(fields.ItemId).Append(':')
+               .Append(fields.EnchantId).Append(':')
+               .Append(fields.Gem1).Append(':')
+               .Append(fields.Gem2).Append(':')
+               .Append(fields.Gem3).Append(':')
+               .Append(fields.Gem4).Append(':')
+               .Append(fields.RandomPropertyId).Append(':')
+               .Append(0).Append(':')
+               .Append(fields.LinkLevel)
+               .Append(":0:0:0");
+    }
+
+    // The random-property value is carried through unchanged in both directions.
+    //
+    // It is tempting to assume the modern client stores the id positive and that legacy
+    // needs it negative, and to negate on the way out — the downstream jimsproxy fix does
+    // exactly that. It is wrong: the modern client already uses the same signed convention
+    // as legacy, where negative means ItemRandomSuffix.dbc and positive means
+    // ItemRandomProperties.dbc.
+    //
+    // Verified against TrinityCore, which rejects a mismatched sign outright:
+    //
+    //     if (randomPropertyId < 0) { if (!val.Item->RandomSuffix) return false; ... }
+    //     else if (randomPropertyId > 0) { if (!val.Item->RandomProperty) return false; ... }
+    //
+    // Bloodstrike Dagger (15247) has RandomProperty=5324 and RandomSuffix=0, so it can only
+    // appear with a positive id. A 3.4.3 client linking "Bloodstrike Dagger of Healing" sent
+    // +2042; negating it produced `Hitem:15247:0:0:0:0:0:-2042:0:80`, which the server logged
+    // as an invalid link and discarded. A 2.5.3 client was separately captured emitting a
+    // negative value directly. Both are the client signing the field correctly on its own.
+}
+
+/// <summary>
+/// WotLK 3.3.5a itemstring:
+/// <c>itemID:enchant:gem1:gem2:gem3:gem4:randomProperty:randomSuffixSeed:renderLevel</c>
+/// <para>
+/// Verified against TrinityCore <c>Chat/HyperlinkTags.cpp</c> <c>LinkTags::item::StoreTo</c>,
+/// which consumes exactly these nine tokens and then requires <c>IsEmpty()</c> and a zero
+/// gem4 slot. CMaNGOS agrees — <c>mangos-wotlk/src/game/Chat/Chat.cpp</c> carries the example
+/// <c>|Hitem:812:0:0:0:0:0:0:0:70|h[Glowing Brightwood Staff]|h|r</c>. Its neighbouring prose
+/// comment lists one field too many and is off by one; the example is the one to trust.
+/// </para>
+/// </summary>
+public sealed class WotLkItemLinkCodec : IItemLinkCodec
+{
+    public static readonly WotLkItemLinkCodec Instance = new();
+
+    private const int TokenCount = 9;
+
+    public bool TryParse(ReadOnlySpan<char> body, out ItemLinkFields fields)
+    {
+        fields = default;
+
+        var tokens = new ItemLinkTokenizer(body);
+        Span<int> values = stackalloc int[TokenCount];
+        for (int i = 0; i < TokenCount; i++)
+        {
+            if (!tokens.TryNext(out values[i]))
+                return false;
+        }
+
+        // Trailing tokens mean this is not a legacy link — most likely a modern one that
+        // happens to start with nine parsable fields.
+        if (!tokens.IsExhausted)
+            return false;
+
+        if (values[0] <= 0)
+            return false;
+
+        fields = new ItemLinkFields(
+            ItemId: values[0],
+            EnchantId: values[1],
+            Gem1: values[2],
+            Gem2: values[3],
+            Gem3: values[4],
+            Gem4: values[5],
+            RandomPropertyId: values[6],
+            RandomSuffixSeed: values[7],
+            LinkLevel: values[8]);
+        return true;
+    }
+
+    public void Format(in ItemLinkFields fields, StringBuilder builder)
+    {
+        builder.Append(fields.ItemId).Append(':')
+               .Append(fields.EnchantId).Append(':')
+               .Append(fields.Gem1).Append(':')
+               .Append(fields.Gem2).Append(':')
+               .Append(fields.Gem3).Append(':')
+               // The parser rejects a non-zero gem4 outright (`!dummy`). 3.3.5a items have
+               // no fourth socket, so discarding a modern gem4 loses nothing real.
+               .Append(0).Append(':')
+               .Append(fields.RandomPropertyId).Append(':')
+               .Append(fields.RandomSuffixSeed).Append(':')
+               .Append(fields.LinkLevel);
+    }
+}
+
+/// <summary>
+/// Splits a colon-separated link body without allocating. An empty token reads as zero,
+/// which is what the modern format's omitted fields mean.
+/// </summary>
+internal ref struct ItemLinkTokenizer
+{
+    private ReadOnlySpan<char> _remaining;
+    private bool _done;
+
+    public ItemLinkTokenizer(ReadOnlySpan<char> body)
+    {
+        _remaining = body;
+        _done = false;
+    }
+
+    /// <summary>True once every token has been consumed.</summary>
+    public readonly bool IsExhausted => _done;
+
+    public bool TryNext(out int value)
+    {
+        value = 0;
+        if (_done)
+            return false;
+
+        int separator = _remaining.IndexOf(':');
+        ReadOnlySpan<char> token;
+        if (separator < 0)
+        {
+            token = _remaining;
+            _done = true;
+        }
+        else
+        {
+            token = _remaining[..separator];
+            _remaining = _remaining[(separator + 1)..];
+        }
+
+        if (token.IsEmpty)
+            return true;
+
+        return int.TryParse(token, out value);
+    }
+}

--- a/HermesProxy/World/Chat/ItemLinkTranslator.cs
+++ b/HermesProxy/World/Chat/ItemLinkTranslator.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Text;
+
+namespace HermesProxy.World.Chat;
+
+// Rewrites item hyperlinks in chat text as it crosses the proxy boundary.
+//
+// Direction matters, and the two directions are independent: an outbound link only has to
+// satisfy the legacy server's validator, and an inbound one only has to satisfy the modern
+// client's parser. Neither side ever sees the other's format, so no single wire form has to
+// serve both and no backend-flavour detection is required.
+//
+// Only eras whose legacy format has been verified against a real parser are registered.
+// An unregistered era falls through untouched, which is the behaviour that ships today and
+// is known to work against mangos-family servers.
+
+public static class ItemLinkTranslator
+{
+    private const string LinkPrefix = "|Hitem:";
+    private const string LinkSuffix = "|h";
+
+    /// <summary>
+    /// Legacy codec for the connected backend, or null when this era is not supported yet
+    /// and links should pass through unchanged.
+    /// </summary>
+    private static IItemLinkCodec? LegacyCodec => LegacyVersion.ExpansionVersion switch
+    {
+        // Vanilla 1.12 and TBC 2.4.3 are deliberately absent: their token layouts have not
+        // been read from a parser the way WotLK's has, and mangos-family servers accept the
+        // modern string unchanged below ChatStrictLinkChecking.Severity 3. Guessing a format
+        // here would risk breaking a path that currently works.
+        3 => WotLkItemLinkCodec.Instance,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Converts modern item links to the legacy format before forwarding to the game server.
+    /// Returns the original instance when there is nothing to rewrite.
+    /// </summary>
+    public static string ModernToLegacy(string text)
+    {
+        var legacy = LegacyCodec;
+        return legacy == null ? text : Rewrite(text, ModernItemLinkCodec.Instance, legacy);
+    }
+
+    /// <summary>
+    /// Converts legacy item links to the modern format before forwarding to the game client.
+    /// Returns the original instance when there is nothing to rewrite.
+    /// </summary>
+    public static string LegacyToModern(string text)
+    {
+        var legacy = LegacyCodec;
+        return legacy == null ? text : Rewrite(text, legacy, ModernItemLinkCodec.Instance);
+    }
+
+    private static string Rewrite(string text, IItemLinkCodec from, IItemLinkCodec to)
+    {
+        // Fast path: most chat lines contain no item link at all, and those must not allocate.
+        int firstLink = text.IndexOf(LinkPrefix, StringComparison.Ordinal);
+        if (firstLink < 0)
+            return text;
+
+        StringBuilder? builder = null;
+        int copiedUpTo = 0;
+        int searchFrom = firstLink;
+
+        while (searchFrom < text.Length)
+        {
+            int linkStart = text.IndexOf(LinkPrefix, searchFrom, StringComparison.Ordinal);
+            if (linkStart < 0)
+                break;
+
+            int bodyStart = linkStart + LinkPrefix.Length;
+            int bodyEnd = text.IndexOf(LinkSuffix, bodyStart, StringComparison.Ordinal);
+            if (bodyEnd < 0)
+                break;
+
+            var body = text.AsSpan(bodyStart, bodyEnd - bodyStart);
+            if (from.TryParse(body, out var fields))
+            {
+                builder ??= new StringBuilder(text.Length + 16);
+                builder.Append(text, copiedUpTo, bodyStart - copiedUpTo);
+                to.Format(fields, builder);
+                copiedUpTo = bodyEnd;
+            }
+            // A body we cannot parse is left exactly as-is. Corrupting a link we do not
+            // understand would be worse than forwarding it unchanged — that at least
+            // preserves whatever behaviour it has today.
+
+            searchFrom = bodyEnd + LinkSuffix.Length;
+        }
+
+        if (builder == null)
+            return text;
+
+        builder.Append(text, copiedUpTo, text.Length - copiedUpTo);
+        return builder.ToString();
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ChatHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Framework;
 using HermesProxy.Enums;
+using HermesProxy.World.Chat;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
@@ -232,6 +233,11 @@ public partial class WorldClient
         if (!ChatPkt.CheckAddonPrefix(GetSession().GameState.AddonPrefixes, ref language, ref text, ref addonPrefix))
             return;
 
+        // No-op until a vanilla codec is registered. Counterpart to the outbound rewrite in
+        // SendMessageChatVanilla. Issue 139.
+        if (addonPrefix.Length == 0)
+            text = ItemLinkTranslator.LegacyToModern(text);
+
         ChatMessageTypeModern chatTypeModern = chatType.CastEnum<ChatMessageTypeModern>();
         ChatPkt chat = new ChatPkt(GetSession(), chatTypeModern, text, language, sender, senderName, receiver, "", channelName, chatFlags, addonPrefix);
         SendPacketToClient(chat);
@@ -372,6 +378,13 @@ public partial class WorldClient
         if (!ChatPkt.CheckAddonPrefix(GetSession().GameState.AddonPrefixes, ref language, ref text, ref addonPrefix))
             return;
 
+        // Counterpart to the outbound rewrite: the server broadcasts links in the legacy
+        // layout, where the random-property id is signed and sits at a different index than
+        // the modern client reads. Without this a suffix lands in a gem slot and the tooltip
+        // renders the base item. Addon payloads are left untouched.
+        if (addonPrefix.Length == 0)
+            text = ItemLinkTranslator.LegacyToModern(text);
+
         ChatMessageTypeModern chatTypeModern = chatType.CastEnum<ChatMessageTypeModern>();
         ChatPkt chat = new ChatPkt(GetSession(), chatTypeModern, text, language, sender, senderName, receiver, receiverName, channelName, chatFlags, addonPrefix, achievementId);
 
@@ -386,11 +399,17 @@ public partial class WorldClient
 
     public void SendMessageChatVanilla(ChatMessageTypeVanilla type, uint lang, string msg, string channel, string to)
     {
+        // No-op until a vanilla codec is registered — see ItemLinkTranslator.LegacyCodec.
+        // Wired here so enabling that era is a one-line change there rather than a hunt
+        // through the chat handlers. Issue 139.
+        if (lang != (uint)Language.Addon)
+            msg = ItemLinkTranslator.ModernToLegacy(msg);
+
         if (HandleHermesInternalChatCommand(msg))
         {
             return; // was handled by us
         }
-        
+
         WorldPacket packet = new WorldPacket(Opcode.CMSG_MESSAGECHAT);
         packet.WriteUInt32((uint)type);
         packet.WriteUInt32(lang);
@@ -462,6 +481,15 @@ public partial class WorldClient
 
     public void SendMessageChatWotLK(ChatMessageTypeWotLK type, uint lang, string msg, string channel, string to)
     {
+        // Modern item links use a field layout the legacy chat validator rejects, which makes
+        // it drop the entire message without a reply. Addon traffic is exempt on the server
+        // side and carries arbitrary payloads, so it is left untouched. See issue 139.
+        //
+        // Rewritten before the trace below so the log shows what is actually put on the wire.
+        // Chat commands never contain item links, so the internal-command check is unaffected.
+        if (lang != (uint)Language.Addon)
+            msg = ItemLinkTranslator.ModernToLegacy(msg);
+
         var preview = msg.Length > 30 ? msg.Substring(0, 30) + "…" : msg;
         Log.Print(LogType.Trace,
             $"[ChatTrace] -> legacy CMSG_MESSAGECHAT (WotLK): type={type} lang={lang} " +


### PR DESCRIPTION
Closes #139.

Shift-clicking an item into chat produced nothing on a 3.4.3.54261 client against TrinityCore or AzerothCore. The message never appeared — not to the sender, not to anyone else — with no error, no client complaint and no disconnect. Plain items were affected, not only random-suffix ones.

## Cause

The proxy had no item-hyperlink handling at all, so the modern client's itemstring was forwarded verbatim to the legacy backend.

TrinityCore `Chat/HyperlinkTags.cpp`, `LinkTags::item::StoreTo`:

```cpp
t.TryConsumeTo(itemId) && t.TryConsumeTo(val.EnchantId)
  && t.TryConsumeTo(val.GemEnchantId[0]) && t.TryConsumeTo(val.GemEnchantId[1])
  && t.TryConsumeTo(val.GemEnchantId[2]) && t.TryConsumeTo(dummy)
  && t.TryConsumeTo(randomPropertyId) && t.TryConsumeTo(val.RandomSuffixBaseAmount)
  && t.TryConsumeTo(val.RenderLevel) && t.IsEmpty() && !dummy
```

Nine numeric tokens, `dummy` must be zero, and `IsEmpty()` forbids trailing fields. The modern client sends seventeen, most empty:

```
Hitem:33447::::::::80:::::::::
      ^^^^^ ^^^^^^^ ^^ ^^^^^^^^^
      itemID 7 empty 80  9 more empty
```

That breaks the grammar three ways. `WorldSession::ValidateHyperlinksAndMaybeKick` returns false, `HandleMessagechatOpcode` returns without broadcasting, and the message is gone. It is logged server-side, which is how this was confirmed rather than inferred:

```
Player Xain ... sent a message with an invalid link:
|cffffffff|Hitem:33447::::::::80:::::::::|h[Runic Healing Potion]|h|r
```

The validation call sits inside `if (lang != LANG_ADDON)` with no severity guard, so on TrinityCore it cannot be configured away — our test server had `ChatStrictLinkChecking.Severity = 0` and `Kick = 0` and still dropped the message. Those settings only control whether the player is *also* kicked, which on a server with `Kick = 1` turns this into a repeatable disconnect from an ordinary shift-click.

### Not every backend is affected

Worth stating explicitly, because it shapes the design. A 2.5.3 client against **cMangos TBC** links items fine, with `Severity = 2` — i.e. checking enabled. mangos gates per-tag field parsing behind severity 3 and does only escape-sequence structure checks below that:

```cpp
if (sWorld.getConfig(CONFIG_UINT32_CHAT_STRICT_LINK_CHECKING_SEVERITY) < 3)
{
    const std::string validCommands = "cHhr|";
```

| backend | field-grammar validation | modern itemstring | status |
|---|---|---|---|
| TrinityCore 3.3.5a | always on, ungated | rejected | broken, confirmed |
| AzerothCore 3.3.5a | TC-derived, same path | rejected | broken, confirmed |
| cMangos TBC | only at Severity 3 | accepted at Severity 2 | works, confirmed |

## Change

A version-aware translation subsystem under `HermesProxy/World/Chat/`:

```
ItemLinkFields        canonical, version-neutral payload
IItemLinkCodec        TryParse(span) / Format(builder)
ModernItemLinkCodec   active — 1.14 / 2.5.x / 3.4.3
WotLkItemLinkCodec    active — the verified nine-token grammar
ItemLinkTokenizer     ref struct, allocation-free
ItemLinkTranslator    scanner, era dispatch, both directions
```

Every format parses into the canonical struct and is emitted from it, so adding an era is one codec rather than a new conversion pair.

**Only eras whose legacy layout has been read from a real parser are registered.** WotLK is verified against TrinityCore's `StoreTo` and the CMaNGOS example link. Vanilla and TBC are deliberately absent — their token layouts are still guesses, and mangos accepts the modern string unchanged anyway, so a guess there could only break a path that currently works. `LegacyCodec` returns null for those, and unregistered eras fall through untouched.

The modern layout is stable across 1.14 / 2.5.x / 3.4.3 for every index used — only the trailing groups (spec, upgrade, item context, bonus and modifier lists) vary by build, and none are needed. One codec covers all modern builds.

| modern idx | field | legacy WotLK use |
|---|---|---|
| — | itemID | `itemId` |
| 0 | enchantID | `EnchantId` |
| 1–3 | gemID1–3 | `GemEnchantId[0..2]` |
| 4 | gemID4 | dropped — legacy `dummy`, must be 0 |
| 5 | randomProperty | `randomPropertyId`, sign preserved |
| 6 | uniqueID | unused |
| 7 | linkLevel | `RenderLevel` |
| 8+ | spec / upgrade / context / bonusIDs | dropped |

Wired at four points in `ChatHandler.cs` — both directions for both eras — with addon traffic exempted on each side, since the server exempts `LANG_ADDON` and those payloads are arbitrary.

The two directions are independent: an outbound link only has to satisfy the server's validator, an inbound one only the client's parser. Neither side ever sees the other's format, so no single wire form has to serve both and **no backend-flavour detection is required** — just as well, since none exists in the codebase.

Behaviour worth knowing:

- **No allocation on the common path.** A line with no `|Hitem:` returns the original string reference; the `StringBuilder` only materialises when a link is actually rewritten.
- **Unparsable bodies are forwarded untouched** rather than mangled — that at least preserves whatever behaviour they have today.
- **The trailing-token check is load-bearing.** A modern link's first nine fields parse cleanly, so without `IsExhausted` the inbound path would happily "parse" outbound strings. There is a test pinning it.

## Do not touch the sign

The one genuinely counter-intuitive part, and the one thing this got wrong before testing caught it.

`randomPropertyId` is signed — negative indexes `ItemRandomSuffix.dbc`, positive `ItemRandomProperties.dbc`. It is tempting to assume the modern client stores it positive and legacy needs it negative, and to negate on the way out. The downstream jimsproxy fix does exactly that:

```csharp
if (suffix > 0)
    suffix = -suffix;
```

That is wrong. The modern client already uses the same signed convention. Two independent captures:

```
3.4.3 client, "Bloodstrike Dagger of Healing"   ->  index 5 = +2042
2.5.3 client, item 25148                        ->  index 5 = -1
```

TrinityCore rejects a mismatched sign outright:

```cpp
if (randomPropertyId < 0)      { if (!val.Item->RandomSuffix)   return false; ... }
else if (randomPropertyId > 0) { if (!val.Item->RandomProperty) return false; ... }
```

Bloodstrike Dagger (15247) has `RandomProperty=5324` and `RandomSuffix=0`, so it can only appear with a positive id. Negating the client's `+2042` produced a structurally perfect link that was still discarded:

```
|cff1eff00|Hitem:15247:0:0:0:0:0:-2042:0:80|h[Bloodstrike Dagger of Healing]|h|r
```

Nine tokens, gem4 zero, nothing trailing — rejected purely on the sign.

This hides well: every plain item carries `0` there, which is sign-agnostic. Fourteen consecutive successful links proved nothing about this branch. Only a random-property item exposes it.

## Testing

Play-tested against TrinityCore 3.3.5a with a 3.4.3.54261 client:

| case | items | result |
|---|---|---|
| plain | 6948, 33448, 2589, 49778, 41427, 2770, 40 | accepted, echoed |
| blue | 44243, 5187, 37186, 37197, 37379 | accepted, echoed |
| epic | 50317, 40546, 40786, 42285, 42115, 19349 | accepted, echoed |
| random property | 15247 with +2042 and +604 | accepted, echoed |
| multi-link message | 360 chars split into 206 + 154 | both accepted |

Tooltips render correctly on the receiving side, including the correct "of Healing" and "of the Monkey" stats — which is what confirms the inbound expansion places the field at the right index, since a wrong index shows up as a base-item tooltip rather than a rejection.

The decisive measure is server-side. Full accounting of every `invalid link` error in TrinityCore's `Server.log` across the whole session:

| rejected form | count | cause |
|---|---|---|
| `Hitem:NNN::::::…` empty fields | 9 | before this change existed |
| `Hitem:15247:…:-2042:0:80` | 4 | the sign bug above, since fixed |
| corrected build | **0** | — |

Re-checked on cMangos TBC to confirm the unregistered-era passthrough is unchanged.

20 new unit tests, suite 800 → 820, build clean. Modern samples in the tests are real captures rather than hand-written strings — two of them were initially wrong from hand-counting colons, which is exactly the trap.

## Known gaps

- `RandomSuffixBaseAmount` (`ITEM_FIELD_PROPERTY_SEED`) has no modern equivalent and is emitted as zero. A rewritten link renders the suffix name but not its rolled stat magnitude. Not observed as a problem in testing.
- Vanilla 1.12 and TBC 2.4.3 codecs are unimplemented by design. Both call sites are already wired, so enabling an era is a one-line registration once its parser has been read the same way.
- The other nineteen hyperlink tag types are untranslated — `achievement`, `spell`, `quest`, `talent`, `glyph` and the rest go through the same validator, so the same failure is plausible for them. Items are simply the ones players hit daily.
