### PR TITLE
fix(wotlk): read the arena team from PLAYER_BYTES_3 instead of guessing from race

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -2318,8 +2318,13 @@ public partial class WorldClient
 
                 if (objectType == ObjectType.Unit)
                     GetSession().GameState.StoreCreatureClass(guid, (Class)updateData.UnitData.ClassId);
-                else
+                else if (!LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
+                {
+                    // Pre-WotLK carries no arena team on the wire, so fall back to race.
+                    // From WotLK on it comes from PLAYER_BYTES_3 byte 3 and guessing here
+                    // would overwrite the real value with "everyone is on my team".
                     updateData.PlayerData.ArenaFaction = (byte)(GameData.IsAllianceRace((Race)updateData.UnitData.RaceId) ? 1 : 0);
+                }
 
                 if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261 &&
                     guid == GetSession().GameState.CurrentPlayerGuid)
@@ -3132,7 +3137,16 @@ public partial class WorldClient
                 updateData.PlayerData.NativeSex = (byte)(genderAndInebriation & 0x1);
                 updateData.PlayerData.Inebriation = (byte)(genderAndInebriation & 0xFFFE);
                 updateData.PlayerData.PvpTitle = (byte)((updates[PLAYER_BYTES_3].UInt32Value >> 16) & 0xFF); // city protector
-                updateData.PlayerData.PvPRank = (byte)((updates[PLAYER_BYTES_3].UInt32Value >> 24) & 0xFF); // honor rank
+                byte playerBytes3High = (byte)((updates[PLAYER_BYTES_3].UInt32Value >> 24) & 0xFF);
+                // Byte 3 changed meaning when PvP ranks were removed. Vanilla/TBC keep the
+                // honor rank there; WotLK reuses it as the arena team (TC
+                // PLAYER_BYTES_3_OFFSET_ARENA_FACTION = 3). Reading it as a rank on WotLK
+                // both corrupts PvPRank and leaves ArenaFaction guessed from race, so every
+                // player in a skirmish renders on the same team.
+                if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_0_2_9056))
+                    updateData.PlayerData.ArenaFaction = playerBytes3High;
+                else
+                    updateData.PlayerData.PvPRank = playerBytes3High; // honor rank
             }
             int PLAYER_DUEL_TEAM = LegacyVersion.GetUpdateField(PlayerField.PLAYER_DUEL_TEAM);
             if (PLAYER_DUEL_TEAM >= 0 && updateMaskArray[PLAYER_DUEL_TEAM])


### PR DESCRIPTION
Two same-faction players queued into the same skirmish rendered as **team mates**, both team counters showed *0 Players Remaining*, and the match never resolved — so the arena was unwinnable.

Found while play-testing #171 on TrinityCore.

## What

`PLAYER_BYTES_3` byte 3 changed meaning when PvP ranks were removed. Vanilla and TBC keep the honor rank there; WotLK reuses it as the arena team (TrinityCore `PLAYER_BYTES_3_OFFSET_ARENA_FACTION = 3`, `Player.h:381`):

```cpp
PLAYER_BYTES_3_OFFSET_GENDER        = 0,
PLAYER_BYTES_3_OFFSET_INEBRIATION   = 1,
PLAYER_BYTES_3_OFFSET_PVP_TITLE     = 2,
PLAYER_BYTES_3_OFFSET_ARENA_FACTION = 3
```

`UpdateHandler` mapped that byte to `PvPRank` on every build, so on WotLK it fed the arena team into a rank field and left `PlayerData.ArenaFaction` unset. The gap was then filled by guessing from race:

```csharp
updateData.PlayerData.ArenaFaction = (byte)(GameData.IsAllianceRace((Race)updateData.UnitData.RaceId) ? 1 : 0);
```

That is wrong for any arena. Teams are assigned by the server and both sides can share a faction — in a skirmish they routinely do. Every Alliance player saw every other Alliance player as an ally regardless of which team the server had put them on.

Map byte 3 to `ArenaFaction` from `V3_0_2` on and keep it as `PvPRank` below that. Keep the race fallback only for pre-WotLK, where no arena team exists on the wire; leaving it active on WotLK would overwrite the real value with "everyone is on my team".

## Tested

TrinityCore 3.3.5a, client 3.4.3.54261. Two Alliance characters queued into the same 3v3 skirmish from an Arena Battlemaster, with `.debug arena` enabled so the bracket pops with one player per side.

- Before: both players friendly to each other, Purple/Gold both *0 Players Remaining*, match hung and the server kept re-issuing the join invite
- After: the two characters are hostile, the match plays out, and the victory screen fires

Not V3_4_3-specific — this affects every WotLK-backed build. `dotnet build -c Release` clean, 885/885 tests pass.

## Note

Two things seen alongside this are **not** addressed here and look like artefacts of forcing a 1v1 pop inside a 3v3 bracket with `.debug arena`, rather than proxy bugs:

- the team counters still read 0/0 (verified the proxy forwards `SMSG_UPDATE_WORLD_STATE` verbatim with the correct modern layout, and `AddClassicStates` never overwrites server values, so ids 3600/3601 arrive untouched — the counts are TC's own, keyed off each player's BG team)
- the player who enters first receives a second "Enter Battle" invite about 18 seconds later, on a second queue slot; accepting it while already inside ports you out and hands the other team the win
