### PR TITLE
fix(v3_4_3): read guild bank log Count as uint32, switch on EntryType

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/GuildHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/GuildHandler.cs
@@ -492,8 +492,6 @@ public partial class WorldClient
     [PacketHandler(Opcode.MSG_GUILD_BANK_LOG_QUERY)]
     void HandleGuildBankLongQuery(WorldPacket packet)
     {
-        const int maxTabs = 6;
-
         GuildBankLogQueryResults result = new();
         result.Tab = packet.ReadUInt8();
         byte logSize = packet.ReadUInt8();
@@ -502,17 +500,34 @@ public partial class WorldClient
             GuildBankLogEntry logEntry = new GuildBankLogEntry();
             logEntry.EntryType = packet.ReadInt8();
             logEntry.PlayerGUID = packet.ReadGuid().To128(GetSession().GameState);
-            
-            if (result.Tab != maxTabs)
+
+            // The legacy writer switches on the event type, not the tab index — see
+            // Guild::BankEventLogEntry::WritePacket / GuildBankLogQueryResults::Write on
+            // 3.3.5a. Keying off the tab happened to agree only because money events are
+            // queried with tab 6; a money event in an item tab (or the reverse) desynced
+            // the rest of the packet.
+            //
+            // Count is a uint32 on the wire. Reading it as a single byte left the
+            // following TimeOffset three bytes early, splicing Count's high bytes onto
+            // the real offset — which is why the guild bank Log tab showed ages like
+            // "35 years ago" that jumped around instead of counting up (issue #158).
+            switch ((GuildBankEventType)logEntry.EntryType)
             {
-                logEntry.ItemID = packet.ReadInt32();
-                logEntry.Count = packet.ReadUInt8();
-                if ((GuildBankEventType)logEntry.EntryType == GuildBankEventType.MoveItem ||
-                    (GuildBankEventType)logEntry.EntryType == GuildBankEventType.MoveItem2)
+                case GuildBankEventType.DepositItem:
+                case GuildBankEventType.WithdrawItem:
+                    logEntry.ItemID = packet.ReadInt32();
+                    logEntry.Count = (int)packet.ReadUInt32();
+                    break;
+                case GuildBankEventType.MoveItem:
+                case GuildBankEventType.MoveItem2:
+                    logEntry.ItemID = packet.ReadInt32();
+                    logEntry.Count = (int)packet.ReadUInt32();
                     logEntry.OtherTab = packet.ReadInt8();
+                    break;
+                default:
+                    logEntry.Money = packet.ReadUInt32();
+                    break;
             }
-            else
-                logEntry.Money = packet.ReadUInt32();
 
             logEntry.TimeOffset = packet.ReadUInt32();
             result.Entry.Add(logEntry);


### PR DESCRIPTION
Fixes #158

The guild bank **Log** tab showed nonsensical ages — "35 years ago" for a deposit made seconds earlier — and the number jumped around (35 → 119 → 63 → 67 over ~20 minutes) instead of counting up.

## Cause

Two defects in `HandleGuildBankLongQuery`, both in the legacy parse. The modern writer was already correct: `GuildBankLogQueryResults.Write` matches `lineagedr/3.4.3_Source` field for field, and both backends populate `TimeOffset` identically as seconds elapsed (`GameTime::GetGameTime() - m_timestamp`).

**1. `Count` read at the wrong width.** 3.3.5a writes it as a `uint32`:

```cpp
_worldPacket << uint32(logEntry.ItemID);
_worldPacket << uint32(logEntry.Count);      // <-- uint32
...
_worldPacket << uint32(logEntry.TimeOffset);
```

The parser read a single byte, so `TimeOffset` was read **three bytes early**, splicing `Count`'s high bytes onto the real offset. `Count` is small and constant (one cloth) while `TimeOffset` grows, which is exactly why the rendered age moved unpredictably rather than increasing. With more than one entry in the log, every entry after the first was misaligned too.

**2. Wrong discriminator.** The item-fields vs money-field branch keyed off the tab index:

```csharp
if (result.Tab != maxTabs)   // maxTabs == 6
```

The server switches on **`EntryType`**. The tab happened to agree because money events are queried with tab 6, but a money event reaching an item-tab query — or the reverse — parsed down the wrong branch and desynced the rest of the packet.

## Change

- `Count` is read as `uint32`
- The branch is a `switch` on `GuildBankEventType`, mirroring `Guild::BankEventLogEntry::WritePacket`: item fields for `DepositItem` / `WithdrawItem` / `MoveItem` / `MoveItem2` (plus `OtherTab` for the two move types), money for everything else

## Testing

TrinityCore 3.3.5a with client 3.4.3.54261:

- A Linen Cloth deposit **2781 seconds** old now renders as "less than an hour ago", and climbs steadily
- **Money Log** tab renders correctly — that exercises the `default:` branch, which is the half the discriminator fix covers

863/863 unit tests green.

No test added: the parse lives inside a `WorldClient` handler that needs a live session, and the test project only reaches handlers reflectively (`PacketHandlerRegistrationTests`). Covering this properly would mean lifting the per-entry parse into a testable helper — reasonable, but larger than the fix.

## Follow-up thought: this is a discriminated union

Worth recording while it is fresh, because the shape of the bug is the shape of the type.

`GuildBankLogEntry` carries four optional fields:

```csharp
public ulong? Money;
public int? ItemID;
public int? Count;
public sbyte? OtherTab;
```

Only one *group* of those is ever valid, decided by `EntryType` — item events carry `ItemID`/`Count` (and `OtherTab` for moves), money events carry `Money`. The type permits every invalid combination: money *and* item set, neither set, `OtherTab` on a deposit. Nothing enforces the correlation, so selecting the wrong branch — which is precisely defect 2 above — produced a silently malformed entry rather than a compile error or an exception.

C# union types (`feature/dotnet11` is already on the branch list) would model this directly: the log entry becomes a sum of `ItemEvent` / `MoveEvent` / `MoneyEvent`, the reader's `switch` is checked for exhaustiveness, and "money event that also has an ItemID" stops being representable. The parse would then fail to compile rather than fail silently.

Not proposing it here — it is a broader change than this fix warrants, and the same argument applies to several other packet types with the same optional-field shape (`GuildBankLogEntry` is just the one that bit us). Flagging it as a candidate for whenever the C# version moves.
