### PR TITLE
fix(v3_4_3): render socketed gems and live item enchantments

### DIFF
--- a/HermesProxy.Tests/SourceGen/ItemSectionEquivalenceTests.cs
+++ b/HermesProxy.Tests/SourceGen/ItemSectionEquivalenceTests.cs
@@ -30,6 +30,10 @@ public class ItemSectionEquivalenceTests
         var session = (GameSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GameSessionData));
         typeof(GameSessionData).GetField(nameof(GameSessionData.OriginalObjectTypes))!
             .SetValue(session, new System.Collections.Generic.Dictionary<WowGuid128, ObjectType>());
+        // The Gems dynamic field reads GetGemsForItem, so the backing store has to exist
+        // on this GetUninitializedObject-built session. Empty == no gems == zero-size field.
+        typeof(GameSessionData).GetField(nameof(GameSessionData.ItemGems))!
+            .SetValue(session, new System.Collections.Generic.Dictionary<WowGuid128, uint[]>());
         return session;
     }
 

--- a/HermesProxy.Tests/SourceGen/ItemSectionEquivalenceTests.cs
+++ b/HermesProxy.Tests/SourceGen/ItemSectionEquivalenceTests.cs
@@ -398,11 +398,14 @@ public class ItemSectionEquivalenceTests
                     if (ench.Duration.HasValue) enchMask |= 4;
                     if (ench.Charges.HasValue) enchMask |= 8;
                     if (enchMask != 0) enchMask |= 1;
-                    data.WriteBits(enchMask, 4);
+                    // 6 bits: UF::ItemEnchantment is HasChangesMask<6> (group, ID, Duration,
+                    // Charges, Field_A, Field_B). This oracle previously encoded the same
+                    // 4-bit bug as the writer, so it agreed with it and never caught it.
+                    data.WriteBits(enchMask, 6);
                     data.FlushBits();
                     if (ench.ID.HasValue) data.WriteInt32(ench.ID.Value);
                     if (ench.Duration.HasValue) data.WriteUInt32(ench.Duration.Value);
-                    if (ench.Charges.HasValue) data.WriteUInt16(ench.Charges.Value);
+                    if (ench.Charges.HasValue) data.WriteInt16((short)ench.Charges.Value);
                 }
             }
         }

--- a/HermesProxy.Tests/SourceGen/ObjectUpdateBuilderGeneratorTests.WriteCreateObjectData_V3_4_3_54261.verified.txt
+++ b/HermesProxy.Tests/SourceGen/ObjectUpdateBuilderGeneratorTests.WriteCreateObjectData_V3_4_3_54261.verified.txt
@@ -3081,7 +3081,7 @@ public partial class ObjectUpdateBuilder
             data.WriteUInt8((byte)0);
         }
         data.WriteUInt32(0u);
-        data.WriteUInt32(0u);
+        WriteCreateItemGemsSize(data, src);
         if (IsOwner) {
             data.WriteUInt32(0u);
         }
@@ -3090,6 +3090,7 @@ public partial class ObjectUpdateBuilder
         if (IsOwner) {
             data.WriteUInt16((ushort)0);
         }
+        WriteCreateItemGemsBody(data, src);
         data.WriteBits(0u, 6);
         data.FlushBits();
     }
@@ -3132,14 +3133,17 @@ public partial class ObjectUpdateBuilder
         if (src.Context.HasValue) { blocks.SetBit(0); blocks.SetBit(15); }
         if (src.ArtifactXP.HasValue) { blocks.SetBit(0); blocks.SetBit(17); }
         if (src.ItemAppearanceModID.HasValue) { blocks.SetBit(0); blocks.SetBit(18); }
+        if (src.HasGemsUpdate) { blocks.SetBit(0); blocks.SetBit(2); }
         byte blocksMask = 0;
         for (int __i = 0; __i < 2; __i++)
             if (blocks[__i] != 0) blocksMask |= (byte)(1 << __i);
         data.WriteBits(blocksMask, 2);
         for (int __i = 0; __i < 2; __i++)
             if ((blocksMask & (1 << __i)) != 0) data.WriteBits(blocks[__i], 32);
+        if (blocks.IsBitSet(2)) WriteUpdateItemGemsMaskPreamble(data, ref blocks, src);
         data.FlushBits();
         if (blocksMask == 0) return;
+        if (blocks.IsBitSet(2)) WriteUpdateItemGemsBody(data, src);
         if (blocks.IsBitSet(3)) data.WritePackedGuid128(src.Owner!.Value);
         if (blocks.IsBitSet(4)) data.WritePackedGuid128(src.ContainedIn!.Value);
         if (blocks.IsBitSet(5)) data.WritePackedGuid128(src.Creator!.Value);
@@ -3196,6 +3200,7 @@ public partial class ObjectUpdateBuilder
         if (src.Context.HasValue) return true;
         if (src.ArtifactXP.HasValue) return true;
         if (src.ItemAppearanceModID.HasValue) return true;
+        if (src.HasGemsUpdate) return true;
         return false;
     }
 

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -542,6 +542,23 @@ public sealed class GameSessionData
         }
         return 0;
     }
+    /// <summary>
+    /// A legacy SMSG_ENCHANTMENTLOG waiting for the item UPDATE_OBJECT that names the
+    /// guid and slot it applies to. The legacy packet carries only (owner, caster,
+    /// item entry, enchant id) — see AzerothCore Item.cpp SendEnchantmentLog — while the
+    /// modern SMSG_ENCHANTMENT_LOG needs the item guid and enchantment slot too.
+    /// </summary>
+    public struct PendingEnchantmentLogData
+    {
+        public bool IsSet;
+        public WowGuid128 Owner;
+        public WowGuid128 Caster;
+        public uint ItemId;
+        public int EnchantId;
+    }
+
+    public PendingEnchantmentLogData PendingEnchantmentLog;
+
     public uint GetItemId(WowGuid128 guid)
     {
         int OBJECT_FIELD_ENTRY = LegacyVersion.GetUpdateField(ObjectField.OBJECT_FIELD_ENTRY);

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1209,7 +1209,7 @@ public sealed class GameSessionData
     {
         return ItemGems.TryGetValue(guid, out var gems) ? gems : null;
     }
-    public void SaveGemsForItem(WowGuid128 guid, uint?[] gems)
+    public void SaveGemsForItem(WowGuid128 guid, ReadOnlySpan<uint?> gems)
     {
         ref var existing = ref CollectionsMarshal.GetValueRefOrAddDefault(ItemGems, guid, out _);
         existing ??= new uint[ItemConst.MaxGemSockets];

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -1,4 +1,5 @@
-﻿using HermesProxy.Enums;
+﻿using System;
+using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Server.Packets;
 
@@ -200,6 +201,29 @@ public partial class WorldClient
         sell.Reason = packet.ReadUInt8();
         SendPacketToClient(sell);
     }
+    // 3.3.5a SMSG_SOCKET_GEMS_RESULT (0x50B) — the authoritative reply to CMSG_SOCKET_GEMS.
+    // Payload is the item guid plus the enchant ids of SOCK1..SOCK3 and BONUS. Modern
+    // clients have no equivalent packet (the proxy answers CMSG_SOCKET_GEMS optimistically
+    // with SMSG_SOCKET_GEMS_SUCCESS), so nothing is forwarded — this refreshes the gem
+    // cache that the V3_4_3 ItemData Gems dynamic field reads from, keeping it correct
+    // even if the item's Values update omits the socket enchant slots.
+    [PacketHandler(Opcode.SMSG_SOCKET_GEMS)]
+    void HandleSocketGemsResult(WorldPacket packet)
+    {
+        var gameState = GetSession().GameState;
+        WowGuid128 itemGuid = packet.ReadGuid().To128(gameState);
+
+        Span<uint?> gems = stackalloc uint?[ItemConst.MaxGemSockets];
+        for (int i = 0; i < ItemConst.MaxGemSockets; i++)
+        {
+            uint enchantId = packet.ReadUInt32();
+            gems[i] = enchantId != 0 ? GameData.GetGemFromEnchantId(enchantId) : 0u;
+        }
+        // Trailing BONUS_ENCHANTMENT_SLOT id — the socket bonus, not a gem.
+
+        gameState.SaveGemsForItem(itemGuid, gems);
+    }
+
     [PacketHandler(Opcode.SMSG_ITEM_ENCHANT_TIME_UPDATE)]
     void HandleItemEnchantTimeUpdate(WorldPacket packet)
     {

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -235,35 +235,118 @@ public partial class WorldClient
         SendPacketToClient(enchant);
     }
 
+    // The legacy packet is (owner, caster, item ENTRY, enchant id) — no item guid and no
+    // enchantment slot (AzerothCore Item.cpp: SendEnchantmentLog(owner, caster, entry, id),
+    // emitted for every slot below MAX_INSPECTED_ENCHANTMENT_SLOT). The modern packet needs
+    // both. The item's own UPDATE_OBJECT carries the guid and the slot but not the caster,
+    // and it always follows in the same server tick — so park the log here and let
+    // ResolvePendingEnchantmentLog complete it from that update.
+    //
+    // The previous implementation guessed the guid by scanning equipped slots for a matching
+    // entry (wrong item whenever the player owns two of the same entry) and left EnchantSlot
+    // at a hardcoded 1 (TEMP) regardless of the real slot.
     [PacketHandler(Opcode.SMSG_ENCHANTMENT_LOG)]
     void HandleEnchantmentLog(WorldPacket packet)
     {
-        EnchantmentLog enchantment = new EnchantmentLog();
+        var gameState = GetSession().GameState;
+
+        WowGuid128 owner, caster;
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
         {
-            enchantment.Owner = packet.ReadPackedGuid().To128(GetSession().GameState);
-            enchantment.Caster = packet.ReadPackedGuid().To128(GetSession().GameState);
+            owner = packet.ReadPackedGuid().To128(gameState);
+            caster = packet.ReadPackedGuid().To128(gameState);
         }
         else
         {
-            enchantment.Owner = packet.ReadGuid().To128(GetSession().GameState);
-            enchantment.Caster = packet.ReadGuid().To128(GetSession().GameState);
+            owner = packet.ReadGuid().To128(gameState);
+            caster = packet.ReadGuid().To128(gameState);
         }
-        enchantment.ItemID = packet.ReadInt32();
-        var session = GetSession().GameState;
+        int itemId = packet.ReadInt32();
+        int enchantId = packet.ReadInt32();
 
-        for (int i = 0; i < 23; i++)
+        // An unresolved predecessor means no item update ever matched it — most often the
+        // "old enchant cleared" log that precedes a replacement. Flush it best-effort so a
+        // log is never silently swallowed.
+        FlushPendingEnchantmentLog();
+
+        gameState.PendingEnchantmentLog = new GameSessionData.PendingEnchantmentLogData
         {
-            if (session.GetItemId(session.GetInventorySlotItem(i).To128(session)).Equals((uint)enchantment.ItemID))
+            IsSet = true,
+            Owner = owner,
+            Caster = caster,
+            ItemId = (uint)itemId,
+            EnchantId = enchantId,
+        };
+    }
+
+    /// <summary>
+    /// Completes a parked SMSG_ENCHANTMENTLOG once the matching item update names the slot.
+    /// Called from the item branch of the update parser.
+    /// </summary>
+    internal void ResolvePendingEnchantmentLog(WowGuid128 itemGuid, Objects.ItemData item)
+    {
+        var gameState = GetSession().GameState;
+        ref var pending = ref gameState.PendingEnchantmentLog;
+        if (!pending.IsSet || item.Enchantment == null)
+            return;
+
+        if (gameState.GetItemId(itemGuid) != pending.ItemId)
+            return;
+
+        for (int slot = 0; slot < item.Enchantment.Length; slot++)
+        {
+            if (item.Enchantment[slot]?.ID != pending.EnchantId)
+                continue;
+
+            SendPacketToClient(new EnchantmentLog
             {
-                enchantment.ItemGUID = session.GetInventorySlotItem(i).To128(session);
+                Owner = pending.Owner,
+                Caster = pending.Caster,
+                ItemGUID = itemGuid,
+                ItemID = (int)pending.ItemId,
+                Enchantment = pending.EnchantId,
+                EnchantSlot = slot,
+            });
+            pending.IsSet = false;
+            return;
+        }
+    }
+
+    /// <summary>
+    /// Sends a parked log that no item update claimed, resolving the guid by entry as a last
+    /// resort. Slot is left at 0 (PERM) because nothing on the wire identifies it.
+    /// </summary>
+    private void FlushPendingEnchantmentLog()
+    {
+        var gameState = GetSession().GameState;
+        ref var pending = ref gameState.PendingEnchantmentLog;
+        if (!pending.IsSet)
+            return;
+
+        pending.IsSet = false;
+
+        // Equipped gear plus equipped bags: slots 0..BagEnd-1.
+        WowGuid128 itemGuid = default;
+        for (int i = 0; i < Enums.Classic.InventorySlots.BagEnd; i++)
+        {
+            WowGuid128 slotGuid = gameState.GetInventorySlotItem(i).To128(gameState);
+            if (gameState.GetItemId(slotGuid) == pending.ItemId)
+            {
+                itemGuid = slotGuid;
                 break;
             }
         }
-        if (enchantment.ItemGUID == default)
+        if (itemGuid == default)
             return;
 
-        enchantment.Enchantment = packet.ReadInt32();
-        SendPacketToClient(enchantment);
+        SendPacketToClient(new EnchantmentLog
+        {
+            Owner = pending.Owner,
+            Caster = pending.Caster,
+            ItemGUID = itemGuid,
+            ItemID = (int)pending.ItemId,
+            Enchantment = pending.EnchantId,
+            EnchantSlot = 0,
+        });
     }
 }

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2152,7 +2152,7 @@ public partial class WorldClient
                     updateData.ItemData.Enchantment[Enums.Classic.EnchantmentSlot.Prop4] = ReadEnchantData(Enums.WotLK.EnchantmentSlot.Prop4);
                 }
 
-                uint?[] gems = new uint?[ItemConst.MaxGemSockets];
+                Span<uint?> gems = stackalloc uint?[ItemConst.MaxGemSockets];
                 for (int i = 0; i < ItemConst.MaxGemSockets; i++)
                 {
                     int slot = Enums.Classic.EnchantmentSlot.Sock1 + i;

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2168,6 +2168,10 @@ public partial class WorldClient
                 }
                 if (updateData.ItemData.HasGemsUpdate)
                     GetSession().GameState.SaveGemsForItem(guid, gems);
+
+                // This update names the guid and slot a parked SMSG_ENCHANTMENTLOG was
+                // missing; send the completed modern packet now.
+                ResolvePendingEnchantmentLog(guid, updateData.ItemData);
             }
             int ITEM_FIELD_PROPERTY_SEED = LegacyVersion.GetUpdateField(ItemField.ITEM_FIELD_PROPERTY_SEED);
             if (ITEM_FIELD_PROPERTY_SEED >= 0 && updateMaskArray[ITEM_FIELD_PROPERTY_SEED])

--- a/HermesProxy/World/Enums/V3_4_3_54261/ItemField.cs
+++ b/HermesProxy/World/Enums/V3_4_3_54261/ItemField.cs
@@ -9,17 +9,19 @@ namespace HermesProxy.World.Enums.V3_4_3_54261;
 // Update path: 43-bit changesMask across 2 blocks of 32 with a 2-bit blocks-prefix.
 //   bit 0:  group gate for bits 1-22
 //   bit 1:  ArtifactPowers dynamic field (unused)
-//   bit 2:  Gems dynamic field (unused)
+//   bit 2:  Gems dynamic field (mask preamble + per-element body, custom writers)
 //   bits 3-22: scalar fields
 //   bit 23: group gate for SpellCharges[5]
 //   bits 24-28: SpellCharges[0..4] individual change bits
 //   bit 29: group gate for Enchantment[13]
 //   bits 30-42: Enchantment[0..12] individual change bits
 //
-// Create path: hand-port emits 4 unconditional PackedGuid128s + owner-gated runs
-// of scalars + Enchantment[13] (custom writer) + 11 trailing zero placeholders
-// (owner-gated mix) + a final WriteBits(0u, 6) + FlushBits dynamic-field-count
-// preamble. Enum declaration order *is* the Create wire byte order.
+// Create path: 4 unconditional PackedGuid128s + owner-gated runs of scalars +
+// Enchantment[13] (custom writer) + trailing scalars (owner-gated mix) that carry
+// the two dynamic-field sizes + the Gems payload + a final WriteBits(0u, 6) +
+// FlushBits. That trailing 6-bit write is ItemModList::WriteCreate for the Modifiers
+// field, not a dynamic-field-count preamble as an earlier comment here claimed.
+// Enum declaration order *is* the Create wire byte order.
 //
 // Previous-life note: file used to hold a legacy descriptor-tree slot-index enum
 // (ITEM_FIELD_OWNER = 7, etc.) for the pre-Cataclysm reader. Nothing referenced it
@@ -134,26 +136,61 @@ public enum ItemField
     [DescriptorCreatePlaceholder(DescriptorType.UInt8, OwnerOnly = true)]
     ITEM_PAD_OWNER_UINT8,
 
+    // ArtifactPowers.size() — stays zero-size; artifacts do not exist in this content
+    // and there is no legacy source for them.
     [DescriptorCreatePlaceholder(DescriptorType.UInt32)]
-    ITEM_PAD_UINT32_1,
+    ITEM_ARTIFACT_POWERS_SIZE,
 
-    [DescriptorCreatePlaceholder(DescriptorType.UInt32)]
-    ITEM_PAD_UINT32_2,
+    // Gems.size() — element count for the Gems dynamic field. The payload itself is
+    // written further down, after DEBUGItemLevel (see ITEM_GEMS_BODY_CREATE).
+    [DescriptorCreatePlaceholder(DescriptorType.UInt32,
+                                 CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateItemGemsSize))]
+    ITEM_GEMS_SIZE_CREATE,
 
+    // DynamicFlags2
     [DescriptorCreatePlaceholder(DescriptorType.UInt32, OwnerOnly = true)]
     ITEM_PAD_OWNER_UINT32,
 
+    // ItemBonusKey: Int32 ItemID + UInt32 BonusListIDs.size() (always 0 here).
     [DescriptorCreatePlaceholder(DescriptorType.UInt32)]
     ITEM_PAD_UINT32_3,
 
     [DescriptorCreatePlaceholder(DescriptorType.UInt32)]
     ITEM_PAD_UINT32_4,
 
+    // DEBUGItemLevel
     [DescriptorCreatePlaceholder(DescriptorType.UInt16, OwnerOnly = true)]
     ITEM_PAD_OWNER_UINT16,
 
-    // Trailing 6-bit zero write + FlushBits — dynamic field count preamble for
-    // ArtifactPowers / Gems (both zero-size for HermesProxy).
+    // Gems payload — ArtifactPowers[] elements would precede it, but that field is
+    // always zero-size so it contributes nothing. 37 bytes per element; the count must
+    // agree with ITEM_GEMS_SIZE_CREATE above.
+    [DescriptorCreatePlaceholder(DescriptorType.UInt32,
+                                 CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateItemGemsBody))]
+    ITEM_GEMS_BODY_CREATE,
+
+    // Trailing 6-bit zero write + FlushBits — ItemModList::WriteCreate for the
+    // Modifiers field (Values.size() == 0).
     [DescriptorCreateBitsPlaceholder(0u, 6)]
     ITEM_PAD_TRAILING_DYNAMIC_FIELDS,
+
+    // -------------------------------------------------------------------------
+    // Gems dynamic field, Update path. Two emit phases, mirroring UnitData's
+    // ChannelObjects:
+    //   1. MaskPreamble between the blocks-mask prefix and FlushBits (32-bit size +
+    //      per-element changed bitmask).
+    //   2. Body at the bit-2 position in the block-0 payload — emitted ahead of bit 3
+    //      (Owner) because the generator sorts Update writes by bit ascending.
+    // The preamble sets no bits; the field entry below sets them, gated on
+    // HasGemsUpdate. SourceProperty names HasGemsUpdate only to bind a member —
+    // CustomPredicate and CustomWriter own both the mask build and the wire write.
+    // -------------------------------------------------------------------------
+
+    [DescriptorMaskPreamble(bit: 2, customWriter: nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteUpdateItemGemsMaskPreamble))]
+    ITEM_GEMS_PREAMBLE_UPDATE,
+
+    [DescriptorUpdateField(nameof(ItemData.HasGemsUpdate), DescriptorType.Int32, bit: 2, ParentBit = 0,
+                           CustomPredicate = "src.HasGemsUpdate",
+                           CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteUpdateItemGemsBody))]
+    ITEM_GEMS_BODY_UPDATE,
 }

--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -386,17 +386,27 @@ public partial class ObjectUpdateBuilder
 
     internal void WriteEnchantmentUpdate(WorldPacket data, ItemEnchantment[] arr, int i)
     {
+        // UF::ItemEnchantment is HasChangesMask<6>, so the inner mask is SIX bits wide:
+        //   bit 0 group gate, 1 ID (int32), 2 Duration (uint32), 3 Charges (int16),
+        //   4 Field_A (uint8), 5 Field_B (uint8).
+        // Writing it as 4 bits silently broke every live enchantment update: the 4-bit
+        // mask 0b0011 flushed to 0x30, the client read 6 bits from that byte and got
+        // 0b001100 — group bit clear — so it discarded the whole struct and left the
+        // payload bytes unconsumed. Symptom was "enchant only appears after relog",
+        // because the Create path writes the struct flat with no mask. Gems escaped it
+        // only because they ride the separate Gems dynamic field.
+        // Field_A / Field_B have no legacy source, so bits 4 and 5 stay clear.
         var ench = arr[i];   // guaranteed non-null — caller gates on element bit
         uint enchMask = 0;
         if (ench.ID.HasValue) enchMask |= 2;
         if (ench.Duration.HasValue) enchMask |= 4;
         if (ench.Charges.HasValue) enchMask |= 8;
         if (enchMask != 0) enchMask |= 1;
-        data.WriteBits(enchMask, 4);
+        data.WriteBits(enchMask, 6);
         data.FlushBits();
         if (ench.ID.HasValue) data.WriteInt32(ench.ID.Value);
         if (ench.Duration.HasValue) data.WriteUInt32(ench.Duration.Value);
-        if (ench.Charges.HasValue) data.WriteUInt16(ench.Charges.Value);
+        if (ench.Charges.HasValue) data.WriteInt16((short)ench.Charges.Value);
     }
 
     // -----------------------------------------------------------------------------------

--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -1,4 +1,4 @@
-// Nullable disabled file-wide because the ported WriteUpdate*Data methods (lifted
+﻿// Nullable disabled file-wide because the ported WriteUpdate*Data methods (lifted
 // verbatim from the HermesProxy-WOTLK fork, which compiles with nullable disabled)
 // access nullable struct/reference members without `.Value` / null-forgiving annotation.
 // The pre-port WriteCreate*Data code in this file was nullable-safe, but the ported
@@ -397,6 +397,94 @@ public partial class ObjectUpdateBuilder
         if (ench.ID.HasValue) data.WriteInt32(ench.ID.Value);
         if (ench.Duration.HasValue) data.WriteUInt32(ench.Duration.Value);
         if (ench.Charges.HasValue) data.WriteUInt16(ench.Charges.Value);
+    }
+
+    // -----------------------------------------------------------------------------------
+    // Item Gems dynamic field (ItemData bit 2). Source is GameState.GetGemsForItem — the
+    // legacy parse path (UpdateHandler) maps each socket enchant id to its gem item id via
+    // CSV/Gems3.csv and caches the 3-slot array there.
+    //
+    // Element layout is UF::SocketedGem from the 3.4.3 server source:
+    //   WriteCreate: Int32 ItemID + 16x UInt16 BonusListIDs + UInt8 Context  (37 bytes)
+    //   WriteUpdate: WriteBits(blocksMask, 1) + WriteBits(block, 32) + FlushBits, then the
+    //                bit-gated fields in *declaration* order (ItemID, Context, BonusListIDs) —
+    //                which is NOT the create order.
+    // Verified against a native Wrathion 3.4.3 capture: two item CreateObject1 blocks with
+    // identical guid packing differ by exactly 74 bytes for 2 gems. (WowPacketParser's
+    // V3_4_0 module under-reads the create element — it skips BonusListIDs — so its parse
+    // output is not the reference here; the server source is.)
+    //
+    // Gems.size() follows Item::SetGem, which does ModifyValue(&Gems, slot): the array is
+    // indexed by socket slot and sized to the highest filled slot + 1, so an item gemmed
+    // only in socket 3 sends 3 elements with the first two ItemID = 0.
+    // -----------------------------------------------------------------------------------
+
+    /// <summary>Element count for the Gems dynamic field: highest filled socket slot + 1.</summary>
+    private uint GetItemGemsSize()
+    {
+        var gems = _gameState.GetGemsForItem(_updateData.Guid);
+        if (gems == null)
+            return 0;
+
+        uint size = 0;
+        for (int i = 0; i < gems.Length; i++)
+            if (gems[i] != 0)
+                size = (uint)(i + 1);
+        return size;
+    }
+
+    internal void WriteCreateItemGemsSize(WorldPacket data, ItemData src)
+    {
+        data.WriteUInt32(GetItemGemsSize());
+    }
+
+    internal void WriteCreateItemGemsBody(WorldPacket data, ItemData src)
+    {
+        uint size = GetItemGemsSize();
+        if (size == 0)
+            return;
+
+        var gems = _gameState.GetGemsForItem(_updateData.Guid)!;
+        for (int i = 0; i < size; i++)
+        {
+            data.WriteInt32((int)gems[i]);      // ItemID
+            for (int b = 0; b < 16; b++)        // BonusListIDs[16] — no legacy source
+                data.WriteUInt16(0);
+            data.WriteUInt8(0);                 // Context
+        }
+    }
+
+    internal void WriteUpdateItemGemsMaskPreamble(WorldPacket data, ref Framework.Util.StackBitMask blocks, ItemData src)
+    {
+        // DynamicUpdateField preamble: 32-bit size + per-element changed bitmask. Runs
+        // between the blocks-mask prefix write and FlushBits, so it is bit-aligned to the
+        // prefix rather than byte-aligned with the field payload.
+        uint size = GetItemGemsSize();
+        data.WriteBits(size, 32);
+        if (size != 0)
+            data.WriteBits(0xFFFFFFFFu, (int)size);
+    }
+
+    internal void WriteUpdateItemGemsBody(WorldPacket data, ItemData src)
+    {
+        uint size = GetItemGemsSize();
+        if (size == 0)
+            return;
+
+        var gems = _gameState.GetGemsForItem(_updateData.Guid)!;
+        for (int i = 0; i < size; i++)
+        {
+            // SocketedGem::WriteUpdate with every bit of the 20-bit inner mask set —
+            // bit 0 group, 1 ItemID, 2 Context, 3 BonusListIDs group, 4..19 per element.
+            // Matches what the native server emits after a socket operation.
+            data.WriteBits(1u, 1);
+            data.WriteBits(0x000FFFFFu, 32);
+            data.FlushBits();
+            data.WriteInt32((int)gems[i]);      // ItemID
+            data.WriteUInt8(0);                 // Context
+            for (int b = 0; b < 16; b++)        // BonusListIDs[16]
+                data.WriteUInt16(0);
+        }
     }
 
     // WriteCreateContainerData emitted by HermesProxy.SourceGen.ObjectUpdateBuilderGenerator

--- a/HermesProxy/World/Server/Packets/ItemPackets.cs
+++ b/HermesProxy/World/Server/Packets/ItemPackets.cs
@@ -934,7 +934,7 @@ class EnchantmentLog : ServerPacket, ISpanWritable
     public WowGuid128 ItemGUID;
     public int ItemID;
     public int Enchantment;
-    public int EnchantSlot = 1;
+    public int EnchantSlot;
 }
 
 public class CancelTempEnchantment : ClientPacket

--- a/HermesProxy/World/Server/Packets/UpdatePackets.cs
+++ b/HermesProxy/World/Server/Packets/UpdatePackets.cs
@@ -589,6 +589,7 @@ public class UpdateObject : ServerPacket
         var item = u.ItemData;
         if (item != null)
         {
+            if (item.HasGemsUpdate) return false;
             if (item.Owner != null || item.ContainedIn != null) return false;
             if (item.Creator != null || item.GiftCreator != null) return false;
             if (item.StackCount.HasValue || item.Duration.HasValue || item.Flags.HasValue) return false;


### PR DESCRIPTION
Closes #146.

Two independent V3_4_3 item-rendering defects, found together because the second one masked the first. Both are write-side only; the parse side was already correct in each case.

---

# 1. Socketed gems never appear (#146)

Socketing a gem applied its stats but the socket rendered empty, and relogging did not help. The parse path already mapped each socket enchant id to its gem item id through `CSV/Gems3.csv` and cached it in `GameState`, but nothing on the V3_4_3 write path read it back — `SaveGemsForItem` was a dead store for this build. `V1_14` / `V2_5` were unaffected; they write gems as a legacy dynamic field.

This adds the `Gems` `DynamicUpdateField` (`ItemData` bit 2), following the `ChannelObjects` pattern already used for `UnitData`:

| Writer | Role |
|---|---|
| `WriteCreateItemGemsSize` | `uint32 Gems.size()` |
| `WriteCreateItemGemsBody` | 37 B per element |
| `WriteUpdateItemGemsMaskPreamble` | `WriteBits(size, 32)` + per-element changed mask |
| `WriteUpdateItemGemsBody` | inner 20-bit mask + gated fields |

Wired from `V3_4_3_54261/ItemField.cs` via `CustomWriter` on the create placeholders plus a `DescriptorMaskPreamble(bit: 2)` and a `DescriptorUpdateField(bit: 2, ParentBit = 0)` gated on `ItemData.HasGemsUpdate`. Data source is the existing `GameState.GetGemsForItem`; no new plumbing.

Element count follows `Item::SetGem`, which does `ModifyValue(&Gems, slot)`: the array is indexed by socket slot and sized to the highest filled slot + 1, so an item gemmed only in socket 3 sends three elements with the first two `ItemID = 0`.

### Two things the issue body got wrong

**The trailing `WriteBits(0u, 6)` is not a dynamic-field-count preamble.** It is `ItemModList::WriteCreate` for the `Modifiers` field (`Values.size()`). The gem count is a plain `uint32` written inline, in what was `ITEM_PAD_UINT32_2`. The stale comment is corrected and the placeholders that actually carry `ArtifactPowers.size()`, `Gems.size()`, `DynamicFlags2`, `ItemBonusKey` and `DEBUGItemLevel` are now named.

**WowPacketParser is not the reference here.** Its `V3_4_0` module under-reads the create element — it stops after `ItemID` and `Context`, skipping the 16 `BonusListIDs`. That is trailing data so nothing errors, and the parse output looks plausible while being 32 bytes short per element.

Ground truth is the 3.4.3 server source: the create element is `int32 ItemID` + `16x uint16 BonusListIDs` + `uint8 Context` = **37 bytes**, and the update element writes the same fields in *declaration* order (`ItemID`, `Context`, `BonusListIDs`), which is not the create order. Confirmed by byte-diffing a native capture: two item `CreateObject1` blocks with identical guid packing measure **299 bytes with no gems and 373 with two** — 74 / 2 = 37.

---

# 2. Live item enchantments were silently discarded

`UF::ItemEnchantment` is `HasChangesMask<6>` — bit 0 group gate, 1 `ID`, 2 `Duration`, 3 `Charges`, 4 `Field_A`, 5 `Field_B` — but `WriteEnchantmentUpdate` emitted the nested mask with `WriteBits(enchMask, 4)`.

The two-bit shortfall **discarded the field entirely** rather than truncating it. A 4-bit mask of `0b0011` (group + ID) flushed to the byte `0x30`; the client read six bits from that byte, got `0b001100` with the group bit clear, and since every field is gated behind `changesMask[0]` it skipped the whole struct and left the four ID bytes unconsumed. No error, no crash.

Everything that only showed up after a relog traces back to this, because the Create path writes the struct flat with no mask:

- weapon enchant text missing from the item tooltip
- `Eternal Belt Buckle` (enchant 3729, prismatic slot 6) not adding its socket
- any other live enchantment change

Socketed gems escaped it only because they ride the separate `Gems` dynamic field — which is why part 1 had to be fixed before this one became visible.

### The equivalence oracle was hiding it

The hand-port reference in `ItemSectionEquivalenceTests` wrote the same four bits, so generated and expected output agreed exactly and the suite stayed green. It is corrected here too. An equivalence oracle hand-written from the same misreading as the code validates the bug rather than catching it — nested mask widths belong against `HasChangesMask<N>` in the 3.4.3 source, not against a sibling implementation.

### SMSG_ENCHANTMENTLOG resolution

The legacy packet carries only `(owner, caster, item entry, enchant id)` and is emitted for every slot below `MAX_INSPECTED_ENCHANTMENT_SLOT`; the modern packet needs the item guid and the enchantment slot as well. The old handler guessed the guid by scanning equipped slots for a matching entry — which picks the wrong item as soon as the player owns two of the same entry — and left `EnchantSlot` hardcoded at `1` (TEMP) whatever the real slot was.

The log is now parked in `GameSessionData.PendingEnchantmentLog` and completed by `ResolvePendingEnchantmentLog` from the item update that follows in the same server tick, which supplies both. An unclaimed log still flushes best-effort so nothing is swallowed.

---

## Also in this PR

- `HasGemsUpdate` is probed in `IsEmptyValuesDelta` so a gems-only Values delta can never be filtered out.
- The two gem staging arrays become `stackalloc` spans and `SaveGemsForItem` takes a `ReadOnlySpan<uint?>`, removing one allocation per item Values update on the parse hot path. Both call sites are per-object and non-loop-nested, and there is no `SkipLocalsInit` in the solution, so the slots still start `null` — the sentinel `SaveGemsForItem` relies on to skip untouched sockets.
- `ArtifactPowers` (bit 1) deliberately stays zero-size.

## Testing

Three playtest runs against AzerothCore mod-playerbots with a 3.4.3.54261 client, with a native Wrathion capture as the reference throughout.

Gems, all confirmed on the wire:

- live socketing renders immediately; socket bonuses apply
- incremental growth across sequential sockets: 1 element to 2 elements
- relog: 11 gemmed items in `CreateObject1`, element counts of **1, 2 and 3**
- **zero-fill**, on both paths — an item gemmed only in socket 3 sends `ItemID: 0`, `ItemID: 0`, `ItemID: 40111`

Enchantments:

- live Values deltas now carry `(Enchantment) [6] ID: 3729` and `[4] ID: 3518`, matching the native capture field for field
- `EnchantSlot` reports **6** for the belt buckle and **4** for a Sock3 gem, against a real item guid
- weapon enchant tooltip text appears without relogging

Session health:

- a full 30-minute session parsed with **zero** `SMSG_UPDATE_OBJECT` errors; the handful of remaining WPP errors are pre-existing module gaps on unrelated opcodes (`ARENA_TEAM_ROSTER`, `UPDATE_ACTION_BUTTONS`, `WORLD_SERVER_INFO`, `PVP_SEASON`, `INITIALIZE_FACTIONS`, `CHAT_MESSAGE_SAY`)
- 829 tests green

One environment note for anyone reproducing: **native Wrathion (TrinityCore 3.4.3) cannot fill a prismatic socket at all**, so the zero-fill case has no native reference and must be exercised against AzerothCore.

The prismatic *enchant* itself works there — `Eternal Belt Buckle` applies, slot 6 gets 3729, and the extra socket reaches the client — but every `CMSG_SOCKET_GEMS` that touches it is dropped without a reply. The cause is the gem-colour check in `WorldSession::HandleSocketGems` (`Handlers/ItemHandler.cpp`):

```cpp
if (SocketColorToGemTypeMask[itemTarget->GetSocketColor(i)] != gemProperties[i]->Type)
{
    if (!(SocketColorToGemTypeMask[itemTarget->GetSocketColor(i)] & SOCKET_COLOR_PRISMATIC) || ...)
        return;
}
```

A prismatic socket has no colour, so `GetSocketColor(i)` is `0`: the mask is `0`, `0 != gemType` is always true, and `0 & SOCKET_COLOR_PRISMATIC` is always false — so the escape hatch can never fire and every gem is rejected. AzerothCore's equivalent only rejects meta/normal mismatches, which leaves `Color == 0` acceptable, which is why the same operation succeeds there. Item data is not involved: `ItemSparse` gives 50707 two native sockets (`SocketType = [4, 2, 0]`) on both, so `firstPrismatic = 2` is correct.

Harness note: `ItemSectionEquivalenceTests` builds `GameSessionData` via `GetUninitializedObject`, so `ItemGems` was null and the new writer threw. Its helper now initialises that field — worth knowing for future builder code that reads session state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjnjeA75aTMyzGK1AB6jrf
