### PR TITLE
fix(v3_4_3): carry LootObj into the loot roll result packets

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -262,6 +262,18 @@ public sealed class GameSessionData
     // (SMSG_SEND_KNOWN_SPELLS + SMSG_LEARNED_SPELL). BattlePetGuidToSummonSpell
     // is rebuilt whenever we emit SMSG_BATTLE_PET_JOURNAL.
     public HashSet<uint> KnownSpells = [];
+
+    /// <summary>
+    /// LootObj per open group-loot roll, keyed by item slot (LootListID).
+    ///
+    /// 3.3.5a only sends the loot object in SMSG_LOOT_START_ROLL and SMSG_LOOT_ALL_PASSED
+    /// (both use <c>roll.itemGUID</c>). The result packets pass <c>ObjectGuid::Empty</c> —
+    /// see AzerothCore Group.cpp SendLootRoll / SendLootRollWon — so forwarding what the
+    /// wire carries gave the modern client a roll for a loot object it had never been told
+    /// about, and it could not tie the roll back to the open dialog. Native 3.4.3 repeats
+    /// the same guid in every packet of the roll. Issue #162.
+    /// </summary>
+    public Dictionary<byte, WowGuid128> LootRollObjects = [];
     public Dictionary<WowGuid128, uint> BattlePetGuidToSummonSpell = [];
     public WowGuid128 SummonedBattlePetGuid;
     public WowGuid128 SummonedCompanionCreatureGuid;

--- a/HermesProxy/World/Client/PacketHandlers/LootHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/LootHandler.cs
@@ -1,4 +1,4 @@
-﻿using Framework;
+using Framework;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
@@ -200,6 +200,11 @@ public partial class WorldClient
             loot.ValidRolls = (RollMask)packet.ReadUInt8();
         else
             loot.ValidRolls = RollMask.AllNoDisenchant;
+
+        // Only this packet and SMSG_LOOT_ALL_PASSED carry the loot object on 3.3.5a; the
+        // result packets send an empty guid. Remember it so they can be given the same one.
+        GetSession().GameState.LootRollObjects[loot.Item.LootListID] = loot.LootObj;
+
         SendPacketToClient(loot);
 
         if (GetSession().GameState.IsPassingOnLoot)
@@ -212,6 +217,24 @@ public partial class WorldClient
         }
     }
 
+    /// <summary>
+    /// 3.3.5a sends <c>ObjectGuid::Empty</c> as the loot object on SMSG_LOOT_ROLL and
+    /// SMSG_LOOT_ROLL_WON (AzerothCore Group.cpp SendLootRoll / SendLootRollWon), so the
+    /// value on the wire cannot be forwarded — the modern client needs the same LootObj it
+    /// was given in SMSG_LOOT_START_ROLL or it cannot match the roll to the open dialog.
+    /// Falls back to whatever the packet carried when the slot was never announced, which
+    /// keeps behaviour unchanged on a backend that does populate it.
+    /// </summary>
+    private WowGuid128 ResolveLootRollObject(byte lootListId, WowGuid64 legacyOwner, WowGuid128 converted)
+    {
+        if (!legacyOwner.IsEmpty())
+            return converted;
+
+        return GetSession().GameState.LootRollObjects.TryGetValue(lootListId, out var remembered)
+            ? remembered
+            : converted;
+    }
+
     [PacketHandler(Opcode.SMSG_LOOT_ROLL)]
     void HandleLootRoll(WorldPacket packet)
     {
@@ -219,6 +242,7 @@ public partial class WorldClient
         WowGuid64 owner = packet.ReadGuid();
         loot.LootObj = owner.ToLootGuid();
         loot.Item.LootListID = (byte)packet.ReadUInt32();
+        loot.LootObj = ResolveLootRollObject(loot.Item.LootListID, owner, loot.LootObj);
         loot.Player = packet.ReadGuid().To128(GetSession().GameState);
         loot.Item.Loot.ItemID = packet.ReadUInt32();
         loot.Item.Loot.RandomPropertiesSeed = packet.ReadUInt32();
@@ -247,8 +271,10 @@ public partial class WorldClient
     void HandleLootRollWon(WorldPacket packet)
     {
         LootRollWon loot = new LootRollWon();
-        loot.LootObj = packet.ReadGuid().ToLootGuid();
+        WowGuid64 wonOwner = packet.ReadGuid();
+        loot.LootObj = wonOwner.ToLootGuid();
         loot.Item.LootListID = (byte)packet.ReadUInt32();
+        loot.LootObj = ResolveLootRollObject(loot.Item.LootListID, wonOwner, loot.LootObj);
         loot.Item.Loot.ItemID = packet.ReadUInt32();
         loot.Item.Loot.RandomPropertiesSeed = packet.ReadUInt32();
         loot.Item.Loot.RandomPropertiesID = packet.ReadUInt32();
@@ -264,6 +290,9 @@ public partial class WorldClient
         complete.LootObj = loot.LootObj;
         complete.LootListID = loot.Item.LootListID;
         SendPacketToClient(complete);
+
+        // The roll is over; drop the remembered loot object so the slot can be reused.
+        GetSession().GameState.LootRollObjects.Remove(loot.Item.LootListID);
     }
 
     [PacketHandler(Opcode.SMSG_LOOT_ALL_PASSED)]
@@ -282,6 +311,9 @@ public partial class WorldClient
         complete.LootObj = loot.LootObj;
         complete.LootListID = loot.Item.LootListID;
         SendPacketToClient(complete);
+
+        // The roll is over; drop the remembered loot object so the slot can be reused.
+        GetSession().GameState.LootRollObjects.Remove(loot.Item.LootListID);
     }
 
     [PacketHandler(Opcode.SMSG_LOOT_MASTER_LIST)]

--- a/HermesProxy/World/Server/Packets/LootPackets.cs
+++ b/HermesProxy/World/Server/Packets/LootPackets.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (C) 2012-2020 CypherCore <http://github.com/CypherCore>
  * 
  * This program is free software: you can redistribute it and/or modify
@@ -312,6 +312,8 @@ class LootRemoved : ServerPacket, ISpanWritable
         writer.WritePackedGuid128(Owner.Low, Owner.High);
         writer.WritePackedGuid128(LootObj.Low, LootObj.High);
         writer.WriteUInt8(LootListID);
+        if (LootRollWire.WritesDungeonEncounterId)
+            writer.WriteInt32(0);                    // DungeonEncounterID
         return writer.Position;
     }
 
@@ -441,6 +443,22 @@ class LootRoll : ClientPacket
     public RollType RollType;
 }
 
+/// <summary>
+/// V3_4_3 writes an int32 DungeonEncounterID before the Item block in the loot-roll result
+/// packets. Verified byte-for-byte against a native Wrathion V3_4_3.23121 capture:
+/// SMSG_LOOT_ROLL and SMSG_LOOT_ROLL_WON carry it at offset 17 (after RollType), and
+/// SMSG_LOOT_ROLLS_COMPLETE at offset 8 (after LootListID). 3.3.5a has no dungeon-encounter
+/// concept on this wire and it is zero in every native packet, so it is always written as 0.
+/// SMSG_LOOT_START_ROLL does NOT have this field. Issue #162.
+/// </summary>
+internal static class LootRollWire
+{
+    public static bool WritesDungeonEncounterId =>
+        ModernVersion.Build == ClientVersionBuild.V3_4_3_54261;
+
+    public static int DungeonEncounterIdBytes => WritesDungeonEncounterId ? 4 : 0;
+}
+
 class LootRollBroadcast : ServerPacket, ISpanWritable
 {
     public LootRollBroadcast() : base(Opcode.SMSG_LOOT_ROLL) { }
@@ -451,6 +469,8 @@ class LootRollBroadcast : ServerPacket, ISpanWritable
         _worldPacket.WritePackedGuid128(Player);
         _worldPacket.WriteInt32(Roll);
         _worldPacket.WriteUInt8((byte)RollType);
+        if (LootRollWire.WritesDungeonEncounterId)
+            _worldPacket.WriteInt32(0);              // DungeonEncounterID
         Item.Write(_worldPacket);
         _worldPacket.WriteBit(Autopassed);
         _worldPacket.FlushBits();
@@ -458,8 +478,9 @@ class LootRollBroadcast : ServerPacket, ISpanWritable
 
     // LootItemData: 1 (bits) + ItemInstance + 6 = 7 + ItemInstanceMaxSize
     private const int LootItemDataSize = 7 + ItemPacketHelpers.ItemInstanceMaxSize;
-    // 2 GUIDs + int + byte + LootItemData + 1 bit
-    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 4 + 1 + LootItemDataSize + 1;
+    // 2 GUIDs + int + byte + DungeonEncounterID + LootItemData + 1 byte of bits
+    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 4 + 1
+        + LootRollWire.DungeonEncounterIdBytes + LootItemDataSize + 1;
 
     public int WriteToSpan(Span<byte> buffer)
     {
@@ -468,6 +489,8 @@ class LootRollBroadcast : ServerPacket, ISpanWritable
         writer.WritePackedGuid128(Player.Low, Player.High);
         writer.WriteInt32(Roll);
         writer.WriteUInt8((byte)RollType);
+        if (LootRollWire.WritesDungeonEncounterId)
+            writer.WriteInt32(0);                    // DungeonEncounterID
 
         // Write LootItemData inline
         writer.WriteBits(Item.Type, 2);
@@ -506,14 +529,18 @@ class LootRollWon : ServerPacket, ISpanWritable
         _worldPacket.WritePackedGuid128(Winner);
         _worldPacket.WriteInt32(Roll);
         _worldPacket.WriteUInt8((byte)RollType);
+        if (LootRollWire.WritesDungeonEncounterId)
+            _worldPacket.WriteInt32(0);              // DungeonEncounterID
         Item.Write(_worldPacket);
+        // Native writes MainSpec as a single flushed bit; 128 as a byte is the same 0x80.
         _worldPacket.WriteUInt8(MainSpec);
     }
 
     // LootItemData: 1 (bits) + ItemInstance + 6 = 7 + ItemInstanceMaxSize
     private const int LootItemDataSize = 7 + ItemPacketHelpers.ItemInstanceMaxSize;
-    // 2 GUIDs + int + byte + LootItemData + byte
-    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 4 + 1 + LootItemDataSize + 1;
+    // 2 GUIDs + int + byte + DungeonEncounterID + LootItemData + MainSpec byte
+    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size * 2 + 4 + 1
+        + LootRollWire.DungeonEncounterIdBytes + LootItemDataSize + 1;
 
     public int WriteToSpan(Span<byte> buffer)
     {
@@ -522,6 +549,8 @@ class LootRollWon : ServerPacket, ISpanWritable
         writer.WritePackedGuid128(Winner.Low, Winner.High);
         writer.WriteInt32(Roll);
         writer.WriteUInt8((byte)RollType);
+        if (LootRollWire.WritesDungeonEncounterId)
+            writer.WriteInt32(0);                    // DungeonEncounterID
 
         // Write LootItemData inline
         writer.WriteBits(Item.Type, 2);
@@ -597,9 +626,13 @@ class LootRollsComplete : ServerPacket, ISpanWritable
     {
         _worldPacket.WritePackedGuid128(LootObj);
         _worldPacket.WriteUInt8(LootListID);
+        if (LootRollWire.WritesDungeonEncounterId)
+            _worldPacket.WriteInt32(0);              // DungeonEncounterID
     }
 
-    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 1; // GUID + byte
+    // GUID + byte + DungeonEncounterID
+    public int MaxSize => PackedGuidHelper.MaxPackedGuid128Size + 1
+        + LootRollWire.DungeonEncounterIdBytes;
 
     public int WriteToSpan(Span<byte> buffer)
     {


### PR DESCRIPTION
Fixes #162

Roll numbers were never shown in a group loot roll — no "X rolled N for [Item]" line, no per-player values in the roll UI. The roll resolved correctly and a winner was chosen; only the reporting was missing.

## Cause: LootObj is empty in the result packets

3.3.5a does not put the loot object in `SMSG_LOOT_ROLL` or `SMSG_LOOT_ROLL_WON`. AzerothCore `Group.cpp`:

```cpp
SendLootRoll(ObjectGuid::Empty, playerGUID, 0, 0, *roll);                 // 1392
SendLootRoll(ObjectGuid::Empty, playerGUID, 128, ROLL_GREED, *roll);      // 1397
SendLootRollWon(ObjectGuid::Empty, maxguid, maxresul, ROLL_NEED, *roll);  // 1504
```

Only `SMSG_LOOT_START_ROLL` and `SMSG_LOOT_ALL_PASSED` carry it (`roll.itemGUID`). Forwarding what the wire held gave the client a roll for a loot object it had never been told about, so it could not tie the roll back to the open dialog.

Our own sniff, before:

| packet | LootObj |
|---|---|
| `SMSG_START_LOOT_ROLL` | `Low: 94124`, `94195`, `94257` … (real, one per roll) |
| `SMSG_LOOT_ROLL` | `Low: 0`, `S: 0xFFFFFF` — identical for every roll |

A native V3_4_3 capture repeats the same guid in all four packets of a roll.

**Fix:** remember the loot object per item slot when the roll starts, and reuse it when the legacy guid is empty. Falls back to the wire value otherwise, so a backend that does populate the field is unaffected. The entry is dropped when the roll completes.

## Also: DungeonEncounterID was missing

Verified byte-for-byte against a native **Wrathion V3_4_3.23121** capture (no proxy in the loop; two clients on separate accounts, grouped, green drop). Saved as `refs/3.4.3_Build/bin/Release/Logs/old/World_group_loot_roll_native.pkt`.

`SMSG_LOOT_ROLL`, native, 43 bytes — consumes 43/43 exactly:

```
  0..6   LootObj (packed guid128)           01 B8 04 80 04 04 3C
  7..11  Winner (packed guid128)            01 A0 5E 04 08
 12..15  Roll (int32)                       00 00 00 00     = 0
 16..16  RollType (uint8)                   01              = 1 (Need)
 17..20  DungeonEncounterID (int32)         00 00 00 00     <-- was missing
 21..21  Item: Type/UIType/CanTrade bits    0C
 22..25    ItemInstance.ItemID              81 3C 00 00     = 15489
 26..29    ItemInstance.RandomPropSeed      00 00 00 00
 30..33    ItemInstance.RandomPropID        00 00 00 00
 34..34    ItemInstance HasBonus bit        00
 35..35    ItemInstance ItemModList (6 bit) 00
 36..39  Quantity (uint32)                  01 00 00 00     = 1
 40..40  LootItemType (uint8)               00
 41..41  LootListID (uint8)                 03
 42..42  bits: Autopassed + OffSpec         00
```

`SMSG_LOOT_ROLL_WON` is the same shape (43/43, `Roll = 82`), and `SMSG_LOOT_ROLLS_COMPLETE` is 12/12 with the field at offset 8 after `LootListID`.

3.3.5a has no dungeon-encounter concept on this wire and it is zero in every native packet, so it is written as zero. **`SMSG_LOOT_START_ROLL` does not have this field** — native confirms 16 bytes of `LootRollIneligibleReason` then `Method` then `Item` — so it is left exactly as #161 shipped it.

## Not changed

`HandleLootRollWon` sets `MainSpec = 128` and writes it as a `uint8`; native writes a single bit that flushes to `0x80`. The byte values are identical in both the set and unset cases, so this is not a defect.

`SMSG_LOOT_ALL_PASSED` was not present in the capture (no roll went entirely unclaimed), so its layout is unconfirmed and it is left alone.

## Testing

AzerothCore 3.3.5a with playerbots, client 3.4.3.54261. Roll numbers now render in chat. Confirmed on the wire — all three packets now carry the same loot object, matching native behaviour:

```
SMSG_START_LOOT_ROLL   LootObj: 0x3C000400000000000040000000017532  Low: 95538
SMSG_LOOT_ROLL         LootObj: 0x3C000400000000000040000000017532  Low: 95538
SMSG_LOOT_ROLL_WON     LootObj: 0x3C000400000000000040000000017532  Low: 95538
```

865/865 unit tests green, clean build.

Not tested on TrinityCore or cMaNGOS: a roll needs a real party, and TrinityCore's NPCBots are Creatures rather than Players so they cannot form one. The empty-guid behaviour is in shared 3.3.5a group code.

## Note on tooling

WowPacketParser cannot be used as the oracle for this packet family. It fails on the **native server's own** `SMSG_START_LOOT_ROLL` with `EndOfStreamException` and dispatches through its `V7_0_3_22248` module; on the native `SMSG_LOOT_ROLL` it runs exactly four bytes behind because it does not read `DungeonEncounterID`. The capture is the reference.
