### PR TITLE
fix(v3_4_3): stop the injected bank activate from stealing the UI

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1,4 +1,4 @@
-﻿using HermesProxy.Auth;
+using HermesProxy.Auth;
 using HermesProxy.Configuration.Options;
 using HermesProxy.World;
 using HermesProxy.World.Client;
@@ -274,6 +274,27 @@ public sealed class GameSessionData
     /// the same guid in every packet of the roll. Issue #162.
     /// </summary>
     public Dictionary<byte, WowGuid128> LootRollObjects = [];
+
+    /// <summary>
+    /// Whether the legacy server still has us subscribed to guild-bank delta updates.
+    ///
+    /// AzerothCore subscribes on CMSG_GUILD_BANKER_ACTIVATE (Guild::SendBankTabsInfo) and
+    /// deliberately unsubscribes on every permissions query (Guild::SendPermissions —
+    /// "the only reliable way to handle /reload"). The 3.4.3 client sends
+    /// CMSG_GUILD_PERMISSIONS_QUERY regularly and never sends an activate of its own, so
+    /// the proxy has to re-activate after each permissions query or post-move deltas stop
+    /// arriving. Re-sending it on *every* tab query instead made the server answer with a
+    /// full tab-0 list that dragged the UI back, which is why the "Buy new guild bank tab"
+    /// slot could never be opened. Issue #157.
+    /// </summary>
+    public bool GuildBankSubscribed;
+
+    /// <summary>
+    /// Number of guild bank tabs actually purchased, from the last SMSG_GUILD_BANK_QUERY_RESULTS
+    /// that carried the tab list. A query for an index at or beyond this is the client opening
+    /// the purchase slot rather than a real tab.
+    /// </summary>
+    public int GuildBankPurchasedTabs;
     public Dictionary<WowGuid128, uint> BattlePetGuidToSummonSpell = [];
     public WowGuid128 SummonedBattlePetGuid;
     public WowGuid128 SummonedCompanionCreatureGuid;

--- a/HermesProxy/World/Client/PacketHandlers/GuildHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/GuildHandler.cs
@@ -1,4 +1,4 @@
-﻿using Framework.Logging;
+using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Logging;
@@ -26,6 +26,13 @@ public partial class WorldClient
     [PacketHandler(Opcode.MSG_GUILD_PERMISSIONS)]
     void HandleGuildPermissions(WorldPacket packet)
     {
+        // Guild::SendPermissions unsubscribes us from bank delta updates every time it
+        // runs — deliberately, as AzerothCore's "only reliable way to handle /reload".
+        // It fires both for a client permissions query and unprompted after a tab
+        // purchase (HandleBuyBankTab ends with SendPermissions), so keying off this
+        // inbound packet catches both. Issue #157.
+        GetSession().GameState.GuildBankSubscribed = false;
+
         GuildPermissionsQueryResults result = new();
         result.RankID = packet.ReadUInt32();
         result.Flags = packet.ReadInt32();
@@ -421,6 +428,11 @@ public partial class WorldClient
                 tabInfo.Icon = packet.ReadCString();
                 result.TabInfo.Add(tabInfo);
             }
+
+            // Remember how many tabs actually exist. A query for an index at or beyond
+            // this is the client opening the "Buy new guild bank tab" slot, which must
+            // not trigger an activate — see HandleGuildBankQueryTab. Issue #157.
+            GetSession().GameState.GuildBankPurchasedTabs = size;
         }
 
         var slots = packet.ReadUInt8();

--- a/HermesProxy/World/Server/PacketHandlers/GuildHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/GuildHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Framework.Constants;
 using Framework.Logging;
 using HermesProxy.Enums;
@@ -244,6 +244,10 @@ public partial class WorldSocket
         packet.WriteGuid(activate.BankGuid.To64());
         packet.WriteBool(activate.FullUpdate);
         SendPacketToServer(packet);
+
+        // A client-sent activate subscribes us just the same. V3_4_3 never sends one,
+        // but older modern builds do, and it saves a redundant injected activate.
+        GetSession().GameState.GuildBankSubscribed = true;
     }
 
     [PacketHandler(Opcode.CMSG_GUILD_BANK_QUERY_TAB)]
@@ -253,7 +257,25 @@ public partial class WorldSocket
         // only fills ItemInfo when sendAllSlots is true (or a slot set is
         // passed). A false query therefore comes back with items=0 and the
         // vault looks empty even after a successful deposit.
-        SendGuildBankActivate(query.BankGuid);
+        //
+        // The activate is only re-sent when the server has actually unsubscribed us
+        // (see GameSessionData.GuildBankSubscribed). Sending it on every query made the
+        // server answer with a full tab-0 list that arrived before the reply for the tab
+        // the client asked for, dragging the UI back to tab 0 — which made the
+        // "Buy new guild bank tab" slot impossible to open. Issue #157.
+        // Never spend the activate on the purchase slot: the server answers an activate
+        // with a full tab-0 list, which arrives before the reply for the tab the client
+        // asked for and drags the UI back to tab 0. That made the "Buy new guild bank tab"
+        // window close the moment it opened. Buying a tab makes AzerothCore call
+        // SendPermissions (its "hack to force client to update permissions"), which
+        // unsubscribes us, so without this the first click after every purchase was eaten.
+        var state = GetSession().GameState;
+        bool isPurchaseSlot = state.GuildBankPurchasedTabs > 0
+            && query.Tab >= state.GuildBankPurchasedTabs;
+
+        if (!state.GuildBankSubscribed && !isPurchaseSlot)
+            SendGuildBankActivate(query.BankGuid);
+
         SendGuildBankQueryTab(query.BankGuid, query.Tab);
     }
 
@@ -477,6 +499,9 @@ public partial class WorldSocket
         packet.WriteGuid(bankGuid.To64());
         packet.WriteBool(true);
         SendPacketToServer(packet);
+
+        // Guild::SendBankTabsInfo subscribes us to bank deltas on the legacy side.
+        GetSession().GameState.GuildBankSubscribed = true;
     }
 
     void SendGuildBankQueryTab(WowGuid128 bankGuid, byte tab)


### PR DESCRIPTION
Fixes #157

The "Buy new guild bank tab" slot could not be opened — the purchase window appeared and immediately snapped back to the existing tab, so no additional tabs could ever be bought.

## Cause

#153 injected `CMSG_GUILD_BANK_ACTIVATE` before every forwarded tab query, to keep the guild-bank delta subscription alive. The server answers an activate with a **full tab-0 list**, which arrives before the reply for the tab the client actually asked for and drags the UI back to tab 0.

Per click on the buy slot:

```
Received  CMSG_GUILD_BANK_QUERY_TAB (13506)      <- client asks for the purchase slot
Sending   CMSG_GUILD_BANK_ACTIVATE  (998)        <- injected
Sending   CMSG_GUILD_BANK_QUERY_TAB (999)        <- forwarded

Guild bank query results tab=0 tabs=1 items=0 fullUpdate=true    <- answer to the activate
Guild bank query results tab=1 tabs=0 items=0 fullUpdate=false   <- answer to the query, too late
```

## The subscription does not need re-sending per query

AzerothCore subscribes in `Guild::SendBankTabsInfo` (reached from the activate handler) and unsubscribes in `Guild::SendPermissions`:

```cpp
member->SubscribeToGuildBankUpdatePackets();     // Guild.cpp:1850, SendBankTabsInfo
member->UnsubscribeFromGuildBankUpdatePackets(); // Guild.cpp:1870, SendPermissions
```

The unsubscribe is deliberate — its comment calls it "the only reliable way to handle /reload from player as GuildPermissionsQuery is sent on each reload". The 3.4.3 client never sends an activate of its own (0 client-originated against 52 injected in a sample session) but does send permissions queries regularly, which is why per-query re-activation looked necessary.

## Change

The activate is now sent only when the server has actually dropped us.

- The flag is cleared on the **inbound `MSG_GUILD_PERMISSIONS`**, not on the client's request. `Guild::HandleBuyBankTab` ends with `SendPermissions(session); /// Hack to force client to update permissions`, so keying off the client's query would leave the flag stale after every purchase — that showed up in testing as needing to click the buy slot twice.
- It is **never spent on the purchase slot**. A query for a tab index at or beyond the purchased count is the client opening the buy window, and an activate there reintroduces exactly the bug being fixed. The purchased-tab count is taken from the tab list on `SMSG_GUILD_BANK_QUERY_RESULTS`.

## Testing

TrinityCore 3.3.5a with client 3.4.3.54261, guild with 2 tabs:

- All four remaining tabs bought in consecutive clicks, each window opening **first time**
- **1 activate for 4 purchases**

Measured against a comparable session on the previous behaviour:

| | before | after |
|---|---|---|
| client `CMSG_GUILD_BANK_QUERY_TAB` | 52 | 18 |
| proxy `CMSG_GUILD_BANK_ACTIVATE` | 52 (one per click) | 4 |
| `SMSG_GUILD_BANK_QUERY_RESULTS` to client | 116 (2.23x) | 24 (1.33x) |

The vault itself was re-checked after the change — tabs load their contents and deposits appear live, which is the behaviour the subscription protects and the reason #153 added the activate in the first place.

865/865 unit tests green, clean build.

Not tested on AzerothCore or cMaNGOS in this round, though the subscribe/unsubscribe pair quoted above is AzerothCore's own code and #153 was authored against it.
