### PR TITLE
fix(logging): route object-lifecycle destroy traces to the Server category

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -28,6 +28,9 @@ public partial class WorldClient
             && guid.GetHighType() == HighGuidType.Corpse)
         {
             GetSession().GameState.DeferredCorpseDestroys.Add(guid);
+            World.Logging.ObjectLifecycleLogMessages.CorpseDestroyDeferred(
+                _melObjLifeClient, guid.Low, guid.High,
+                GetSession().GameState.DeferredCorpseDestroys.Count);
             return;
         }
 
@@ -45,7 +48,7 @@ public partial class WorldClient
 
         bool wasKnown = GetSession().GameState.ClientKnownGuids.Remove(guid);
         World.Logging.ObjectLifecycleLogMessages.KnownGuidRemoved(
-            _melLog, guid.Low, guid.High, "destroy-object", wasKnown);
+            _melObjLifeClient, guid.Low, guid.High, "destroy-object", wasKnown);
 
         var companion = GetSession().GameState.SummonedCompanionCreatureGuid;
         if (!companion.IsEmpty() && guid == companion)
@@ -65,8 +68,18 @@ public partial class WorldClient
             || guid.GetHighType() != HighGuidType.Corpse)
             return false;
         if (GetSession().GameState.DeferredCorpseDestroys.Remove(guid))
+        {
+            World.Logging.ObjectLifecycleLogMessages.CorpseRecreateSkipped(
+                _melObjLifeClient, guid.Low, guid.High, "paired-with-deferred-destroy");
             return true;
-        return GetSession().GameState.ClientKnownGuids.Contains(guid);
+        }
+        if (GetSession().GameState.ClientKnownGuids.Contains(guid))
+        {
+            World.Logging.ObjectLifecycleLogMessages.CorpseRecreateSkipped(
+                _melObjLifeClient, guid.Low, guid.High, "already-known");
+            return true;
+        }
+        return false;
     }
 
     void FlushDeferredCorpseDestroys()
@@ -87,7 +100,7 @@ public partial class WorldClient
             GetSession().GameState.LastAuraCasterOnTarget.Remove(guid);
             bool wasKnown = GetSession().GameState.ClientKnownGuids.Remove(guid);
             World.Logging.ObjectLifecycleLogMessages.KnownGuidRemoved(
-                _melLog, guid.Low, guid.High, "deferred-corpse-destroy", wasKnown);
+                _melObjLifeClient, guid.Low, guid.High, "deferred-corpse-destroy", wasKnown);
             UpdateObject destroy = new UpdateObject(GetSession().GameState);
             destroy.DestroyedGuids.Add(guid);
             SendPacketToClient(destroy);
@@ -926,7 +939,7 @@ public partial class WorldClient
             // as HandleDestroyObject above.
             bool wasKnown = GetSession().GameState.ClientKnownGuids.Remove(guid);
             World.Logging.ObjectLifecycleLogMessages.KnownGuidRemoved(
-                _melLog, guid.Low, guid.High, "out-of-range", wasKnown);
+                _melObjLifeClient, guid.Low, guid.High, "out-of-range", wasKnown);
         }
     }
 

--- a/HermesProxy/World/Logging/ObjectLifecycleLogMessages.cs
+++ b/HermesProxy/World/Logging/ObjectLifecycleLogMessages.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
 namespace HermesProxy.World.Logging;
 
@@ -60,4 +60,18 @@ internal static partial class ObjectLifecycleLogMessages
         Message = "[ObjLife] toys sync flushed guidLow={GuidLow} guidHigh={GuidHigh} after player CreateObject")]
     public static partial void ToysFlushed(
         ILogger logger, ulong guidLow, ulong guidHigh);
+
+    [LoggerMessage(
+        EventId = 906,
+        Level = LogLevel.Trace,
+        Message = "[ObjLife] corpse destroy deferred guidLow={GuidLow} guidHigh={GuidHigh} pending={Pending}")]
+    public static partial void CorpseDestroyDeferred(
+        ILogger logger, ulong guidLow, ulong guidHigh, int pending);
+
+    [LoggerMessage(
+        EventId = 907,
+        Level = LogLevel.Trace,
+        Message = "[ObjLife] corpse recreate skipped guidLow={GuidLow} guidHigh={GuidHigh} reason={Reason}")]
+    public static partial void CorpseRecreateSkipped(
+        ILogger logger, ulong guidLow, ulong guidHigh, string reason);
 }


### PR DESCRIPTION
## Problem

`ObjectLifecycleLogMessages.KnownGuidRemoved` is `Level = Trace`, but every call site passed `_melLog`, which is `Log.CreateMelLogger(Log.CategoryPacket)`. Play-tests run Packet at `Debug`, so the message was filtered out before it ever reached a sink.

The result: **`guid no longer known` has never printed, in any build**. Its sibling `[ObjLife] values forwarded` uses `_melObjLifeClient` on `Log.CategoryServer`, which runs at Verbose, and appears ~32,000 times in the same log file where the destroy traces appear zero times.

Object destroys were therefore undiagnosable. While investigating the V3_4_3 corpse-to-bones behaviour for #190, the absence of these lines twice looked like proof that the code path had not executed, when in fact it had run on every corpse.

## Change

- Point the three `KnownGuidRemoved` call sites at `_melObjLifeClient` (`destroy-object`, `out-of-range`, and the corpse deferral from #186).
- Add `CorpseDestroyDeferred` (EventId 906) — the deferral in `HandleDestroyObject` had **no** logging at all, so the whole hold was invisible.
- Add `CorpseRecreateSkipped` (EventId 907) with a reason string, so a suppressed corpse re-create is distinguishable between `paired-with-deferred-destroy` and `already-known`.

No behaviour change; diagnostics only.

## Why it matters

These are exactly the traces needed to work #190. With the fix, a corpse conversion reads end to end:

```
[ObjLife] corpse destroy deferred guidLow=78 guidHigh=4035229664170475520 pending=1
[ObjLife] corpse recreate skipped guidLow=78 guidHigh=4035229664170475520 reason=paired-with-deferred-destroy
```

and with the hold removed, the crash sequence is visible in one place:

```
[ObjLife] create registered    guidLow=78 CreateObject2
[ObjLife] guid no longer known guidLow=78 cause=destroy-object wasKnown=true
[ObjLife] create registered    guidLow=78 CreateObject2
[ObjLife] values forwarded     guidLow=78 hasCorpse=true
CMSG_LOG_DISCONNECT x2
```

Handy when reading these: corpse-type guids are `(guidHigh >> 58) & 0x3F == 14`.

## Testing

Built clean. Exercised on AzerothCore 3.3.5a (mod-playerbots) in Eye of the Storm with client 3.4.3.54261 — all four trace variants observed firing with `Log.Server.MinimumLevel=Verbose`.

Refs #190.
