### PR TITLE
fix(v3_4_3): read the channel chat text length as 11 bits, not 9

### DIFF
--- a/HermesProxy/World/Server/Packets/ChatPackets.cs
+++ b/HermesProxy/World/Server/Packets/ChatPackets.cs
@@ -270,6 +270,25 @@ public class ChatMessageChannel : ClientPacket
     {
         Language = _worldPacket.ReadUInt32();
         ChannelGUID = _worldPacket.ReadPackedGuid128();
+
+        // V3_4_3 writes the text length as 11 bits, not 9, and follows the two lengths
+        // with a conditional secure-flag bit pair (TC 3.4.3 ChatMessageChannel::Read).
+        // Bit reads are MSB-first, so reading 9 bits of an 11-bit length yields len >> 2 —
+        // "gooday" (6) came through as 1 and the client posted "g". Messages of 1-3
+        // characters read as length 0 and post nothing at all. Same hazard as the one
+        // already handled in ChatMessage and ChatMessageWhisper above; this packet was
+        // missed when those were fixed. Issue #177.
+        if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+        {
+            uint targetLen343 = _worldPacket.ReadBits<uint>(9);
+            uint textLen343 = _worldPacket.ReadBits<uint>(11);
+            if (_worldPacket.HasBit())
+                IsSecure = _worldPacket.HasBit();
+            Target = _worldPacket.ReadString(targetLen343);
+            Text = _worldPacket.ReadString(textLen343);
+            return;
+        }
+
         uint targetLen = _worldPacket.ReadBits<uint>(9);
         uint textLen = _worldPacket.ReadBits<uint>(9);
         Target = _worldPacket.ReadString(targetLen);
@@ -280,6 +299,7 @@ public class ChatMessageChannel : ClientPacket
     public WowGuid128 ChannelGUID;
     public string Text = string.Empty;
     public string Target = string.Empty;
+    public bool IsSecure;
 }
 
 public class ChatMessageWhisper : ClientPacket


### PR DESCRIPTION
Fixes #177.

## Problem

On V3_4_3, every message sent to a chat channel was truncated to its first character. `/1 gooday` posted `g`.

## Cause

`ChatMessageChannel.Read()` read the text length as a **9-bit** field. V3_4_3 writes it as **11 bits**, and follows the two lengths with a conditional secure-flag bit pair that was not being consumed.

TrinityCore 3.4.3, `WorldPackets::Chat::ChatMessageChannel::Read`:

```cpp
_worldPacket >> Language;
_worldPacket >> ChannelGUID;
uint32 targetLen = _worldPacket.ReadBits(9);
uint32 textLen   = _worldPacket.ReadBits(11);
if (_worldPacket.ReadBit())
    IsSecure = _worldPacket.ReadBit();

Target = _worldPacket.ReadString(targetLen);
Text   = _worldPacket.ReadString(textLen);
```

Bit reads are MSB-first, so reading 9 bits of an 11-bit length yields `len >> 2`. A six-character message reads as length 1, which is exactly the reported symptom. Messages of one to three characters read as length 0 and posted nothing at all.

## Why only channel chat

`ChatMessage` (say / party / raid / instance) and `ChatMessageWhisper` already carry a `V3_4_3_54261` branch with the 11-bit length, each commented with this same hazard. `ChatMessageChannel` was missed when those were updated. That asymmetry — `/say` working while `/1` truncated — is what identified the packet.

## Fix

Adds the matching version-gated branch: 11-bit text length plus the conditional secure bit for `V3_4_3_54261`, leaving the existing 9-bit path untouched for V1_14 / V2_5.

## Testing

Verified in-game against an AzerothCore 3.3.5a backend with a V3_4_3_54261 client:

- long channel messages arrive intact (previously first character only)
- `/say` unchanged — it was already correct, and served as the control

Backend-independent: this is client-to-proxy parsing, so it affects every backend.
