### PR TITLE
fix(v3_4_3): enter 3v3/5v5 skirmish and surface arena join errors

### DIFF
--- a/HermesProxy.Tests/World/Server/ArenaQueueTests.cs
+++ b/HermesProxy.Tests/World/Server/ArenaQueueTests.cs
@@ -1,0 +1,39 @@
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+public class ArenaQueueTests
+{
+    [Theory]
+    [InlineData(false, false, (byte)0, (byte)2)]
+    [InlineData(false, true, (byte)3, (byte)2)]
+    [InlineData(true, false, (byte)3, (byte)0)]
+    [InlineData(true, true, (byte)2, (byte)2)]
+    [InlineData(true, true, (byte)3, (byte)3)]
+    [InlineData(true, true, (byte)5, (byte)5)]
+    [InlineData(true, true, (byte)0, (byte)2)]
+    public void ForLegacyPort_UsesQueuedArenaTypeOnV343Arenas(bool isV343, bool isArena, byte queued, byte expected)
+    {
+        Assert.Equal(expected, BattlefieldQueueArenaType.ForLegacyPort(isV343, isArena, queued));
+    }
+
+    [Theory]
+    [InlineData(-3, 3)]
+    [InlineData(-12, 12)]
+    [InlineData(0, 0)]
+    [InlineData(6, 6)]
+    public void ToModernJoinError_NegatesAcCodes(int ac, int modern)
+    {
+        Assert.Equal(modern, BattlefieldQueueArenaType.ToModernJoinError(ac));
+    }
+
+    [Fact]
+    public void JoinErrorText_PartySizeAndGroupFailed()
+    {
+        Assert.Equal("Incorrect party size for this arena.", BattlefieldQueueArenaType.JoinErrorText(-3, null));
+        Assert.Equal("Join as a group failed. Every grouped player must be on the same arena team.", BattlefieldQueueArenaType.JoinErrorText(-12, null));
+        Assert.Equal("Mildeena was unavailable to join the queue.", BattlefieldQueueArenaType.JoinErrorText(-11, "Mildeena"));
+        Assert.Null(BattlefieldQueueArenaType.JoinErrorText(6, null));
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -336,6 +336,7 @@ public sealed class GameSessionData
     public HashSet<uint> RequestedItemTextIds = [];
     public Dictionary<uint, string> ItemTexts = [];
     public Dictionary<uint, uint> BattleFieldQueueTypes = [];
+    public Dictionary<uint, byte> BattleFieldQueueArenaTypes = [];
     public Dictionary<uint, long> BattleFieldQueueTimes = [];
     public Dictionary<uint, uint> DailyQuestsDone = [];
     public HashSet<WowGuid128> FlagCarrierGuids = [];
@@ -921,6 +922,20 @@ public sealed class GameSessionData
     public uint GetBattleFieldQueueType(uint queueSlot)
     {
         return BattleFieldQueueTypes.TryGetValue(queueSlot, out var value) ? value : 0u;
+    }
+    public void StoreBattleFieldQueueArenaType(uint queueSlot, byte arenaType)
+    {
+        BattleFieldQueueArenaTypes[queueSlot] = arenaType;
+    }
+    public byte GetBattleFieldQueueArenaType(uint queueSlot)
+    {
+        return BattleFieldQueueArenaTypes.TryGetValue(queueSlot, out var value) ? value : (byte)0;
+    }
+    public void RemoveBattleFieldQueue(uint queueSlot)
+    {
+        BattleFieldQueueTypes.Remove(queueSlot);
+        BattleFieldQueueArenaTypes.Remove(queueSlot);
+        BattleFieldQueueTimes.Remove(queueSlot);
     }
     public void StoreAuraDurationLeft(WowGuid128 guid, byte slot, int duration, int currentTime)
     {

--- a/HermesProxy/World/BattlefieldQueueArenaType.cs
+++ b/HermesProxy/World/BattlefieldQueueArenaType.cs
@@ -1,0 +1,47 @@
+namespace HermesProxy.World;
+
+internal static class BattlefieldQueueArenaType
+{
+    // AC CMSG_BATTLEFIELD_PORT looks up the queue as (bgTypeId, arenaType).
+    // 0 = battleground. 2/3/5 = arena team size. A hardcoded 2 made 3v3/5v5
+    // Enter Battle miss the queue the player was actually in.
+    public static byte ForLegacyPort(bool isV343, bool isArena, byte queuedArenaType)
+    {
+        if (!isV343)
+            return 2;
+        if (!isArena)
+            return 0;
+        return queuedArenaType is 2 or 3 or 5 ? queuedArenaType : (byte)2;
+    }
+
+    // AC GroupJoinBattlegroundResult is negative. 3.4.3 STATUS_FAILED uses the
+    // positive codes from the same family (party size = 3, not -3).
+    public static int ToModernJoinError(int acResult) =>
+        acResult < 0 ? -acResult : acResult;
+
+    // Official 3.3.5 / Classic GlobalStrings for SMSG_GROUP_JOINED_BATTLEGROUND.
+    // 3.4.3 STATUS_FAILED clears the queue eye and does not print these.
+    public static string? JoinErrorText(int acResult, string? playerName)
+    {
+        return acResult switch
+        {
+            0 => "Your group has joined a battleground queue, but you are not eligible",
+            -2 => "You cannot join the battleground yet because you or one of your party members is flagged as a Deserter.",
+            -3 => "Incorrect party size for this arena.",
+            -4 => "You can only be queued for 2 battles at once",
+            -5 => "You cannot queue for a rated match while queued for other battles",
+            -6 => "You cannot queue for another battle while queued for a rated arena match",
+            -7 => "Your team has left the arena queue",
+            -8 => "You can't do that in a battleground.",
+            -10 => "Cannot join the queue unless all members of your party are in the same battleground level range.",
+            -11 => string.IsNullOrEmpty(playerName)
+                ? "A party member was unavailable to join the queue."
+                : $"{playerName} was unavailable to join the queue.",
+            -12 => "Join as a group failed. Every grouped player must be on the same arena team.",
+            -13 => "You cannot queue for a battleground or arena while using the dungeon system.",
+            -14 => "Can't do that while in a Random Battleground queue.",
+            -15 => "Can't queue for Random Battleground while in another Battleground queue.",
+            _ => acResult <= 0 ? "Join as a group failed" : null,
+        };
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/BattleGroundHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/BattleGroundHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Framework.Logging;
 using HermesProxy.Enums;
+using HermesProxy.World;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
@@ -168,7 +169,7 @@ public partial class WorldClient
             failed.Reason = 30;
             failed.BattlefieldListId = GameData.GetBattlegroundIdFromMapId(queuedMapId);
             SendPacketToClient(failed);
-            GetSession().GameState.BattleFieldQueueTimes.Remove(hdr.Ticket.Id);
+            GetSession().GameState.RemoveBattleFieldQueue(hdr.Ticket.Id);
         }
         GetSession().GameState.StoreBattleFieldQueueType(hdr.Ticket.Id, mapId);
     }
@@ -257,9 +258,11 @@ public partial class WorldClient
             failed.Reason = 30;
             failed.BattlefieldListId = GetSession().GameState.GetBattleFieldQueueType(hdr.Ticket.Id);
             SendPacketToClient(failed);
-            GetSession().GameState.BattleFieldQueueTimes.Remove(hdr.Ticket.Id);
+            GetSession().GameState.RemoveBattleFieldQueue(hdr.Ticket.Id);
         }
         GetSession().GameState.StoreBattleFieldQueueType(hdr.Ticket.Id, battlefieldListId);
+        if (battlefieldListId != 0)
+            GetSession().GameState.StoreBattleFieldQueueArenaType(hdr.Ticket.Id, hdr.ArenaTeamSize);
     }
 
     [PacketHandler(Opcode.MSG_PVP_LOG_DATA, ClientVersionBuild.Zero, ClientVersionBuild.V2_0_1_6180)]
@@ -450,6 +453,47 @@ public partial class WorldClient
             GetSession().GameState.FlagCarrierGuids.Add(position.Guid);
         }
         SendPacketToClient(bglist);
+    }
+
+    // Legacy 0x2E8 is SMSG_GROUP_JOINED_BATTLEGROUND (int32 result). The 3.3.5
+    // table names it SMSG_BATTLEFIELD_STATUS_QUEUED. Rated join-as-group failures
+    // only send this packet, so dropping it made Join as Group look like a no-op.
+    [PacketHandler(Opcode.SMSG_BATTLEFIELD_STATUS_QUEUED)]
+    void HandleGroupJoinedBattleground(WorldPacket packet)
+    {
+        int result = packet.ReadInt32();
+        WowGuid128? playerGuid = null;
+        if (packet.CanRead())
+            playerGuid = packet.ReadGuid().To128(GetSession().GameState);
+
+        Log.Print(LogType.Debug, $"[BG] SMSG_GROUP_JOINED_BATTLEGROUND: result={result} hasGuid={playerGuid.HasValue}.");
+
+        if (result > 0 || result == -1)
+            return;
+
+        string? playerName = playerGuid.HasValue
+            ? GetSession().GameState.GetPlayerName(playerGuid.Value)
+            : null;
+        string? text = BattlefieldQueueArenaType.JoinErrorText(result, playerName);
+        if (!string.IsNullOrEmpty(text))
+        {
+            PrintNotification notify = new PrintNotification();
+            notify.NotifyText = text;
+            SendPacketToClient(notify);
+        }
+
+        BattlefieldStatusFailed failed = new BattlefieldStatusFailed();
+        failed.Ticket.Id = 1;
+        failed.Ticket.RequesterGuid = GetSession().GameState.CurrentPlayerGuid;
+        failed.Ticket.Time = GetSession().GameState.GetBattleFieldQueueTime(failed.Ticket.Id);
+        failed.Ticket.Type = RideType.Battlegrounds;
+        failed.BattlefieldListId = GetSession().GameState.GetBattleFieldQueueType(failed.Ticket.Id);
+        if (failed.BattlefieldListId == 0)
+            failed.BattlefieldListId = 6; // BATTLEGROUND_AA
+        failed.Reason = BattlefieldQueueArenaType.ToModernJoinError(result);
+        if (playerGuid.HasValue)
+            failed.ClientID = playerGuid.Value;
+        SendPacketToClient(failed);
     }
 
     [PacketHandler(Opcode.SMSG_BATTLEGROUND_PLAYER_JOINED)]

--- a/HermesProxy/World/Server/PacketHandlers/ArenaHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ArenaHandler.cs
@@ -63,6 +63,7 @@ public partial class WorldSocket
         packet.WriteUInt8(join.TeamIndex);
         packet.WriteBool(true); // As Group
         packet.WriteBool(true); // Is Rated
+        Log.Print(LogType.Debug, $"[BG] CMSG_BATTLEMASTER_JOIN_ARENA: teamIndex={join.TeamIndex} asGroup=1 rated=1.");
         SendPacketToServer(packet);
     }
 
@@ -74,6 +75,7 @@ public partial class WorldSocket
         packet.WriteUInt8(join.TeamSize);
         packet.WriteBool(join.AsGroup);
         packet.WriteBool(false); // Is Rated
+        Log.Print(LogType.Debug, $"[BG] CMSG_BATTLEMASTER_JOIN_SKIRMISH: teamSize={join.TeamSize} asGroup={join.AsGroup}.");
         SendPacketToServer(packet);
     }
 

--- a/HermesProxy/World/Server/PacketHandlers/BattlegroundHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/BattlegroundHandler.cs
@@ -56,14 +56,13 @@ public partial class WorldSocket
         WorldPacket packet = new WorldPacket(Opcode.CMSG_BATTLEFIELD_PORT);
         uint bgTypeId = GetSession().GameState.GetBattleFieldQueueType(port.Ticket.Id);
 
-        // arenatype byte. V3_4_3-only fix: send 0 for non-arena battlegrounds. The legacy
-        // server derives the BattlegroundQueueTypeId from (bgTypeId, arenaType); a non-zero
-        // arenatype on a non-arena BG resolves to a queue the player isn't in, so the server
-        // silently dropped "Enter Battle" and the player never entered the popped BG (#102).
-        // V1_14/V2_5 keep the prior constant (2) so older modern clients are unaffected.
-        byte arenaType = 2;
-        if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
-            arenaType = (byte)(GameData.Battlegrounds.TryGetValue(bgTypeId, out var bg) && bg.IsArena ? 2 : 0);
+        // arenatype byte. The legacy server derives BattlegroundQueueTypeId from
+        // (bgTypeId, arenaType). A non-zero type on a real BG misses the queue (#102).
+        // A hardcoded 2 on arenas misses 3v3/5v5. V1_14/V2_5 keep the prior constant.
+        bool isArena = GameData.Battlegrounds.TryGetValue(bgTypeId, out var bg) && bg.IsArena;
+        byte queuedArenaType = GetSession().GameState.GetBattleFieldQueueArenaType(port.Ticket.Id);
+        byte arenaType = BattlefieldQueueArenaType.ForLegacyPort(
+            ModernVersion.Build == ClientVersionBuild.V3_4_3_54261, isArena, queuedArenaType);
 
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
         {
@@ -102,9 +101,14 @@ public partial class WorldSocket
         WorldPacket packet = new WorldPacket(Opcode.CMSG_BATTLEFIELD_LEAVE);
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
         {
-            packet.WriteUInt8(2);
+            uint bgTypeId = GetSession().GameState.GetBattleFieldQueueType(1);
+            bool isArena = GameData.Battlegrounds.TryGetValue(bgTypeId, out var bg) && bg.IsArena;
+            byte arenaType = BattlefieldQueueArenaType.ForLegacyPort(
+                ModernVersion.Build == ClientVersionBuild.V3_4_3_54261, isArena,
+                GetSession().GameState.GetBattleFieldQueueArenaType(1));
+            packet.WriteUInt8(arenaType);
             packet.WriteUInt8(0);
-            packet.WriteUInt32(GetSession().GameState.GetBattleFieldQueueType(1));
+            packet.WriteUInt32(bgTypeId);
             packet.WriteUInt16(0x1F90);
         }
         else


### PR DESCRIPTION
3v3 / 5v5 skirmish queued, then **Enter Battle** did nothing. 2v2 skirmish (solo and as a group) already worked. Rated 2v2 **Join as Group** and incomplete 3v3/5v5 groups also looked like a no-op: the client never printed why.

## What

`CMSG_BATTLEFIELD_PORT` always wrote `arenatype=2`, leftover from the non-arena BG fix (#102). AzerothCore looks up the queue as `(bgTypeId, arenaType)`, so a 3v3/5v5 pop was answered as 2v2 and dropped.

`SMSG_BATTLEFIELD_STATUS` already carries `ArenaTeamSize`. Store it per queue slot and write 2 / 3 / 5 on PORT and LEAVE. Non-arena BGs still send 0. V1_14 / V2_5 keep the old constant.

Rated / group rejects only arrive as legacy `0x2E8` (`SMSG_GROUP_JOINED_BATTLEGROUND`; this tree names it `SMSG_BATTLEFIELD_STATUS_QUEUED`). There was no handler. 3.4.3 `SMSG_BATTLEFIELD_STATUS_FAILED` only clears the queue eye, so the official GlobalStrings go out as `SMSG_PRINT_NOTIFICATION`.

## Tested

AzerothCore 3.3.5a, client 3.4.3.54261.

- Solo 3v3 skirmish: queue, Enter Battle, enter
- Solo 5v5 skirmish: same
- 2v2 skirmish still queues (solo and with a bot)
- 3v3 / 5v5 Join as Group with 2 people: **Incorrect party size for this arena.**
- Rated 2v2 Join as Group with a bot who is not on the 2v2 team: **Join as a group failed. Every grouped player must be on the same arena team.**

WotLK rated is team-only. Solo **Join Battle** staying grey is original behaviour (`isRated && !asGroup` returns on AC). Group 3v3 needs 3, group 5v5 needs 5.

## Not in this PR

Arena Organizer charter vendor (King Dond / `SMSG_PETITION_SHOW_LIST` still opens the guild registrar). That is still being chased and is not play-tested.