### PR TITLE
fix(v3_4_3): drop fake LFG item-level zeros from lock tooltips

### DIFF
--- a/HermesProxy.Tests/World/Server/LfgSlotsTests.cs
+++ b/HermesProxy.Tests/World/Server/LfgSlotsTests.cs
@@ -96,8 +96,33 @@ public class LfgSlotsTests
     [InlineData(1031u, 2u)] // NotInSeason
     [InlineData(0u, 0u)]
     [InlineData(6u, 0u)]   // RaidLocked stays visible
+    [InlineData(4u, 0u)]   // TooLowGearScore stays visible (remapped, not hidden)
+    [InlineData(15u, 0u)]  // HasRestriction stays visible
     public void ToSoftLock_HidesExpansionLevelAndSeason(uint lockStatus, uint expected)
     {
         Assert.Equal(expected, LfgSlots.ToSoftLock(lockStatus));
+    }
+
+    [Theory]
+    [InlineData(4u, 15u)]   // TooLowGearScore → HasRestriction
+    [InlineData(5u, 15u)]   // TooHighGearScore → HasRestriction
+    [InlineData(2u, 2u)]    // TooLowLevel unchanged
+    [InlineData(6u, 6u)]    // RaidLocked unchanged
+    [InlineData(1031u, 1031u)]
+    public void ToDisplayLockStatus_RewritesGearScoreToNumberlessReason(uint lockStatus, uint expected)
+    {
+        Assert.Equal(expected, LfgSlots.ToDisplayLockStatus(lockStatus));
+    }
+
+    [Theory]
+    [InlineData(2u, 0u)]    // TooLowLevel stays a visible party reason
+    [InlineData(3u, 0u)]    // TooHighLevel stays a visible party reason
+    [InlineData(4u, 0u)]
+    [InlineData(15u, 0u)]
+    [InlineData(1u, 2u)]    // InsufficientExpansion still hidden
+    [InlineData(1031u, 2u)] // NotInSeason still hidden
+    public void ToPartySoftLock_KeepsLevelAndGearReasonsVisible(uint lockStatus, uint expected)
+    {
+        Assert.Equal(expected, LfgSlots.ToPartySoftLock(lockStatus));
     }
 }

--- a/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/LFGHandler.cs
@@ -66,7 +66,7 @@ public partial class WorldClient
                 {
                     DFJoinBlackListSlot slot = new DFJoinBlackListSlot();
                     slot.Slot = packet.ReadUInt32();
-                    slot.Reason = packet.ReadUInt32();
+                    slot.Reason = LfgSlots.ToDisplayLockStatus(packet.ReadUInt32());
                     bl.Slots.Add(slot);
                 }
                 result.BlackList.Add(bl);
@@ -260,8 +260,8 @@ public partial class WorldClient
             {
                 LFGLockInfoData li = new LFGLockInfoData();
                 li.Slot = packet.ReadUInt32();
-                li.LockStatus = packet.ReadUInt32();
-                li.SoftLock = LfgSlots.ToSoftLock(li.LockStatus);
+                li.LockStatus = LfgSlots.ToDisplayLockStatus(packet.ReadUInt32());
+                li.SoftLock = LfgSlots.ToPartySoftLock(li.LockStatus);
                 entry.Locks.Add(li);
                 alreadyListed.Add(LfgSlots.GetDungeonId(li.Slot));
                 GetSession().GameState.RememberLfgSlot(li.Slot);
@@ -345,7 +345,7 @@ public partial class WorldClient
         {
             LFGBlackListSlot slot = new LFGBlackListSlot();
             slot.Slot = packet.ReadUInt32();
-            slot.Reason = packet.ReadUInt32();
+            slot.Reason = LfgSlots.ToDisplayLockStatus(packet.ReadUInt32());
             // Map legacy LFGLockStatus → modern LFGSoftLock per TC
             // wotlk_classic LFGMgr.cpp:1807-1823.
             slot.SoftLock = LfgSlots.ToSoftLock(slot.Reason);

--- a/HermesProxy/World/Server/LfgSlots.cs
+++ b/HermesProxy/World/Server/LfgSlots.cs
@@ -71,6 +71,28 @@ public static class LfgSlots
         _ => (uint)LFGSoftLock.None,
     };
 
+    // Party-info SoftLock only hides content the backend cannot serve. Level
+    // and gear locks stay SoftLock=None so 3.4.3 prints the real per-player
+    // reason (e.g. "Caklick must advance to a higher level.") instead of a
+    // bare "You may not queue for this dungeon."
+    public static uint ToPartySoftLock(uint lockStatus) => (LFGLockStatus)lockStatus switch
+    {
+        LFGLockStatus.InsufficientExpansion
+        or LFGLockStatus.NotInSeason => (uint)LFGSoftLock.Unk2,
+        _ => (uint)LFGSoftLock.None,
+    };
+
+    // 3.3.5a only sends lock status, not required/current item level. Leaving
+    // TooLow/TooHighGearScore on the wire makes 3.4.3 print "Requires: 0.
+    // Currently 0." (issue #144). HasRestriction (15) has no FrameXML string
+    // and renders INSTANCE_UNAVAILABLE_*_OTHER instead.
+    public static uint ToDisplayLockStatus(uint lockStatus) => (LFGLockStatus)lockStatus switch
+    {
+        LFGLockStatus.TooLowGearScore
+        or LFGLockStatus.TooHighGearScore => (uint)LFGLockStatus.HasRestriction,
+        _ => lockStatus,
+    };
+
     /// <summary>
     /// Packed slots to inject as SoftLock hide-rows so the 3.4.3 client drops the
     /// Titan Rune Protocol categories from Specific Dungeons. Skips IDs already

--- a/HermesProxy/World/Server/Packets/LFG/LFGEnums.cs
+++ b/HermesProxy/World/Server/Packets/LFG/LFGEnums.cs
@@ -14,6 +14,10 @@ public enum LFGLockStatus : uint
     TooLowGearScore        = 4,
     TooHighGearScore       = 5,
     RaidLocked             = 6,
+    // 3.4.3 LFG.h LFG_LOCKSTATUS_HAS_RESTRICTION. FrameXML has no string at
+    // [15], so the tooltip is INSTANCE_UNAVAILABLE_*_OTHER ("You do not meet
+    // the requirements for this dungeon.") with no Requires/Currently numbers.
+    HasRestriction         = 15,
     AttunementTooLowLevel  = 1001,
     AttunementTooHighLevel = 1002,
     QuestNotCompleted      = 1022,


### PR DESCRIPTION
Fixes #144

3.4.3.54261 client on AzerothCore 3.3.5a: Wrath Heroic lock tooltips printed **Requires: 0. Currently 0.** for every party member. The lock itself was real (fresh 80s cannot queue). The numbers were not.

## Cause

3.4.3 FrameXML maps lock reason 4 (`TooLowGearScore`) to `INSTANCE_UNAVAILABLE_*_GEAR_TOO_LOW`, which always interpolates `SubReason1` / `SubReason2` as required / current item level.

**3.3.5a does not send those numbers.** `SMSG_LFG_PLAYER_INFO` / `SMSG_LFG_PARTY_INFO` / `SMSG_LFG_JOIN_RESULT` only carry `dungeonId` + `lockStatus`. There is no required-ilvl or current-ilvl field on that wire. Hermes left `SubReason1/2` at 0, so the client printed zeros.

Synthesising the pair would invent values the server never sent (and would drift on custom `access_requirement`). This change does not invent them.

## Change

- Remap `TooLowGearScore` / `TooHighGearScore` → `HasRestriction` (15)
- 3.4.3 `LFG_INSTANCE_INVALID_CODES[15]` is unset, so the tooltip falls through to `INSTANCE_UNAVAILABLE_*_OTHER`: **You do not meet the requirements for this dungeon.**
- SoftLock stays `None` for those rows, so heroics remain visible and locked
- Party-info no longer SoftLocks level / gear. A level-3 party member now prints the real line (**Caklick must advance to a higher level**) instead of a bare header. Titan Rune / expansion / season hide-rows are unchanged
- Real locks we do understand (quest, achievement, missing item, raid lock) are forwarded as-is

## Testing

AzerothCore + 3.4.3.54261, party of 80s + a level 3 bot (Caklick):

- Hover Pit of Saron / Gundrak (quest gate) → **You have not completed the required quest** / **Galaedon has not completed the required quest**
- Hover a WotLK Normal with Caklick in the group → header **You may not queue for this dungeon** plus the real per-player reason, not `Requires: 0`
- Heroics stay listed and locked. Queue behaviour unchanged

836 unit tests green, including `ToDisplayLockStatus` / `ToPartySoftLock`.

Not retested on TrinityCore or cMaNGOS. Same 3.3.5a lock wire (status only, no item-level pair).

## Playtest screenshots

Quest lock (Pit of Saron / Gundrak) still shows the real 3.3.5a reason. No invented item-level numbers:

![Quest lock tooltip](https://raw.githubusercontent.com/rursache/HermesProxy/pr-150-screenshots/lfg-quest-lock.jpg)

Party with a level-3 bot. Header is the 3.4.3 lock title. Detail lines come from lock status only — 3.3.5a never sends required/current level or item-level numbers on this packet:

![Party lock tooltip](https://raw.githubusercontent.com/rursache/HermesProxy/pr-150-screenshots/lfg-party-lock.jpg)
