### PR TITLE
fix(v3_4_3): interleave glyph slot and glyph ids on Values update

### DIFF
--- a/HermesProxy.Tests/SourceGen/ActivePlayerSectionEquivalenceTests.cs
+++ b/HermesProxy.Tests/SourceGen/ActivePlayerSectionEquivalenceTests.cs
@@ -742,9 +742,10 @@ public class ActivePlayerSectionEquivalenceTests
         if (blocks.IsBitSet(1512))
         {
             for (int i = 0; i < PlayerConst.MaxGlyphSlots; i++)
+            {
                 if (blocks.IsBitSet(1513 + i)) data.WriteUInt32(gameState.ActiveGlyphSlotIds[i]);
-            for (int i = 0; i < PlayerConst.MaxGlyphSlots; i++)
                 if (blocks.IsBitSet(1519 + i)) data.WriteUInt32((uint)(gameState.ActiveGlyphs[i]));
+            }
         }
         if (blocks.IsBitSet(607))
         {

--- a/HermesProxy.Tests/World/GlyphSlotUpdateOrderTests.cs
+++ b/HermesProxy.Tests/World/GlyphSlotUpdateOrderTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Framework.Util;
+using HermesProxy;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using HermesProxy.World.Objects.Version.V3_4_3_54261;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class GlyphSlotUpdateOrderTests
+{
+    [Fact]
+    public void WriteUpdateGlyphsGroup_InterleavesSlotThenGlyphPerIndex()
+    {
+        var session = (GameSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GameSessionData));
+        typeof(GameSessionData).GetField(nameof(GameSessionData.OriginalObjectTypes))!
+            .SetValue(session, new Dictionary<WowGuid128, ObjectType>());
+        typeof(GameSessionData).GetField(nameof(GameSessionData.ActiveGlyphSlotIds))!
+            .SetValue(session, new uint[] { 21, 22, 23, 24, 25, 26 });
+        typeof(GameSessionData).GetField(nameof(GameSessionData.ActiveGlyphs))!
+            .SetValue(session, new ushort[] { 493, 487, 485, 0, 0, 0 });
+
+        var guid = WowGuid128.Create(HighGuidType703.Player, 1);
+        typeof(GameSessionData).GetField(nameof(GameSessionData.CurrentPlayerGuid))!
+            .SetValue(session, guid);
+
+        var global = (GlobalSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GlobalSessionData));
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, global);
+        update.ActivePlayerData ??= new ActivePlayerData();
+        var builder = new ObjectUpdateBuilder(update, session);
+
+        uint[] blocksBuf = new uint[48];
+        var blocks = new StackBitMask(blocksBuf);
+        for (int i = 0; i < PlayerConst.MaxGlyphSlots; i++)
+        {
+            blocks.SetBit(1513 + i);
+            blocks.SetBit(1519 + i);
+        }
+
+        var packet = new WorldPacket();
+        builder.WriteUpdateActivePlayerGlyphsGroup(packet, ref blocks, update.ActivePlayerData);
+
+        using var reader = new WorldPacket(0, packet.GetData()!);
+        ushort[] glyphs = [493, 487, 485, 0, 0, 0];
+        for (int i = 0; i < 6; i++)
+        {
+            Assert.Equal(21u + (uint)i, reader.ReadUInt32());
+            Assert.Equal(glyphs[i], reader.ReadUInt32());
+        }
+        Assert.False(reader.CanRead());
+    }
+}

--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -1350,16 +1350,19 @@ public partial class ObjectUpdateBuilder
         }
     }
 
-    // Glyphs group (bit 1512) — interleaved GlyphSlots[0..5] then Glyphs[0..5],
-    // each gated on its element bit (1513+i / 1519+i). Source = _gameState.
+    // Glyphs group (bit 1512). Native WriteUpdate interleaves per index
+    // (Slot[i] then Glyph[i]), not all slots then all glyphs. A slots-then-glyphs
+    // dump makes the client reread glyph IDs as GlyphSlot.dbc rows, so only the
+    // first Major/Minor sockets stay valid drop targets.
     internal void WriteUpdateActivePlayerGlyphsGroup(WorldPacket data, ref Framework.Util.StackBitMask blocks, ActivePlayerData src)
     {
         for (int i = 0; i < PlayerConst.MaxGlyphSlots; i++)
+        {
             if (blocks.IsBitSet(1513 + i))
                 data.WriteUInt32(_gameState.ActiveGlyphSlotIds[i]);
-        for (int i = 0; i < PlayerConst.MaxGlyphSlots; i++)
             if (blocks.IsBitSet(1519 + i))
                 data.WriteUInt32((uint)_gameState.ActiveGlyphs[i]);
+        }
     }
 
     // HasAny helper for the InvSlots mask-mutator. Returns true when any of the 141


### PR DESCRIPTION
Empty glyph sockets rejected every drop with **That Glyph cannot be inscribed there**. Only the first Major and first Minor sockets (top / top-left) accepted a glyph. The client never sent `CMSG_USE_ITEM` — it was a local type check.

## What

Native 3.4.3 `ActivePlayerData::WriteUpdate` interleaves per index when the glyphs group bit is set:

```
for i in 0..5:
    if Slot[i] changed: write GlyphSlots[i]
    if Glyph[i] changed: write Glyphs[i]
```

The proxy wrote all six `GlyphSlots` and then all six `Glyphs`. After the talent-push dirty re-emit (every login), the client reread glyph property ids (493 Devastate, …) as `GlyphSlot.dbc` rows. Those ids have no Major/Minor type, so only socket 0 (`21`, Major) and the first surviving Minor stayed valid drop targets.

Create was already interleaved and matched Wrathion. Only the Values path was wrong.

## Tested

AzerothCore 3.3.5a, client 3.4.3.54261.

- Brahand (Arms 80): after relog, empty Major sockets take Rending / Execution / Mortal Strike
- Empty Minor takes Command
- All six slots filled