### PR TITLE
fix(v3_4_3): fill the inspect talent tree from SMSG_INSPECT_TALENT

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Logging;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server;
 using HermesProxy.World.Server.Packets;
@@ -695,16 +696,35 @@ public partial class WorldClient
             }
         }
 
-        // TODO: format seems to be different in new client
         if (packet.GetUniversalOpcode(false) == Opcode.SMSG_INSPECT_TALENT)
         {
-            uint talentsCount = packet.ReadUInt32();
-            for (uint i = 0; i < talentsCount; i++)
+            // BuildPlayerTalentsInfoData (no isPet prefix). Unspent points are
+            // not a rank-byte count — treating them as one emptied the tree.
+            uint unspent = packet.ReadUInt32();
+            byte specsCount = packet.ReadUInt8();
+            byte activeSpec = packet.ReadUInt8();
+            int totalTalents = 0;
+
+            for (byte specIdx = 0; specIdx < specsCount; ++specIdx)
             {
-                byte talent = packet.ReadUInt8();
-                if (i < 25)
-                    inspect.Talents.Add(talent);
+                byte talentCount = packet.ReadUInt8();
+                for (byte t = 0; t < talentCount; ++t)
+                {
+                    uint talentId = packet.ReadUInt32();
+                    byte rank = packet.ReadUInt8();
+                    if (specIdx == activeSpec)
+                        inspect.InspectedTalents.Add(new TalentEntry { TalentID = talentId, Rank = rank });
+                }
+
+                byte glyphSlots = packet.ReadUInt8();
+                for (byte g = 0; g < glyphSlots; ++g)
+                    packet.ReadUInt16();
+
+                totalTalents += talentCount;
             }
+
+            WorldClientLogMessages.InspectTalents(
+                _melLog, _sourceFile, "C P<S", unspent, specsCount, activeSpec, totalTalents);
         }
 
         SendPacketToClient(inspect);

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -724,7 +724,7 @@ public partial class WorldClient
             }
 
             WorldClientLogMessages.InspectTalents(
-                _melLog, _sourceFile, "C P<S", unspent, specsCount, activeSpec, totalTalents);
+                _melLog, _sourceFile, _netDirRecv, unspent, specsCount, activeSpec, totalTalents);
         }
 
         SendPacketToClient(inspect);

--- a/HermesProxy/World/Logging/WorldClientLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldClientLogMessages.cs
@@ -122,4 +122,17 @@ internal static partial class WorldClientLogMessages
         int ItemCount,
         bool FullUpdate,
         ulong Money);
+
+    [LoggerMessage(
+        EventId = 211,
+        Level = LogLevel.Debug,
+        Message = "Inspect talents unspent={Unspent} specs={Specs} active={Active} talents={Talents}")]
+    public static partial void InspectTalents(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        uint Unspent,
+        byte Specs,
+        byte Active,
+        int Talents);
 }

--- a/HermesProxy/World/Server/Packets/CharacterPackets.cs
+++ b/HermesProxy/World/Server/Packets/CharacterPackets.cs
@@ -23,6 +23,7 @@ using Framework.Constants;
 using Framework.GameMath;
 using Framework.IO;
 using Framework.Logging;
+using HermesProxy.Enums;
 using HermesProxy.World;
 using HermesProxy.World.Enums;
 
@@ -1205,6 +1206,13 @@ public class InspectResult : ServerPacket
     public override void Write()
     {
         DisplayInfo.Write(_worldPacket);
+
+        if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+        {
+            WriteV343();
+            return;
+        }
+
         _worldPacket.WriteInt32(Glyphs.Count);
         _worldPacket.WriteInt32(Talents.Count);
         _worldPacket.WriteInt32(ItemLevel);
@@ -1234,9 +1242,47 @@ public class InspectResult : ServerPacket
             _worldPacket.WriteUInt32((uint)AzeriteLevel);
     }
 
+    // Wrathion InspectPackets.cpp / InspectHandler.cpp. Fixed 71-slot array,
+    // not a counted list. The four constants after honor are from their 3.4.3 sniff.
+    void WriteV343()
+    {
+        _worldPacket.WriteUInt16(0);
+        _worldPacket.WriteUInt16(0);
+        _worldPacket.WriteInt32(ItemLevel);
+        _worldPacket.WriteUInt8(LifetimeMaxRank);
+        _worldPacket.WriteUInt16(TodayHK);
+        _worldPacket.WriteUInt16(YesterdayHK);
+        _worldPacket.WriteUInt32(LifetimeHK);
+        _worldPacket.WriteUInt32(HonorLevel);
+
+        _worldPacket.WriteUInt64(2199023255552UL);
+        _worldPacket.WriteUInt32(1776384);
+        _worldPacket.WriteUInt32(101056512);
+        _worldPacket.WriteUInt32(33554432);
+
+        for (int i = 0; i < 71; ++i)
+        {
+            if (i < InspectedTalents.Count)
+            {
+                _worldPacket.WriteUInt32(InspectedTalents[i].TalentID);
+                _worldPacket.WriteUInt8((byte)InspectedTalents[i].Rank);
+            }
+            else
+            {
+                _worldPacket.WriteUInt32(0);
+                _worldPacket.WriteUInt8(0);
+            }
+        }
+
+        for (int i = 0; i < 61; ++i)
+            _worldPacket.WriteUInt64(0);
+        _worldPacket.WriteUInt32(0);
+    }
+
     public PlayerModelDisplayInfo DisplayInfo = new();
     public List<ushort> Glyphs = new();
     public List<byte> Talents = new();
+    public List<TalentEntry> InspectedTalents = new();
     public InspectGuildData GuildData = null!;
     public PVPBracketData[] Bracket = new PVPBracketData[6];
     public uint? AzeriteLevel;


### PR DESCRIPTION
Client 3.4.3.54261 through HermesProxy to AzerothCore 3.3.5a. Inspecting another player showed the paperdoll but the Talents tab was all zeros.

## Cause

Legacy `SMSG_INSPECT_TALENT` is `BuildPlayerTalentsInfoData`: unspent points, spec count, then `(talentId, rank)` pairs. The handler treated the first `uint32` as a count of rank bytes. At 80 that value is 0, so we forwarded an empty list.

3.4.3 does not read a counted talent list. Wrathion (`InspectPackets.h` / `InspectHandler.cpp`) writes a **fixed 71-slot** `{id, rank}` array after honor, plus the four post-honor constants from their 3.4.3 sniff.

## Fix

- Parse the real WotLK inspect-talent body and keep the active spec
- Emit Wrathion's 3.4.3 inspect tail (71 slots, unused remain `{0,0}`)

## Testing

Inspected playerbot Galaedon (Druid). Restoration tree 65 points, unspent 0. No hang / ERROR #132.

![Galaedon inspect talents — Restoration 65](https://files.catbox.moe/9gm445.jpg)