### PR TITLE
fix(v3_4_3): defer the Toy Box sync, clear known guids on world change, synthesize item cooldowns

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -373,6 +373,14 @@ public sealed class GameSessionData
     // client doesn't have in its world model — those would round-trip as
     // CMSG_OBJECT_UPDATE_FAILED rejections (e.g. Transports we filter at create time).
     public HashSet<WowGuid128> ClientKnownGuids = [];
+    // V3_4_3-only: set when CollectionSync.SendToys was asked to publish the Toy Box
+    // while the player's CreateObject had not yet reached the client. The Toys list
+    // lives on ActivePlayerData, so it ships as a Values delta on the player guid —
+    // and the client discards (and CMSG_OBJECT_UPDATE_FAILED's) any Values for an
+    // object it does not know yet, which on login leaves it unable to instantiate
+    // further objects until a zone change rebuilds the grid. UpdateHandler flushes
+    // this once the player CreateObject has actually been forwarded.
+    public bool PendingToysSync;
     public Dictionary<WowGuid128, ArenaTeamInspectData[]> PlayerArenaTeams = [];
     public HashSet<string> AddonPrefixes = [];
     public Dictionary<byte, Dictionary<byte, int>> FlatSpellMods = [];

--- a/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/ItemHandler.cs
@@ -189,7 +189,25 @@ public partial class WorldClient
         ItemCooldown item = new ItemCooldown();
         item.ItemGuid = packet.ReadGuid().To128(GetSession().GameState);
         item.SpellID = packet.ReadUInt32();
+
+        // The legacy packet carries no duration, so read it off the item template rather
+        // than asserting a flat 30s for every item. Slots were indexed by the legacy spell
+        // id when the item query was parsed. Keep the old constant as the last resort so a
+        // backend that does send this opcode still shows *some* sweep.
         item.Cooldown = 30000;
+        uint cooldownItemId = GetSession().GameState.GetItemId(item.ItemGuid);
+        if (cooldownItemId != 0 && GameData.GetItemTemplate(cooldownItemId) is { } cooldownTemplate)
+        {
+            byte cooldownSlot = GameData.GetItemEffectSlot(cooldownItemId, item.SpellID);
+            if (cooldownSlot < cooldownTemplate.TriggeredSpellCooldowns.Length)
+            {
+                int ms = cooldownTemplate.TriggeredSpellCooldowns[cooldownSlot];
+                if (ms <= 0)
+                    ms = cooldownTemplate.TriggeredSpellCategoryCooldowns[cooldownSlot];
+                if (ms > 0)
+                    item.Cooldown = (uint)ms;
+            }
+        }
         SendPacketToClient(item);
     }
     [PacketHandler(Opcode.SMSG_SELL_RESPONSE)]

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -234,6 +234,16 @@ public partial class WorldClient
         {
             GetSession().GameState.IsWaitingForNewWorld = false;
             GetSession().GameState.IsWaitingForWorldPortAck = true;
+
+            // SMSG_NEW_WORLD tears down the client's entire world model, the player object
+            // included, and the server re-sends a CreateObject for everything on the new map.
+            // ClientKnownGuids has to follow or it stays stale across the transition: the
+            // Values filter would then forward deltas for objects the client no longer has,
+            // which come straight back as CMSG_OBJECT_UPDATE_FAILED. Observed as a player
+            // Values sent in the gap between the teleport and the re-create.
+            if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+                GetSession().GameState.ClientKnownGuids.Clear();
+
             SendPacketToClient(teleport);
             if (teleport.MapID > 1)
             {

--- a/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/SpellHandler.cs
@@ -489,6 +489,73 @@ public partial class WorldClient
         SendPacketToClient(spell);
     }
 
+    private static readonly Microsoft.Extensions.Logging.ILogger _melSpellLog =
+        Log.CreateMelLogger(Log.CategoryServer);
+
+    /// <summary>
+    /// Legacy 3.3.5a never announces item-use cooldowns: on that client the cooldown is
+    /// applied locally from the item_template fields delivered by the item query, so the
+    /// server has nothing to say and sends no SMSG_ITEM_COOLDOWN / SMSG_SPELL_COOLDOWN.
+    /// The modern client applies cooldowns locally too, but from its own SpellCooldowns.db2
+    /// keyed on the spell — so an item whose cooldown lives only on the legacy item row
+    /// (no SpellCooldowns entry for its on-use spell) renders no sweep anywhere: bag icon,
+    /// action bar and Toy Box all read that same store. The backend still enforces the
+    /// timer, so the button looks ready and the recast comes back as SMSG_CAST_FAILED.
+    ///
+    /// Synthesize the cooldown from the legacy template once the cast is confirmed. Only
+    /// send a positive value: 3.3.5a writes -1 for "use the spell's own cooldown" (that is
+    /// what Hearthstone 6948/8690 carries), and forwarding a zero would clear a cooldown
+    /// the client had correctly derived from its own DB2.
+    /// </summary>
+    void SendSynthesizedItemCooldown(ClientCastRequest pendingCast, uint modernSpellId)
+    {
+        if (ModernVersion.Build != ClientVersionBuild.V3_4_3_54261)
+            return;
+        if (pendingCast.ItemGUID.IsEmpty() || modernSpellId == 0)
+            return;
+
+        uint itemId = GetSession().GameState.GetItemId(pendingCast.ItemGUID);
+        if (itemId == 0)
+            return;
+
+        var template = GameData.GetItemTemplate(itemId);
+        if (template == null)
+            return;
+
+        // SaveItemEffectSlot indexed the slots by the legacy spell id from the item query.
+        uint legacySpellId = pendingCast.LegacySpellId != 0 ? pendingCast.LegacySpellId : pendingCast.SpellId;
+        byte slot = GameData.GetItemEffectSlot(itemId, legacySpellId);
+        if (slot >= template.TriggeredSpellCooldowns.Length)
+            return;
+
+        int cooldownMs = template.TriggeredSpellCooldowns[slot];
+        if (cooldownMs <= 0)
+            cooldownMs = template.TriggeredSpellCategoryCooldowns[slot];
+        if (cooldownMs <= 0)
+            return;
+
+        // Both packets are needed. SMSG_SPELL_COOLDOWN drives the spell-keyed store the
+        // action bar and Toy Box read; the bag icon is keyed on the item itself, which is
+        // what SMSG_ITEM_COOLDOWN addresses. Sending only the spell one leaves the bag
+        // slot with no sweep.
+        var cooldown = new SpellCooldownPkt { Caster = GetSession().GameState.CurrentPlayerGuid };
+        cooldown.SpellCooldowns.Add(new SpellCooldownStruct
+        {
+            SpellID = modernSpellId,
+            ForcedCooldown = (uint)cooldownMs,
+        });
+        SendPacketToClient(cooldown);
+
+        SendPacketToClient(new ItemCooldown
+        {
+            ItemGuid = pendingCast.ItemGUID,
+            SpellID = modernSpellId,
+            Cooldown = (uint)cooldownMs,
+        });
+
+        World.Logging.SpellLogMessages.ItemCooldownSynthesized(_melSpellLog, itemId, modernSpellId, cooldownMs);
+    }
+
     [PacketHandler(Opcode.SMSG_SPELL_GO)]
     void HandleSpellGo(WorldPacket packet)
     {
@@ -517,6 +584,8 @@ public partial class WorldClient
                 });
                 pendingCast.PrepareSent = true;
             }
+
+            SendSynthesizedItemCooldown(pendingCast, (uint)spell.Cast.SpellID);
 
             GetSession().GameState.LastCompletedNormalCast = pendingCast;
         }

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -16,6 +16,9 @@ namespace HermesProxy.World.Client;
 
 public partial class WorldClient
 {
+    private static readonly Microsoft.Extensions.Logging.ILogger _melObjLifeClient =
+        Log.CreateMelLogger(Log.CategoryServer);
+
     // Handlers for SMSG opcodes coming the legacy world server
     [PacketHandler(Opcode.SMSG_DESTROY_OBJECT)]
     void HandleDestroyObject(WorldPacket packet)
@@ -809,6 +812,24 @@ public partial class WorldClient
                 SendPacketToClient(playerAuraSync);
                 Log.Print(LogType.Trace,
                     $"[PlayerEnterTrace] post-CreateObject AURA_UPDATE_ALL sent for player guid={currentPlayerGuid} populatedAuras={playerAuraSync.Auras.Count}");
+            }
+
+            // The Toy Box lives on ActivePlayerData, so CollectionSync publishes it as a
+            // Values delta on the player guid. Anything the collection sync tried to send
+            // before the player create was deferred (see CollectionSync.SendToys); replay it
+            // once the client has the player object. This deliberately does not hang off
+            // playerCreateInBatch: the player's CreateObject is usually split out into its own
+            // per-create packet above, so by the time we get here it is no longer in
+            // updateObject.ObjectUpdates and that flag reads false on most logins.
+            // ClientKnownGuids is the durable signal — FilterV3_4_3Values registers the guid
+            // whichever packet carried the create.
+            if (GetSession().GameState.PendingToysSync &&
+                GetSession().GameState.ClientKnownGuids.Contains(currentPlayerGuid))
+            {
+                GetSession().GameState.PendingToysSync = false;
+                World.Logging.ObjectLifecycleLogMessages.ToysFlushed(
+                    _melObjLifeClient, currentPlayerGuid.Low, currentPlayerGuid.High);
+                World.Server.CollectionSync.RefreshUsableToys(GetSession());
             }
         }
     }

--- a/HermesProxy/World/Logging/ObjectLifecycleLogMessages.cs
+++ b/HermesProxy/World/Logging/ObjectLifecycleLogMessages.cs
@@ -46,4 +46,18 @@ internal static partial class ObjectLifecycleLogMessages
         Message = "[ObjLife] guid no longer known guidLow={GuidLow} guidHigh={GuidHigh} cause={Cause} wasKnown={WasKnown}")]
     public static partial void KnownGuidRemoved(
         ILogger logger, ulong guidLow, ulong guidHigh, string cause, bool wasKnown);
+
+    [LoggerMessage(
+        EventId = 904,
+        Level = LogLevel.Trace,
+        Message = "[ObjLife] toys sync deferred guidLow={GuidLow} guidHigh={GuidHigh} (player CreateObject not yet delivered)")]
+    public static partial void ToysDeferred(
+        ILogger logger, ulong guidLow, ulong guidHigh);
+
+    [LoggerMessage(
+        EventId = 905,
+        Level = LogLevel.Trace,
+        Message = "[ObjLife] toys sync flushed guidLow={GuidLow} guidHigh={GuidHigh} after player CreateObject")]
+    public static partial void ToysFlushed(
+        ILogger logger, ulong guidLow, ulong guidHigh);
 }

--- a/HermesProxy/World/Logging/SpellLogMessages.cs
+++ b/HermesProxy/World/Logging/SpellLogMessages.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Logging;
+
+namespace HermesProxy.World.Logging;
+
+/// <summary>
+/// Source-generated logging for the spell / cast translation path.
+///
+/// EventId 300-399 is reserved for this file (100-199 WorldSocket dispatch, 200-299
+/// WorldClient dispatch, 900-909 object lifecycle).
+///
+/// All Trace level, so they cost nothing unless Log.Server.MinimumLevel=Verbose.
+/// </summary>
+internal static partial class SpellLogMessages
+{
+    [LoggerMessage(
+        EventId = 300,
+        Level = LogLevel.Trace,
+        Message = "[SpellCooldown] synthesized from legacy item template itemId={ItemId} spellId={SpellId} cooldownMs={CooldownMs}")]
+    public static partial void ItemCooldownSynthesized(
+        ILogger logger, uint itemId, uint spellId, int cooldownMs);
+}

--- a/HermesProxy/World/Server/CollectionSync.cs
+++ b/HermesProxy/World/Server/CollectionSync.cs
@@ -98,11 +98,33 @@ public static class CollectionSync
         session.WorldClient.SendPacketToClient(new SpellGo { Cast = cast });
     }
 
+    private static readonly Microsoft.Extensions.Logging.ILogger _melObjLife =
+        Framework.Logging.Log.CreateMelLogger(Framework.Logging.Log.CategoryServer);
+
     public static void SendToys(GlobalSessionData session)
     {
         var state = session.GameState;
         if (state.CurrentPlayerGuid.IsEmpty() || session.WorldClient == null)
             return;
+
+        // The Toys list is an ActivePlayerData field, so publishing it means sending a
+        // Values delta on the player guid. This builds its own UpdateObject and hands it
+        // straight to the client, bypassing UpdatePackets.FilterV3_4_3Values — which is
+        // where ClientKnownGuids normally stops pre-create Values from going out. During
+        // login the collection sync runs before the player's CreateObject has been
+        // forwarded, so an account with toys shipped a delta for an object the client did
+        // not have: it answered CMSG_OBJECT_UPDATE_FAILED and then stopped instantiating
+        // newly created objects (pets, spell-spawned GameObjects) until the next zone
+        // change rebuilt the grid. Defer instead, and let UpdateHandler flush once the
+        // player create has actually gone out.
+        if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261
+            && !state.ClientKnownGuids.Contains(state.CurrentPlayerGuid))
+        {
+            state.PendingToysSync = true;
+            World.Logging.ObjectLifecycleLogMessages.ToysDeferred(
+                _melObjLife, state.CurrentPlayerGuid.Low, state.CurrentPlayerGuid.High);
+            return;
+        }
 
         var usable = state.GetUsableToysOrdered();
         state.LastSentUsableToys = usable;


### PR DESCRIPTION
Closes #180. Follow-up to #170.

Three independent changes, one per commit, all gated to `V3_4_3_54261`.

## 1. Defer the Toy Box sync until the player create is delivered (`807fe58e`)

`CollectionSync.SendToys` hand-builds its own `UpdateObject` and hands it straight to the client, bypassing `UpdatePackets.FilterV3_4_3Values` — where `ClientKnownGuids` normally stops pre-create Values from going out. At login it therefore shipped a Values delta on the player guid before the player's CreateObject, the client answered `CMSG_OBJECT_UPDATE_FAILED`, and then stopped instantiating newly created objects until a zone change rebuilt the grid.

Adds a `PendingToysSync` flag; `SendToys` defers while the player is not in `ClientKnownGuids`, and `UpdateHandler` replays it once the guid is registered.

The flush deliberately does **not** hang off `playerCreateInBatch` — the player's CreateObject is normally split into its own per-create packet, so that flag reads `playerCreateMatched=False` on most logins. That was the first attempt and it never fired.

## 2. Clear `ClientKnownGuids` when the client changes world (`42890ed2`)

`SMSG_NEW_WORLD` tears down the client's world model and the server re-creates everything on the new map, but the known-guid set was never cleared — so after any teleport it was stale and the Values filter forwarded deltas for objects the client no longer had.

Pre-existing on the branch and independent of the Toy Box work, which merely exposed it.

## 3. Synthesize item-use cooldowns from the legacy item template (`4051a7f1`)

Closes the limitation #170 documented. Legacy 3.3.5a never announces item-use cooldowns; the modern client derives them from its own `SpellCooldowns.db2`, keyed on the spell. An item whose cooldown lives only on the legacy `item_template` row renders no sweep anywhere while the backend still enforces the timer.

Synthesizes from `ItemTemplate.TriggeredSpellCooldowns` (falling back to `TriggeredSpellCategoryCooldowns`) once the cast is confirmed, sending **both** `SMSG_SPELL_COOLDOWN` (spell-keyed store behind the action bar and Toy Box) and `SMSG_ITEM_COOLDOWN` (bag icon). Only positive values are sent, so Hearthstone — which carries `-1`, meaning "use the spell's own cooldown" — keeps the 30-minute sweep it correctly derives from DB2.

Also stops asserting a flat `Cooldown = 30000` on `SMSG_ITEM_COOLDOWN` and reads the real duration.

## Testing

TrinityCore 3.3.5a, client 3.4.3.54261. Suite 937/937.

**Commit 1** — verified across five logins on two characters: `toys sync deferred` → `toys sync flushed` pairs cleanly, journal populates at login, and a Picnic Basket cast plus a summoned companion both render in the same zone with no walk to a zone boundary. Whole session: **0** `CMSG_OBJECT_UPDATE_FAILED`, where every toy-bearing login previously produced one.

**Commit 3** — verified in-client across 7 toys; sweeps visible on bag, action bar and Toy Box:

| item | spell | cooldown |
|---|---|---|
| 33223 Fishing Chair | 42766 | 5 min |
| 32566 Picnic Basket | 40530 | 3 min |
| 34686 | 45426 | 3 min |
| 34499 Paper Flying Machine Kit | 45135 | 30 s |
| 45984 Unusual Compass | 64385 | 10 s |
| 54343 Racer Controller | 75111 | 5 s |

Session after the fix also recorded **0** `SMSG_CAST_FAILED` — the recasts that used to bounce off the backend no longer happen, because the cooldown is now visible and the client stops the click first.

**Commit 2 has no runtime evidence.** No `SMSG_NEW_WORLD` occurred during the play-test, so the teleport path was never exercised. It is inert until a world change, but it should be play-tested across a hearthstone or portal before this merges — or dropped from this PR and held back. Flagging rather than implying it was covered.

## Known limits

- Shared cooldown *categories* are not propagated, so using one potion will not grey out its siblings. Under-reports rather than over-blocks, and matches the behaviour before this change.
- `CollectionSync.SendSummonedBattlePet`, `CurrentPlayerStorage.cs:170`, `GuildHandler.cs:228` and `CharacterHandler.cs:623` build player Values the same way as the bug fixed in commit 1 and carry the same latent hazard. Left alone here; worth an audit.
