### PR TITLE
fix(v3_4_3): arena petition drop, vendor slots, and rated party invite

### DIFF
--- a/HermesProxy.Tests/World/Server/ArenaQueueTests.cs
+++ b/HermesProxy.Tests/World/Server/ArenaQueueTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using HermesProxy.World;
+using HermesProxy.World.Server.Packets;
 using Xunit;
 
 namespace HermesProxy.Tests.World.Server;
@@ -27,6 +28,20 @@ public class ArenaQueueTests
     public void ToModernJoinError_NegatesAcCodes(int ac, int modern)
     {
         Assert.Equal(modern, BattlefieldQueueArenaType.ToModernJoinError(ac));
+    }
+
+    [Fact]
+    public void ShouldDropArenaList_DropsNonGuildCharters()
+    {
+        Assert.False(PetitionShowListCompat.ShouldDropArenaList([]));
+        Assert.False(PetitionShowListCompat.ShouldDropArenaList(
+        [
+            new PetitionEntry { CharterEntry = PetitionShowListCompat.GuildCharterEntry }
+        ]));
+        Assert.True(PetitionShowListCompat.ShouldDropArenaList(
+        [
+            new PetitionEntry { CharterEntry = 23560 }
+        ]));
     }
 
     [Fact]

--- a/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/NPCHandler.cs
@@ -163,7 +163,8 @@ public partial class WorldClient
             vendorItem.StackCount = packet.ReadUInt32();
             if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
                 vendorItem.ExtendedCostID = packet.ReadInt32();
-            vendorItem.MuID = (uint)(i + 1);
+            // MuID is the 1-based vendor-array slot the server wrote, not the packed row index.
+            vendorItem.MuID = (uint)vendorItem.Slot;
             GetSession().GameState.SetItemBuyCount(vendorItem.Item.ItemID, vendorItem.StackCount);
             vendor.Items.Add(vendorItem);
         }

--- a/HermesProxy/World/Client/PacketHandlers/PetitionHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/PetitionHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Framework;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Logging;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
@@ -34,8 +35,22 @@ public partial class WorldClient
                 petition.RequiredSignatures = 9;
 
             petitions.Petitions.Add(petition);
-
         }
+
+        // 3.4.3 has no arena registrar; a non-guild SHOW_LIST opens GuildRegistrar.
+        if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261
+            && PetitionShowListCompat.ShouldDropArenaList(petitions.Petitions))
+        {
+            WorldClientLogMessages.ArenaPetitionDropped(
+                _melLog, _sourceFile, _netDirSend,
+                petitions.Petitions.Count, petitions.Petitions[0].CharterEntry);
+            SendPacketToClient(new PrintNotification
+            {
+                NotifyText = "Arena teams are no longer available."
+            });
+            return;
+        }
+
         SendPacketToClient(petitions);
     }
 

--- a/HermesProxy/World/Logging/WorldClientLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldClientLogMessages.cs
@@ -135,4 +135,15 @@ internal static partial class WorldClientLogMessages
         byte Specs,
         byte Active,
         int Talents);
+
+    [LoggerMessage(
+        EventId = 212,
+        Level = LogLevel.Debug,
+        Message = "Dropped arena petition list count={Count} firstEntry={FirstEntry}")]
+    public static partial void ArenaPetitionDropped(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        int Count,
+        uint FirstEntry);
 }

--- a/HermesProxy/World/Logging/WorldSocketLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldSocketLogMessages.cs
@@ -112,4 +112,37 @@ internal static partial class WorldSocketLogMessages
         string NetDir,
         int QuestId,
         string Action);
+
+    [LoggerMessage(
+        EventId = 113,
+        Level = LogLevel.Debug,
+        Message = "Arena team invite team={TeamId} name={Name}")]
+    public static partial void ArenaTeamPartyInvite(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        uint TeamId,
+        string Name);
+
+    [LoggerMessage(
+        EventId = 114,
+        Level = LogLevel.Debug,
+        Message = "CMSG_BATTLEMASTER_JOIN_ARENA teamIndex={TeamIndex} teamId={TeamId}")]
+    public static partial void BattlemasterJoinArena(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        uint TeamIndex,
+        uint TeamId);
+
+    [LoggerMessage(
+        EventId = 115,
+        Level = LogLevel.Debug,
+        Message = "CMSG_BATTLEMASTER_JOIN_SKIRMISH teamSize={TeamSize} asGroup={AsGroup}")]
+    public static partial void BattlemasterJoinSkirmish(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        byte TeamSize,
+        bool AsGroup);
 }

--- a/HermesProxy/World/PetitionShowListCompat.cs
+++ b/HermesProxy/World/PetitionShowListCompat.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using HermesProxy.World.Server.Packets;
+
+namespace HermesProxy.World;
+
+internal static class PetitionShowListCompat
+{
+    public const uint GuildCharterEntry = 5863;
+
+    public static bool ShouldDropArenaList(IReadOnlyList<PetitionEntry> rows) =>
+        rows.Count > 0 && rows[0].CharterEntry != GuildCharterEntry;
+}

--- a/HermesProxy/World/Server/PacketHandlers/ArenaHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ArenaHandler.cs
@@ -1,8 +1,8 @@
 ﻿using Framework.Constants;
-using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Logging;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
@@ -58,13 +58,48 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_BATTLEMASTER_JOIN_ARENA)]
     void HandleBattlematerJoinArena(BattlemasterJoinArena join)
     {
+        // 3.4.3 has no invite opcode, so rated Join as Group injects CMSG_ARENA_TEAM_INVITE.
+        uint teamId = join.TeamIndex < GetSession().GameState.CurrentArenaTeamIds.Length
+            ? GetSession().GameState.CurrentArenaTeamIds[join.TeamIndex]
+            : 0;
+        if (teamId != 0)
+            InvitePartyToArenaTeam(teamId);
+
         WorldPacket packet = new WorldPacket(Opcode.CMSG_BATTLEMASTER_JOIN_ARENA);
         packet.WriteGuid(join.Guid.To64());
         packet.WriteUInt8(join.TeamIndex);
         packet.WriteBool(true); // As Group
         packet.WriteBool(true); // Is Rated
-        Log.Print(LogType.Debug, $"[BG] CMSG_BATTLEMASTER_JOIN_ARENA: teamIndex={join.TeamIndex} asGroup=1 rated=1.");
+        WorldSocketLogMessages.BattlemasterJoinArena(
+            _melLog, _sourceFile, _netDirSend, join.TeamIndex, teamId);
         SendPacketToServer(packet);
+    }
+
+    void InvitePartyToArenaTeam(uint teamId)
+    {
+        var group = GetSession().GameState.GetCurrentGroup();
+        if (group == null)
+            return;
+
+        var self = GetSession().GameState.CurrentPlayerGuid;
+        foreach (var member in group.PlayerList)
+        {
+            if (member.GUID == self)
+                continue;
+
+            string name = member.Name;
+            if (string.IsNullOrEmpty(name))
+                name = GetSession().GameState.GetPlayerName(member.GUID);
+            if (string.IsNullOrEmpty(name))
+                continue;
+
+            WorldPacket invite = new WorldPacket(Opcode.CMSG_ARENA_TEAM_INVITE);
+            invite.WriteUInt32(teamId);
+            invite.WriteCString(name);
+            SendPacketToServer(invite);
+            WorldSocketLogMessages.ArenaTeamPartyInvite(
+                _melLog, _sourceFile, _netDirSend, teamId, name);
+        }
     }
 
     [PacketHandler(Opcode.CMSG_BATTLEMASTER_JOIN_SKIRMISH)]
@@ -75,7 +110,8 @@ public partial class WorldSocket
         packet.WriteUInt8(join.TeamSize);
         packet.WriteBool(join.AsGroup);
         packet.WriteBool(false); // Is Rated
-        Log.Print(LogType.Debug, $"[BG] CMSG_BATTLEMASTER_JOIN_SKIRMISH: teamSize={join.TeamSize} asGroup={join.AsGroup}.");
+        WorldSocketLogMessages.BattlemasterJoinSkirmish(
+            _melLog, _sourceFile, _netDirSend, join.TeamSize, join.AsGroup);
         SendPacketToServer(packet);
     }
 

--- a/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/ItemHandler.cs
@@ -25,10 +25,7 @@ public partial class WorldSocket
 
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_1_0_9767))
         {
-            // The legacy "Slot" field for CMSG_BUY_ITEM is the 1-based vendor
-            // index. V3_4_3 sends that as MuID (which we populate in
-            // NPCHandler.HandleVendorInventory as i+1); older modern clients
-            // sent it as Slot. Forward whichever the client gave us.
+            // Legacy slot is the 1-based vendor-array index. 3.4.3 sends that as MuID.
             uint legacySlot = ModernVersion.Build == ClientVersionBuild.V3_4_3_54261 ? item.MuID : item.Slot;
             packet.WriteUInt32(legacySlot);
             packet.WriteUInt32(quantity);


### PR DESCRIPTION
Do not forward a non-guild `SMSG_PETITION_SHOW_LIST`. This client only has GuildRegistrar, so King Dond's 2v2/3v3/5v5 list opened that frame and left the NPC unclickable until you walked away. The gossip option now closes and prints that arena teams are no longer available.

Vendor `MuID` is now the 1-based slot from the server list, not the packed row index. Sparse merchants (Grikkin gems at slot 134) were buying `GetItem(51)` and returning item-not-found.

Rated Join as Group injects `CMSG_ARENA_TEAM_INVITE` for party members. This client has no invite opcode. First click invites, second click queues. A match still needs another 2v2 team in queue.

Play-tested on AzerothCore: Dond close/reclick + notice, Gleaming Ornate Dawnstone buy, Galaedon invited onto TeamName then All Arenas queued.