### PR TITLE
fix(v3_4_3): show unlocked titles in the character-panel dropdown

### DIFF
--- a/HermesProxy.Tests/World/KnownTitlesTests.cs
+++ b/HermesProxy.Tests/World/KnownTitlesTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using HermesProxy;
+using HermesProxy.Enums;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using HermesProxy.World.Objects.Version.V3_4_3_54261;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class KnownTitlesTests
+{
+    [Fact]
+    public void FoldKnownTitles_Empty_ReturnsZero()
+    {
+        var dest = new ulong[6];
+        Assert.Equal(0, ObjectUpdateBuilder.FoldKnownTitles(new uint?[12], dest));
+        Assert.Equal(0, ObjectUpdateBuilder.FoldKnownTitles(null!, dest));
+    }
+
+    [Fact]
+    public void FoldKnownTitles_WotlkSixWords_FoldsIntoSixUInt64()
+    {
+        // Brahand on AC: 6 uint32 knownTitles words (TITLES + TITLES1 + TITLES2).
+        var src = new uint?[12];
+        src[0] = 3758129150u;
+        src[1] = 4294966511u;
+        src[2] = 4294868991u;
+        src[3] = 4294967039u;
+        src[4] = 32767u;
+        src[5] = 0u;
+
+        var dest = new ulong[6];
+        Assert.Equal(6, ObjectUpdateBuilder.FoldKnownTitles(src, dest));
+        Assert.Equal(3758129150uL | ((ulong)4294966511u << 32), dest[0]);
+        Assert.Equal(4294868991uL | ((ulong)4294967039u << 32), dest[1]);
+        Assert.Equal(32767uL, dest[2]);
+        Assert.Equal(0uL, dest[3]);
+        Assert.Equal(0uL, dest[4]);
+        Assert.Equal(0uL, dest[5]);
+    }
+
+    [Fact]
+    public void WriteCreateActivePlayerAll_WithTitles_AppendsSixUInt64Payload()
+    {
+        int empty = CreateLength(titles: null);
+        int withTitles = CreateLength(titles: new uint?[]
+        {
+            3758129150u, 4294966511u, 4294868991u, 4294967039u, 32767u, 0u,
+            null, null, null, null, null, null
+        });
+
+        Assert.Equal(empty + 6 * sizeof(ulong), withTitles);
+    }
+
+    [Fact]
+    public void WriteCreateActivePlayerAll_WithoutTitles_KeepsZeroSize()
+    {
+        int empty = CreateLength(titles: null);
+        int explicitEmpty = CreateLength(titles: new uint?[12]);
+        Assert.Equal(empty, explicitEmpty);
+    }
+
+    private static int CreateLength(uint?[]? titles)
+    {
+        if (VersionBootstrap.LegacyBuild == ClientVersionBuild.Zero)
+            VersionBootstrap.LegacyBuild = ClientVersionBuild.V3_3_5a_12340;
+
+        var session = (GameSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GameSessionData));
+        typeof(GameSessionData).GetField(nameof(GameSessionData.OriginalObjectTypes))!
+            .SetValue(session, new Dictionary<WowGuid128, ObjectType>());
+        typeof(GameSessionData).GetField(nameof(GameSessionData.ActiveGlyphSlotIds))!
+            .SetValue(session, new uint[] { 21, 22, 23, 24, 25, 26 });
+        typeof(GameSessionData).GetField(nameof(GameSessionData.ActiveGlyphs))!
+            .SetValue(session, new ushort[6]);
+
+        var guid = WowGuid128.Create(HighGuidType703.Player, 1);
+        typeof(GameSessionData).GetField(nameof(GameSessionData.CurrentPlayerGuid))!
+            .SetValue(session, guid);
+
+        var global = (GlobalSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GlobalSessionData));
+        var update = new ObjectUpdate(guid, UpdateTypeModern.CreateObject1, global);
+        update.ActivePlayerData ??= new ActivePlayerData();
+        if (titles != null)
+        {
+            for (int i = 0; i < titles.Length; i++)
+                update.ActivePlayerData.KnownTitles[i] = titles[i];
+        }
+
+        var packet = new WorldPacket();
+        new ObjectUpdateBuilder(update, session).WriteCreateActivePlayerData(packet);
+        return packet.GetData()!.Length;
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -3153,7 +3153,8 @@ public partial class WorldClient
             int PLAYER_FIELD_KNOWN_TITLES = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_KNOWN_TITLES);
             if (PLAYER_FIELD_KNOWN_TITLES >= 0)
             {
-                int count = LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056) ? 3 : 2;
+                // TBC: one LONG (2 uint32). WotLK: TITLES + TITLES1 + TITLES2 (6 uint32 / 3 uint64).
+                int count = LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056) ? 6 : 2;
                 for (int i = 0; i < count; i++)
                 {
                     if (updateMaskArray[PLAYER_FIELD_KNOWN_TITLES + i])

--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -917,6 +917,9 @@ public partial class ObjectUpdateBuilder
 
         var active = src;
 
+        ulong[] foldedTitles = new ulong[6];
+        int knownTitlesCount = FoldKnownTitles(active.KnownTitles, foldedTitles);
+
         // InvSlots[141] — modern flat layout fanned from legacy 23/24/28/7/12/32 slots.
         for (int i = 0; i < 141; i++)
             data.WritePackedGuid128(GetModernInvSlot(active, i) ?? WowGuid128.Empty);
@@ -924,7 +927,7 @@ public partial class ObjectUpdateBuilder
         data.WritePackedGuid128(active.FarsightObject ?? WowGuid128.Empty);       // bit 26: FarsightObject (PackedGuid128)
         data.WritePackedGuid128(active.SummonedBattlePetGUID
             ?? _gameState.SummonedBattlePetGuid);                                  // bit 27: SummonedBattlePetGUID
-        data.WriteUInt32(0u);                                                      // bit 3 dynamic field: KnownTitles.size — proxy does not track titles
+        data.WriteUInt32((uint)knownTitlesCount);                                  // bit 3 dynamic field: KnownTitles.size
         data.WriteUInt64(active.Coinage.GetValueOrDefault());                      // bit 28: Coinage (UInt64)
         data.WriteInt32(active.XP.GetValueOrDefault());                            // bit 29: XP (Int32)
         data.WriteInt32(active.NextLevelXP.GetValueOrDefault());                   // bit 30: NextLevelXP (Int32)
@@ -1159,10 +1162,10 @@ public partial class ObjectUpdateBuilder
         data.WriteUInt8(0);                                                        // NumStableSlots
 
         // Dynamic-field payloads. WPP wire order: KnownTitles, DailyQuestsCompleted,
-        // AvailableQuestLineXQuestIDs, Field_1000 (all 0-count → 0 bytes),
-        // then Heirlooms[Count], HeirloomFlags[Count], then Toys/Transmog/etc
-        // (all 0-count → 0 bytes), then PvpInfo. Only Heirlooms + HeirloomFlags
-        // carry real payload bytes.
+        // AvailableQuestLineXQuestIDs, Field_1000, then Heirlooms[Count],
+        // HeirloomFlags[Count], then Toys/Transmog/etc, then PvpInfo.
+        for (int i = 0; i < knownTitlesCount; i++)
+            data.WriteUInt64(foldedTitles[i]);
         foreach (var itemId in GameData.Heirlooms)
             data.WriteInt32(itemId);
         for (int i = 0; i < GameData.Heirlooms.Count; i++)


### PR DESCRIPTION
Unlocked titles never appeared in the character-panel dropdown. `.titles current` still painted the name over the head, so it looked like titles worked until you opened C.

<img width="1031" height="235" alt="ScreenShot_2026-08-27_17 45 43" src="https://github.com/user-attachments/assets/2991b4f4-5714-4f43-adf8-d6939a80f0f6" />


<img width="1039" height="244" alt="image" src="https://github.com/user-attachments/assets/e2a1c041-a9ef-4528-b524-d0b66cfb01f9" />


## What

3.4.3 `ActivePlayerData.KnownTitles` is a `DynamicUpdateField<uint64>` of MaskID bits. Create advertised `size = 0` (`// proxy does not track titles`) and wrote no payload, so `IsTitleKnown` stayed false and the picker hid itself (`titleCount < 2`).

Create now folds the legacy bitfield (`uint32[6]` → `uint64[6]`) and writes the count next to `SummonedBattlePetGUID` plus the payload after `NumStableSlots`, matching Wrathion `ActivePlayerData::WriteCreate`.

WotLK ingest only copied the first 3 of AC's 6 `uint32` words (`PLAYER_FIELD_KNOWN_TITLES` + `TITLES1` + `TITLES2`). Titles at MaskID ≥ 96 never reached the client. Read all six.

`CMSG_SET_TITLE` was already forwarded as MaskID. No change there.

## Tested

AzerothCore 3.3.5a, client 3.4.3.54261.

- Brahand (`knownTitles` almost full): C now shows the title dropdown
- Current title still displays on the nameplate
- Selecting a title from the picker works