### PR TITLE
fix(v3_4_3): open the group loot roll dialog

### DIFF
--- a/HermesProxy.Tests/World/Server/LootRollOpcodeTests.cs
+++ b/HermesProxy.Tests/World/Server/LootRollOpcodeTests.cs
@@ -1,0 +1,38 @@
+using Xunit;
+using V343 = HermesProxy.World.Enums.V3_4_3_54261;
+
+namespace HermesProxy.Tests.World.Server;
+
+public class LootRollOpcodeTests
+{
+    /// <summary>
+    /// SMSG_LOOT_START_ROLL sat at the 0u placeholder, so the packet that opens the
+    /// Need/Greed/Pass dialog was discarded at send time and group loot silently
+    /// resolved around the player. The rest of the family was mapped, which is why the
+    /// rolls still scrolled past in chat and a winner was announced.
+    ///
+    /// It is named SMSG_START_LOOT_ROLL in the 3.4.3 sources, and the gap sits *below*
+    /// the mapped block (0x261F is SMSG_MASTER_LOOT_CANDIDATE_LIST, not this), which is
+    /// how it was missed. Pinning the neighbours documents that.
+    /// </summary>
+    [Fact]
+    public void V343_LootRollOpcodes_MatchLineagedr()
+    {
+        Assert.Equal(9757u, (uint)V343.Opcode.SMSG_LOOT_START_ROLL);        // 0x261D
+        Assert.Equal(9758u, (uint)V343.Opcode.SMSG_LOOT_ROLL);              // 0x261E
+        Assert.Equal(9760u, (uint)V343.Opcode.SMSG_LOOT_ROLLS_COMPLETE);    // 0x2620
+        Assert.Equal(9761u, (uint)V343.Opcode.SMSG_LOOT_ALL_PASSED);        // 0x2621
+        Assert.Equal(9762u, (uint)V343.Opcode.SMSG_LOOT_ROLL_WON);          // 0x2622
+        Assert.Equal(12820u, (uint)V343.Opcode.CMSG_LOOT_ROLL);
+    }
+
+    /// <summary>
+    /// A zero here means "no wire value for this build", and ServerPacket throws
+    /// UnmappedOpcodeException rather than sending — the exact failure this fixes.
+    /// </summary>
+    [Fact]
+    public void V343_LootStartRoll_IsNotAPlaceholder()
+    {
+        Assert.NotEqual(0u, (uint)V343.Opcode.SMSG_LOOT_START_ROLL);
+    }
+}

--- a/HermesProxy/World/Enums/V3_4_3_54261/Opcode.cs
+++ b/HermesProxy/World/Enums/V3_4_3_54261/Opcode.cs
@@ -460,7 +460,12 @@ public enum Opcode : uint
 	SMSG_LOOT_RESPONSE = 9748u,
 	SMSG_LOOT_ROLL = 9758u,
 	SMSG_LOOT_ROLL_WON = 9762u,
-	SMSG_LOOT_START_ROLL = 0u,
+	// Named SMSG_START_LOOT_ROLL in the 3.4.3 sources (0x261D), which is why it was
+	// missed while 0x261E/0x2620/0x2621/0x2622 were mapped — the gap sits below the
+	// block rather than inside it, and 0x261F is SMSG_MASTER_LOOT_CANDIDATE_LIST.
+	// Without this the Need/Greed/Pass dialog never opens: the roll resolves around
+	// the player because LOOT_ROLL / ROLL_WON / ALL_PASSED are all mapped.
+	SMSG_LOOT_START_ROLL = 9757u,
 	SMSG_MAIL_LIST_RESULT = 10070u,
 	SMSG_CHAT = 11181u,
 	SMSG_MINIMAP_PING = 9934u,

--- a/HermesProxy/World/Server/Packets/LootPackets.cs
+++ b/HermesProxy/World/Server/Packets/LootPackets.cs
@@ -16,6 +16,7 @@
  */
 
 
+using HermesProxy.Enums;
 using System;
 using Framework.Constants;
 using Framework.GameMath;
@@ -353,20 +354,38 @@ class StartLootRoll : ServerPacket, ISpanWritable
 {
     public StartLootRoll() : base(Opcode.SMSG_LOOT_START_ROLL) { }
 
+    // V3_4_3 StartLootRoll::Write inserts LootRollIneligibleReason between ValidRolls
+    // and Method: std::array<LootRollIneligibilityReason, 4> where the enum is uint32,
+    // appended as 4 * sizeof(uint32) = 16 bytes. Omitting it lands Method and the whole
+    // Item block 16 bytes early. 3.3.5a has no equivalent — it sends only the ValidRolls
+    // mask — so every entry is written as None (0).
+    private const int IneligibleReasonCount = 4;
+    private const int IneligibleReasonBytes = IneligibleReasonCount * sizeof(uint);
+
+    private static bool WritesIneligibleReasons =>
+        ModernVersion.Build == ClientVersionBuild.V3_4_3_54261;
+
     public override void Write()
     {
         _worldPacket.WritePackedGuid128(LootObj);
         _worldPacket.WriteUInt32(MapID);
         _worldPacket.WriteUInt32(RollTime);
         _worldPacket.WriteUInt8((byte)ValidRolls);
+        if (WritesIneligibleReasons)
+        {
+            for (int i = 0; i < IneligibleReasonCount; i++)
+                _worldPacket.WriteUInt32(0);         // LootRollIneligibilityReason.None
+        }
         _worldPacket.WriteUInt8((byte)Method);
         Item.Write(_worldPacket);
     }
 
     // LootItemData: 1 (bits) + ItemInstance + 4 + 1 + 1 = 7 + ItemInstanceMaxSize
     private const int LootItemDataSize = 7 + ItemPacketHelpers.ItemInstanceMaxSize;
-    // GUID(18) + 2 uints(8) + 2 bytes(2) + LootItemData
-    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 8 + 2 + LootItemDataSize;
+    // GUID(18) + 2 uints(8) + 2 bytes(2) + LootRollIneligibleReason(16 on V3_4_3) + LootItemData
+    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 8 + 2
+        + (WritesIneligibleReasons ? IneligibleReasonBytes : 0)
+        + LootItemDataSize;
 
     public int WriteToSpan(Span<byte> buffer)
     {
@@ -375,6 +394,11 @@ class StartLootRoll : ServerPacket, ISpanWritable
         writer.WriteUInt32(MapID);
         writer.WriteUInt32(RollTime);
         writer.WriteUInt8((byte)ValidRolls);
+        if (WritesIneligibleReasons)
+        {
+            for (int i = 0; i < IneligibleReasonCount; i++)
+                writer.WriteUInt32(0);               // LootRollIneligibilityReason.None
+        }
         writer.WriteUInt8((byte)Method);
 
         // Write LootItemData inline


### PR DESCRIPTION
Fixes #155

Group loot resolved silently around the player: other members' rolls scrolled past in chat and a winner was announced, but the **Need / Greed / Pass** prompt never appeared, so there was no way to roll.

## Cause

Two defects — mapping the opcode alone is not enough.

**1. `SMSG_LOOT_START_ROLL` sat at the `0u` placeholder.** The handler ran and built the packet, then `ServerPacket` discarded it at send time:

```
Received opcode "SMSG_LOOT_START_ROLL" (673).
Handling SMSG_LOOT_START_ROLL (673):
  No V3_4_3_54261 opcode mapping for SMSG_LOOT_START_ROLL, packet dropped.
```

The real value is **9757** (`0x261D`). It is named `SMSG_START_LOOT_ROLL` in the 3.4.3 sources, and the gap sits *below* the mapped block rather than inside it — `0x261E`/`0x2620`/`0x2621`/`0x2622` were all found and mapped, while `0x261F` is `SMSG_MASTER_LOOT_CANDIDATE_LIST`. That is why this one was missed, and why the roll appeared to work from the outside: every other packet in the family was fine.

**2. The 3.4.3 wire has a field the writer did not.** `StartLootRoll::Write`:

```cpp
_worldPacket << LootObj;
_worldPacket << int32(MapID);
_worldPacket << RollTime;
_worldPacket << uint8(ValidRolls);
_worldPacket.append(LootRollIneligibleReason.data(), LootRollIneligibleReason.size());
_worldPacket << uint8(Method);
_worldPacket << Item;
```

`LootRollIneligibleReason` is `std::array<LootRollIneligibilityReason, 4>` with the enum declared `: uint32`, so the templated `append` emits `4 * sizeof(uint32)` = **16 bytes**. Without them `Method` and the entire `Item` block land 16 bytes early.

3.3.5a has no equivalent — it sends only the `ValidRolls` mask — so all four entries are written as `None` (0). The enum carries the per-roll-type "why you cannot roll this" reasons (`UnusableByClass`, `MaxUniqueItemCount`, `CannotBeDisenchanted`, `EnchantingSkillTooLow`, `NeedDisabled`, `OwnBetterItem`), none of which the legacy server communicates.

## Change

- Map `SMSG_LOOT_START_ROLL = 9757u`
- Write the 16-byte `LootRollIneligibleReason` block between `ValidRolls` and `Method`, gated to V3_4_3, in **both** `Write()` and `WriteToSpan()` — the span path is the one that ships (`Packet.cs` prefers `ISpanWritable`), and `MaxSize` is bumped to match

## Testing

AzerothCore 3.3.5a with playerbots, client 3.4.3.54261, group loot on a green drop:

```
23:35:55  Received SMSG_LOOT_START_ROLL (673)
23:35:55  Sending  SMSG_LOOT_START_ROLL (9757)     <- previously "packet dropped"
23:35:58  Received CMSG_LOOT_ROLL (12820)
23:35:58  Sending  CMSG_LOOT_ROLL (672), 17 bytes
23:35:58  Sending  SMSG_LOOT_ROLL_WON (9762)
23:35:58  Sending  SMSG_LOOT_ROLLS_COMPLETE (9760)
```

The prompt appeared on screen and Need was pressed — the inbound `CMSG_LOOT_ROLL` is the proof, since the client only sends it from an interactable dialog. That also covers defect 2: a packet still missing the 16 bytes would have `Method` and the item block misaligned and could not have rendered a working dialog. The roll then resolved with a winner.

Zero loot-related drops and no exceptions in the session. 865/865 unit tests green, including new assertions pinning the whole loot-roll opcode family so a regression back to `0u` fails the build rather than going silent.

Not tested on TrinityCore or cMaNGOS: a roll needs a real party, and TrinityCore's NPCBots are Creatures rather than Players so they cannot form one. The 3.3.5a `SMSG_LOOT_START_ROLL` wire is identical across both.

## Note

This is the same failure shape as #149, #151, #153 and #154 — a placeholder or missing entry in the V3_4_3 opcode table, where the handler is already written and correct and the packet is thrown away at dispatch. It always presents as a feature that is simply inert, with no error anywhere the user can see.

The same session also logged `SMSG_MOVE_SPLINE_SET_WALK_BACK_SPEED` dropped 128 times and `SMSG_CONQUEST_FORMULA_CONSTANTS` twice, both for the same reason. Per the note on #154, the audit worth doing is not "all 84 `= 0u` entries" — most of those packets genuinely do not exist in 3.4.3 — but specifically **placeholders that a live handler constructs or dispatches**, which are guaranteed silent failures.
