### PR TITLE
fix(v3_4_3): echo the queue bracket id on battlefield port and leave

### DIFF
--- a/HermesProxy.Tests/World/Server/ArenaQueueTests.cs
+++ b/HermesProxy.Tests/World/Server/ArenaQueueTests.cs
@@ -1,3 +1,4 @@
+﻿using System;
 using HermesProxy.World;
 using Xunit;
 
@@ -35,5 +36,30 @@ public class ArenaQueueTests
         Assert.Equal("Join as a group failed. Every grouped player must be on the same arena team.", BattlefieldQueueArenaType.JoinErrorText(-12, null));
         Assert.Equal("Mildeena was unavailable to join the queue.", BattlefieldQueueArenaType.JoinErrorText(-11, "Mildeena"));
         Assert.Null(BattlefieldQueueArenaType.JoinErrorText(6, null));
+    }
+
+    // TrinityCore packs CMSG_BATTLEFIELD_PORT as a single uint64 queue id and matches the
+    // whole struct: BattlemasterListId = (p >> 16) & 0xFFFF, BracketId = (p >> 8) & 0x7F,
+    // TeamSize = p & 0x7F, plus a 0x1F90 marker in the top bits. The legacy field order
+    // the proxy writes lines up with that packing byte for byte, so a hardcoded bracket
+    // silently addresses a queue the player is not in.
+    [Theory]
+    [InlineData(6u, (byte)14, (byte)3)]   // 3v3 skirmish, level 80 bracket
+    [InlineData(6u, (byte)0, (byte)2)]    // 2v2, first bracket
+    [InlineData(2u, (byte)9, (byte)0)]    // Warsong Gulch, non-arena
+    public void LegacyPortFieldsPackIntoTrinityQueueId(uint bgTypeId, byte bracketId, byte teamSize)
+    {
+        // Same byte order as HandleBattlefieldPort writes for V2_0_1+.
+        var bytes = new byte[8];
+        bytes[0] = teamSize;
+        bytes[1] = bracketId;
+        BitConverter.GetBytes(bgTypeId).CopyTo(bytes, 2);
+        BitConverter.GetBytes((ushort)0x1F90).CopyTo(bytes, 6);
+        ulong packed = BitConverter.ToUInt64(bytes, 0);
+
+        Assert.Equal(bgTypeId, (uint)((packed >> 16) & 0xFFFF));
+        Assert.Equal(bracketId, (byte)((packed >> 8) & 0x7F));
+        Assert.Equal(teamSize, (byte)(packed & 0x7F));
+        Assert.Equal(0x1F90000000000000UL, packed & 0xFFFF000000000000UL);
     }
 }

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -1,4 +1,4 @@
-using HermesProxy.Auth;
+﻿using HermesProxy.Auth;
 using HermesProxy.Configuration.Options;
 using HermesProxy.World;
 using HermesProxy.World.Client;
@@ -349,6 +349,7 @@ public sealed class GameSessionData
     public Dictionary<uint, string> ItemTexts = [];
     public Dictionary<uint, uint> BattleFieldQueueTypes = [];
     public Dictionary<uint, byte> BattleFieldQueueArenaTypes = [];
+    public Dictionary<uint, byte> BattleFieldQueueBracketIds = [];
     public Dictionary<uint, long> BattleFieldQueueTimes = [];
     public Dictionary<uint, uint> DailyQuestsDone = [];
     public HashSet<WowGuid128> FlagCarrierGuids = [];
@@ -943,10 +944,23 @@ public sealed class GameSessionData
     {
         return BattleFieldQueueArenaTypes.TryGetValue(queueSlot, out var value) ? value : (byte)0;
     }
+    // Legacy CMSG_BATTLEFIELD_PORT packs (BattlemasterListId, BracketId, TeamSize) into
+    // the leading uint64. TrinityCore matches the whole struct, so a hardcoded bracket
+    // misses the queue of any character above the first level bracket. The value comes
+    // back on every SMSG_BATTLEFIELD_STATUS.
+    public void StoreBattleFieldQueueBracketId(uint queueSlot, byte bracketId)
+    {
+        BattleFieldQueueBracketIds[queueSlot] = bracketId;
+    }
+    public byte GetBattleFieldQueueBracketId(uint queueSlot)
+    {
+        return BattleFieldQueueBracketIds.TryGetValue(queueSlot, out var value) ? value : (byte)0;
+    }
     public void RemoveBattleFieldQueue(uint queueSlot)
     {
         BattleFieldQueueTypes.Remove(queueSlot);
         BattleFieldQueueArenaTypes.Remove(queueSlot);
+        BattleFieldQueueBracketIds.Remove(queueSlot);
         BattleFieldQueueTimes.Remove(queueSlot);
     }
     public void StoreAuraDurationLeft(WowGuid128 guid, byte slot, int duration, int currentTime)

--- a/HermesProxy/World/Client/PacketHandlers/BattleGroundHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/BattleGroundHandler.cs
@@ -184,7 +184,7 @@ public partial class WorldClient
         hdr.Ticket.Type = RideType.Battlegrounds;
 
         hdr.ArenaTeamSize = packet.ReadUInt8();
-        packet.ReadUInt8(); // unk
+        byte bracketId = packet.ReadUInt8(); // bracket id, echoed back on PORT/LEAVE
         uint battlefieldListId = packet.ReadUInt32();
         packet.ReadUInt16(); // 0x1F90
 
@@ -262,7 +262,10 @@ public partial class WorldClient
         }
         GetSession().GameState.StoreBattleFieldQueueType(hdr.Ticket.Id, battlefieldListId);
         if (battlefieldListId != 0)
+        {
             GetSession().GameState.StoreBattleFieldQueueArenaType(hdr.Ticket.Id, hdr.ArenaTeamSize);
+            GetSession().GameState.StoreBattleFieldQueueBracketId(hdr.Ticket.Id, bracketId);
+        }
     }
 
     [PacketHandler(Opcode.MSG_PVP_LOG_DATA, ClientVersionBuild.Zero, ClientVersionBuild.V2_0_1_6180)]

--- a/HermesProxy/World/Server/PacketHandlers/BattlegroundHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/BattlegroundHandler.cs
@@ -67,7 +67,7 @@ public partial class WorldSocket
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
         {
             packet.WriteUInt8(arenaType);
-            packet.WriteUInt8(0);
+            packet.WriteUInt8(GetSession().GameState.GetBattleFieldQueueBracketId(port.Ticket.Id));
             packet.WriteUInt32(bgTypeId);
             packet.WriteUInt16(0x1F90);
             packet.WriteBool(port.AcceptedInvite);
@@ -107,7 +107,7 @@ public partial class WorldSocket
                 ModernVersion.Build == ClientVersionBuild.V3_4_3_54261, isArena,
                 GetSession().GameState.GetBattleFieldQueueArenaType(1));
             packet.WriteUInt8(arenaType);
-            packet.WriteUInt8(0);
+            packet.WriteUInt8(GetSession().GameState.GetBattleFieldQueueBracketId(1));
             packet.WriteUInt32(bgTypeId);
             packet.WriteUInt16(0x1F90);
         }


### PR DESCRIPTION
Follow-up to #171. That PR fixed the arena team size in `CMSG_BATTLEFIELD_PORT`, which was necessary but not sufficient on TrinityCore — arena entry still did nothing there. This fixes the other half of the same field.

## What

TrinityCore does not read the five classic fields. It reads a single packed `uint64` queue id (`BattleGroundHandler.cpp:365`, `SharedDefines.h:3686`):

```cpp
BattlegroundQueueTypeId::FromPacked(uint64 packed)
{
    BattlemasterListId = (packed >> 16) & 0xFFFF;
    BracketId          = (packed >> 8)  & 0x7F;
    TeamSize           =  packed        & 0x7F;
}
```

The legacy field order we write lines up with that packing byte for byte — `[arenaType][unk2][bgTypeId u32][0x1F90]` **is** the packed id, and the trailing `0x1F90` matches the marker in TC's own `GetPacked()`.

So the second byte is not padding, it is `BracketId`. It was hardcoded to `0`, while the `SMSG_BATTLEFIELD_STATUS` that carries the real value read it as `// unk` and discarded it. `GetBattlegroundQueueIndex` compares the whole struct, so any character above the first level bracket addressed a queue it was not in, and the server returned silently — no port, no dequeue, no error message.

A level 80 character queues in bracket 14, so this affected every max-level queue.

Store the bracket per queue slot next to the arena team size and echo it on PORT and LEAVE. The vanilla status reader already labelled the equivalent byte `// bracket id`; only the TBC+ path threw it away.

## Tested

TrinityCore 3.3.5a, client 3.4.3.54261. Two clients queued for a 3v3 skirmish with `.debug arena` enabled.

Before, with #171 alone:

```
PORT  bgTypeId=6 arenatype=3 bracket=0 action=0   -> no server response, queue not cleared
PORT  bgTypeId=6 arenatype=3 bracket=0 action=1   -> no teleport, invite re-sent until it expired
```

After:

```
SMSG_BATTLEFIELD_STATUS  arenaTeamSize=3 bracket=14
PORT  arenatype=3 bracket=14 action=0  -> SMSG_BATTLEFIELD_STATUS listId=0   (queue cleared)
PORT  arenatype=3 bracket=14 action=1  -> STATUS_ACTIVE -> TRANSFER_PENDING -> NEW_WORLD
```

Both players entered the arena. Leaving a queue is also acknowledged by the server for the first time.

Adds a test asserting the legacy field order packs into TC's layout for a 3v3 at bracket 14, a 2v2 at bracket 0, and a non-arena battleground.

## Note

#171 was tested on AzerothCore, where it worked without this. Either AC tolerates a zero bracket or the tested character was in bracket 0 — worth confirming, since the two cores diverge here.

## Known issue, not addressed here

The queue slot is still hardcoded to `1` (`GetBattleFieldQueueType(1)`, `failed.Ticket.Id = 1`). On entering an arena TC sends two statuses at once — a clear for the queue slot and an active status for the arena — and they collapse onto the same ticket, so the client re-renders a stale "Enter Battle" invite. Clicking it while already inside ports you back out and hands the other team the win. Pre-existing, and worth its own change.
