### PR TITLE
fix(v3_4_3): write GuildClubMemberID and RaceID on the guild roster

### DIFF
--- a/HermesProxy.Tests/World/Server/GuildRosterMemberDataTests.cs
+++ b/HermesProxy.Tests/World/Server/GuildRosterMemberDataTests.cs
@@ -1,0 +1,39 @@
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+public class GuildRosterMemberDataTests
+{
+    [Fact]
+    public void Write_EmitsMemberName()
+    {
+        var member = new GuildRosterMemberData
+        {
+            Guid = WowGuid128.Create(HighGuidType703.Player, 1),
+            Name = "Brahand",
+            RankID = 0,
+            AreaID = 1519,
+            Level = 80,
+            ClassID = Class.Warrior,
+            SexID = Gender.Male,
+            RaceID = Race.Human,
+            Status = 1,
+            Authenticated = true
+        };
+
+        var packet = new GuildRoster();
+        packet.MemberData.Add(member);
+        packet.WelcomeText = "hello";
+        packet.CreateDate = 1700000000;
+        packet.WritePacketData();
+
+        byte[]? bytes = packet.GetData();
+        Assert.NotNull(bytes);
+        string ascii = System.Text.Encoding.ASCII.GetString(bytes);
+        Assert.Contains("Brahand", ascii);
+        Assert.Contains("hello", ascii);
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/GuildHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/GuildHandler.cs
@@ -314,6 +314,9 @@ public partial class WorldClient
             member.ClassID = cache.ClassId =(Class)packet.ReadUInt8();
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_4_0_8089))
                 member.SexID = cache.SexId = (Gender)packet.ReadUInt8();
+            if (GetSession().GameState.CachedPlayers.TryGetValue(member.Guid, out var existing)
+                && existing.RaceId != Race.None)
+                member.RaceID = existing.RaceId;
             GetSession().GameState.UpdatePlayerCache(member.Guid, cache);
             member.AreaID = packet.ReadInt32();
 

--- a/HermesProxy/World/Server/Packets/GuildPackets.cs
+++ b/HermesProxy/World/Server/Packets/GuildPackets.cs
@@ -21,6 +21,7 @@ using System.Text;
 using Framework.Constants;
 using Framework.GameMath;
 using Framework.IO;
+using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using System.Collections.Generic;
@@ -215,11 +216,22 @@ public class GuildRosterMemberData
         data.WriteUInt8((byte)ClassID);
         data.WriteUInt8((byte)SexID);
 
+        // V3_4_3 (lineagedr/3.4.3_Source GuildPackets.cpp GuildRosterMemberData)
+        // inserts GuildClubMemberID + RaceID before the name/note bits.
+        // Without them the client reads those 9 bytes as the name length
+        // and the MOTD/info strings after the members land on garbage.
+        if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+        {
+            data.WriteUInt64(GuildClubMemberID);
+            data.WriteUInt8((byte)RaceID);
+        }
+
         data.WriteBits(Name.GetByteCount(), 6);
         data.WriteBits(Note.GetByteCount(), 8);
         data.WriteBits(OfficerNote.GetByteCount(), 8);
         data.WriteBit(Authenticated);
         data.WriteBit(SorEligible);
+        data.FlushBits();
 
         data.WriteString(Name);
         data.WriteString(Note);
@@ -245,6 +257,8 @@ public class GuildRosterMemberData
     public Gender SexID;
     public bool Authenticated;
     public bool SorEligible;
+    public ulong GuildClubMemberID;
+    public Race RaceID = Race.None;
     public GuildRosterProfessionData[] Profession = new GuildRosterProfessionData[2];
 }
 
@@ -356,6 +370,7 @@ public class GuildEventMotd : ServerPacket, ISpanWritable
     public override void Write()
     {
         _worldPacket.WriteBits(MotdText.GetByteCount(), 11);
+        _worldPacket.FlushBits();
         _worldPacket.WriteString(MotdText);
     }
 


### PR DESCRIPTION
Fixes the 3.4.3 guild pane showing a garbage name and an empty MOTD after a successful set

3.4.3.54261 client on AzerothCore 3.3.5a: guild **DEV**, Brahand (80 Warrior). Roster Name showed **Ilo**. MOTD **hello** printed in chat (`SMSG_GUILD_EVENT_MOTD`) but the pane box stayed empty

## Cause

`SMSG_GUILD_ROSTER` header already matched Wrathion (NumAccounts, CreateDate, GuildFlags, member count, 11-bit WelcomeText/InfoText, members, then the two strings)

The per-member body did not. Native 3.4.3 (`lineagedr/3.4.3_Source` `GuildPackets.cpp` `operator<<(GuildRosterMemberData)`) writes after Gender:

1. `uint64 GuildClubMemberID`
2. `uint8 RaceID`
3. then Name(6) / Note(8) / OfficerNote(8) / Authenticated / SorEligible bits

Hermes used the Cypher/9.x layout and started those bits immediately after Gender. The client ate 9 bytes of the name field as club-id + race. A 6-bit length of 3 plus three leftover bytes is how **Ilo** showed up. MOTD (`WelcomeText`) sits after the member list, so it landed on the wrong bytes too

AC still sends the player name in the 3.3.5a roster. This is not a guid-cache mixup

## Change

- Write `GuildClubMemberID` (0, same as Wrathion) and `RaceID` (from the player cache) on V3_4_3 only
- FlushBits before the three strings
- FlushBits on `SMSG_GUILD_EVENT_MOTD` to match native write order

Do not write `DungeonScore` (commented out in Wrathion)

## Testing

AzerothCore + 3.4.3.54261, play-tested on Brahand:

- Roster Name is **Brahand**, zone / level / class unchanged
- MOTD **hello22** shows in the guild pane after set + reopen `J`
- Chat MOTD line still prints

830 unit tests green, including a roster write that keeps the member name and WelcomeText in the payload

Not retested on TrinityCore or cMaNGOS. Same 3.3.5a roster wire (name is a CString on each member)