### PR TITLE
fix(v3_4_3): open the guild crest designer from tabard gossip

### DIFF
--- a/HermesProxy.Tests/World/Server/BinderConfirmOpcodeTests.cs
+++ b/HermesProxy.Tests/World/Server/BinderConfirmOpcodeTests.cs
@@ -15,6 +15,8 @@ public class BinderConfirmOpcodeTests
         Assert.Equal(10378u, (uint)V343.Opcode.SMSG_BINDER_CONFIRM);
         Assert.Equal((uint)V343.Opcode.SMSG_SHOW_BANK, (uint)V343.Opcode.SMSG_BINDER_CONFIRM);
         Assert.Equal((uint)V343.Opcode.SMSG_SPIRIT_HEALER_CONFIRM, (uint)V343.Opcode.SMSG_BINDER_CONFIRM);
+        Assert.Equal((uint)V343.Opcode.SMSG_PLAYER_TABARD_VENDOR_ACTIVATE, (uint)V343.Opcode.SMSG_BINDER_CONFIRM);
         Assert.Equal(20, (int)PlayerInteractionType.Binder);
+        Assert.Equal(14, (int)PlayerInteractionType.GuildTabardVendor);
     }
 }

--- a/HermesProxy/World/Enums/V3_4_3_54261/Opcode.cs
+++ b/HermesProxy/World/Enums/V3_4_3_54261/Opcode.cs
@@ -342,9 +342,9 @@ public enum Opcode : uint
 	SMSG_BATTLEFIELD_STATUS = 10533u,
 	SMSG_BATTLEGROUND_PLAYER_JOINED = 10539u,
 	SMSG_BATTLEGROUND_PLAYER_LEFT = 10540u,
-	// Same wire as SMSG_SHOW_BANK / SMSG_SPIRIT_HEALER_CONFIRM
-	// (SMSG_NPC_INTERACTION_OPEN_RESULT, 10378). V3_4_3 dropped
-	// the dedicated binder-confirm packet; the innkeeper dialog
+	// Same wire as SMSG_SHOW_BANK / SMSG_SPIRIT_HEALER_CONFIRM /
+	// SMSG_PLAYER_TABARD_VENDOR_ACTIVATE (SMSG_NPC_INTERACTION_OPEN_RESULT, 10378).
+	// V3_4_3 dropped the dedicated binder-confirm packet; the innkeeper dialog
 	// is InteractionType=Binder (20). See BinderConfirm.Write.
 	SMSG_BINDER_CONFIRM = 10378u,
 	SMSG_BIND_POINT_UPDATE = 9597u,
@@ -553,14 +553,15 @@ public enum Opcode : uint
 	SMSG_SHOW_BANK = 10378u,
 	SMSG_SHOW_RATINGS = 0u,
 	SMSG_SOCKET_GEMS_SUCCESS = 10023u,
-	// Same wire opcode as SMSG_SHOW_BANK / SMSG_BINDER_CONFIRM
-	// (SMSG_NPC_INTERACTION_OPEN_RESULT, 10378).
+	// Same wire opcode as SMSG_SHOW_BANK / SMSG_BINDER_CONFIRM /
+	// SMSG_PLAYER_TABARD_VENDOR_ACTIVATE (SMSG_NPC_INTERACTION_OPEN_RESULT, 10378).
 	// V3_4_3 dropped the dedicated SMSG_SPIRIT_HEALER_CONFIRM packet; the modern
 	// spirit-healer res dialog is driven by NPC_INTERACTION_OPEN_RESULT with
 	// InteractionType=SpiritHealer. The generated universal->wire table keys on the
-	// universal name, so SHOW_BANK, BINDER_CONFIRM and SPIRIT_HEALER_CONFIRM each
-	// map to 10378 independently. The reverse wire->universal slot for 10378 is
-	// server-to-client only (the client never sends it), so the alias is harmless.
+	// universal name, so SHOW_BANK, BINDER_CONFIRM, SPIRIT_HEALER_CONFIRM and
+	// PLAYER_TABARD_VENDOR_ACTIVATE each map to 10378 independently. The reverse
+	// wire->universal slot for 10378 is server-to-client only (the client never
+	// sends it), so the alias is harmless.
 	SMSG_SPIRIT_HEALER_CONFIRM = 10378u,
 	SMSG_SPELL_COOLDOWN = 11285u,
 	SMSG_SPELL_DAMAGE_SHIELD = 11310u,
@@ -725,6 +726,11 @@ public enum Opcode : uint
 	SMSG_GUILD_EVENT_TAB_MODIFIED = 10741u,
 	SMSG_GUILD_EVENT_TAB_TEXT_CHANGED = 10742u,
 	SMSG_PLAYER_SAVE_GUILD_EMBLEM = 10745u,
+	// Same wire as SMSG_SHOW_BANK / SMSG_BINDER_CONFIRM /
+	// SMSG_SPIRIT_HEALER_CONFIRM (SMSG_NPC_INTERACTION_OPEN_RESULT, 10378).
+	// V3_4_3 dropped SMSG_PLAYER_TABARD_VENDOR_ACTIVATE; the crest UI is
+	// InteractionType=GuildTabardVendor (14). See PlayerTabardVendorActivate.Write.
+	SMSG_PLAYER_TABARD_VENDOR_ACTIVATE = 10378u,
 	SMSG_QUEST_PUSH_RESULT = 10896u,
 	SMSG_QUEST_UPDATE_ADD_CREDIT_SIMPLE = 10893u,
 	SMSG_LOOT_LIST = 10049u,

--- a/HermesProxy/World/Server/PacketHandlers/GuildHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/GuildHandler.cs
@@ -187,6 +187,14 @@ public partial class WorldSocket
         SendPacketToServer(packet);
     }
 
+    [PacketHandler(Opcode.CMSG_TABARD_VENDOR_ACTIVATE)]
+    void HandleTabardVendorActivate(InteractWithNPC interact)
+    {
+        WorldPacket packet = new WorldPacket(Opcode.MSG_TABARDVENDOR_ACTIVATE);
+        packet.WriteGuid(interact.CreatureGUID.To64());
+        SendPacketToServer(packet);
+    }
+
     [PacketHandler(Opcode.CMSG_SAVE_GUILD_EMBLEM)]
     void HandleSaveGuildEmblem(SaveGuildEmblem emblem)
     {

--- a/HermesProxy/World/Server/Packets/GuildPackets.cs
+++ b/HermesProxy/World/Server/Packets/GuildPackets.cs
@@ -21,6 +21,7 @@ using System.Text;
 using Framework.Constants;
 using Framework.GameMath;
 using Framework.IO;
+using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System.Collections.Generic;
@@ -991,15 +992,34 @@ public class PlayerTabardVendorActivate : ServerPacket, ISpanWritable
 
     public override void Write()
     {
+        // V3_4_3 wire-opcode 10378 is SMSG_NPC_INTERACTION_OPEN_RESULT
+        // (Guid + Int32 InteractionType + bit Success). Same shape as
+        // ShowBank / BinderConfirm. WPP V3_4_3_51666 has no
+        // SMSG_PLAYER_TABARD_VENDOR_ACTIVATE; type GuildTabardVendor (14)
+        // opens TabardFrame. AC still sends MSG_TABARDVENDOR_ACTIVATE
+        // with no guild check; the no-guild error is on save.
         _worldPacket.WritePackedGuid128(DesignerGUID);
+        if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+        {
+            _worldPacket.WriteInt32((int)PlayerInteractionType.GuildTabardVendor);
+            _worldPacket.WriteBit(true);
+            _worldPacket.FlushBits();
+        }
     }
 
-    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size;
+    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size
+        + (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261 ? 5 : 0);
 
     public int WriteToSpan(Span<byte> buffer)
     {
         var writer = new SpanPacketWriter(buffer);
         writer.WritePackedGuid128(DesignerGUID.Low, DesignerGUID.High);
+        if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+        {
+            writer.WriteInt32((int)PlayerInteractionType.GuildTabardVendor);
+            writer.WriteBit(true);
+            writer.FlushBits();
+        }
         return writer.Position;
     }
 


### PR DESCRIPTION
3.4.3.54261 client on AzerothCore 3.3.5a: Stormwind Guild Master (Aldwin Laughlin) gossip **I want to create a guild crest** did nothing. No UI, no error.

## Cause

1. AC `OnGossipSelect` for `GOSSIP_OPTION_TABARDDESIGNER` (11) closes gossip and sends `MSG_TABARDVENDOR_ACTIVATE` (0x1F2) with the NPC guid only. No guild check on open.

2. Hermes `HandleTabardVendorActivate` built `PlayerTabardVendorActivate` / `SMSG_PLAYER_TABARD_VENDOR_ACTIVATE`. That opcode is missing from the V3_4_3 table, so `ServerPacket` threw `UnmappedOpcodeException` and the packet was dropped.

3. Native 3.4.3 (lineagedr/3.4.3_Source / Wrathion) has no `SMSG_PLAYER_TABARD_VENDOR_ACTIVATE`. The designer is `SMSG_NPC_INTERACTION_OPEN_RESULT` (10378) with `PlayerInteractionType.GuildTabardVendor` (14) + Success bit. Same wire as bank / binder / spirit healer.

FrameXML `PlayerInteractionFrameManager`: type 14 → TabardFrame + TabardFrame_Open.

Not-in-guild is client-side: `TABARDVENDORNOGUILDGREETING` ("You must be a guild master to purchase a tabard, but feel free to browse.") and Accept disabled. Server `MSG_SAVE_GUILD_EMBLEM` error 2 (`NoGuild`) only if a save is sent.

## Change

- Alias `SMSG_PLAYER_TABARD_VENDOR_ACTIVATE = 10378u` in the V3_4_3 opcode table
- `PlayerTabardVendorActivate.Write` / `WriteToSpan` emit Guid + int32(14) + Success=1 on V3_4_3 (same shape as BinderConfirm / ShowBank)
- Forward `CMSG_TABARD_VENDOR_ACTIVATE` → legacy `MSG_TABARDVENDOR_ACTIVATE` (guid only). 3.4.3 CMSG also has a Type int32 (0=guild); leftover unread bytes are fine. Do not invent a no-guild error on open
- Extend BinderConfirmOpcodeTests to assert the 10378 alias and type 14

## Testing

AzerothCore + 3.4.3.54261, play-tested on Brahand:

- Unguilded: gossip opens TabardFrame, greeting is the not-guild-master browse line, Accept greyed out
- `.guild create "DEV"` then reopen designer: Accept enabled, 10g, crest saved

Not retested on TrinityCore or cMaNGOS. Same 3.3.5a `MSG_TABARDVENDOR_ACTIVATE` wire.
