### PR TITLE
fix(v3_4_3): spam-cast reject no longer prints Requires %s

### DIFF
--- a/HermesProxy.Tests/World/Server/SpellCastResultMappingTests.cs
+++ b/HermesProxy.Tests/World/Server/SpellCastResultMappingTests.cs
@@ -1,0 +1,16 @@
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+public class SpellCastResultMappingTests
+{
+    [Fact]
+    public void Classic_SpellInProgress_CollidesWith_V343_RequiresSpellFocus()
+    {
+        // SendCastRequestFailed must not emit Classic 123 at a 3.4.3 client.
+        Assert.Equal(123u, (uint)SpellCastResultClassic.SpellInProgress);
+        Assert.Equal(123u, (uint)SpellCastResultV343.RequiresSpellFocus);
+        Assert.Equal(126u, (uint)SpellCastResultV343.SpellInProgress);
+    }
+}

--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -88,11 +88,16 @@ public partial class WorldSocket
             SendPacket(prepare2);
         }
 
+        // V3_4_3 RequiresSpellFocus is 123, the same number as Classic SpellInProgress.
+        uint inProgress = ModernVersion.Build == ClientVersionBuild.V3_4_3_54261
+            ? (uint)SpellCastResultV343.SpellInProgress
+            : (uint)SpellCastResultClassic.SpellInProgress;
+
         if (isPet)
         {
             PetCastFailed failed = new();
             failed.SpellID = castRequest.SpellId;
-            failed.Reason = (uint)SpellCastResultClassic.SpellInProgress;
+            failed.Reason = inProgress;
             failed.CastID = castRequest.ServerGUID;
             SendPacket(failed);
         }
@@ -101,7 +106,7 @@ public partial class WorldSocket
             CastFailed failed = new();
             failed.SpellID = castRequest.SpellId;
             failed.SpellXSpellVisualID = castRequest.SpellXSpellVisualId;
-            failed.Reason = (uint)SpellCastResultClassic.SpellInProgress;
+            failed.Reason = inProgress;
             failed.CastID = castRequest.ServerGUID;
             SendPacket(failed);
         }    


### PR DESCRIPTION
3.4.3.54261 client on AzerothCore 3.3.5a: spam-clicking abilities printed **Requires %s**. The fail was real. The string was not.

## Cause

When a cast is already started, the proxy rejects the extra click locally in `SendCastRequestFailed` (never forwarded). It sent `SpellCastResultClassic.SpellInProgress` (**123**).

On V3_4_3 that number is `RequiresSpellFocus`. The client looks up a spell-focus name for `FailedArg1`, gets nothing, and prints the raw format string.

Server-forwarded `CAST_FAILED` was already name-mapped via `ConvertSpellCastResult`. This path is proxy-local, so it never went through that helper. Passing Classic 123 through it would also be wrong: legacy 123 is WotLK `TargetNoPockets`.

Live spam in a duel: many `C<P S SMSG_CAST_FAILED` with no matching `C P<S` receive. Those were the local rejects.

## Change

- On V3_4_3 emit `SpellCastResultV343.SpellInProgress` (**126**)
- Other modern builds keep Classic 123
- Unit test locks the 123 / 126 collision

## Testing

AzerothCore + 3.4.3.54261, play-tested in a duel:

- **Requires %s** is gone
- Extra clicks show the real GCD / **Ability is not ready yet** text

Not retested on TrinityCore or cMangos. Same local reject path.