### PR TITLE
fix(v3_4_3): ship Corpse Customizations on the create path

### DIFF
--- a/HermesProxy.Tests/SourceGen/CorpseDynamicObjectSectionEquivalenceTests.cs
+++ b/HermesProxy.Tests/SourceGen/CorpseDynamicObjectSectionEquivalenceTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using HermesProxy;
 using HermesProxy.Enums;
 using HermesProxy.World;
@@ -93,6 +93,25 @@ public class CorpseDynamicObjectSectionEquivalenceTests
             c.Flags = 0x08u;
             c.FactionTemplate = 1801;
         }) };
+
+        // A real corpse always carries appearance choices — UpdateHandler builds them from
+        // the legacy CORPSE_FIELD_BYTES_1/_2 bytes. Native 3.4.3 ships 5 for a human corpse.
+        yield return new object[] { "customizations", new System.Action<CorpseData>(c =>
+        {
+            c.DynamicFlags = 0u;
+            c.Owner = WowGuid128.Create(HighGuidType703.Player, 95);
+            c.DisplayID = 16125u;
+            c.RaceId = (byte)11;
+            c.SexId = (byte)0;
+            c.ClassId = (byte)1;
+            c.Flags = 1u;
+            c.FactionTemplate = 1629;
+            c.Customizations[0] = new ChrCustomizationChoice(128, 18027);
+            c.Customizations[1] = new ChrCustomizationChoice(129, 18047);
+            c.Customizations[2] = new ChrCustomizationChoice(130, 28662);
+            c.Customizations[3] = new ChrCustomizationChoice(131, 18058);
+            c.Customizations[4] = new ChrCustomizationChoice(132, 18072);
+        }) };
     }
 
     [Theory]
@@ -147,9 +166,28 @@ public class CorpseDynamicObjectSectionEquivalenceTests
         data.WriteUInt8(corpse.RaceId.GetValueOrDefault());
         data.WriteUInt8(corpse.SexId.GetValueOrDefault());
         data.WriteUInt8(corpse.ClassId.GetValueOrDefault());
-        data.WriteUInt32(0u); // Customizations.size() = 0
+        // Customizations.size(), then Flags/FactionTemplate, then the payload — matching
+        // TC CorpseData::WriteCreate and the native 3.4.3 capture
+        // (refs/native-captures/wrathion_343_corpse_bones_20260829.pkt, packet 2639, 5 entries).
+        int customizationCount = 0;
+        if (corpse.Customizations != null)
+            for (int i = 0; i < corpse.Customizations.Length; i++)
+                if (corpse.Customizations[i] != null) customizationCount++;
+        data.WriteUInt32((uint)customizationCount);
         data.WriteUInt32(corpse.Flags.GetValueOrDefault());
         data.WriteInt32(corpse.FactionTemplate.GetValueOrDefault());
+        if (corpse.Customizations != null)
+        {
+            for (int i = 0; i < corpse.Customizations.Length; i++)
+            {
+                var choice = corpse.Customizations[i];
+                if (choice != null)
+                {
+                    data.WriteUInt32(choice.ChrCustomizationOptionID);
+                    data.WriteUInt32(choice.ChrCustomizationChoiceID);
+                }
+            }
+        }
     }
 
     // Transcribed from TC 3.4.3 UpdateFields.cpp CorpseData::WriteUpdate. Note bit 12 gates

--- a/HermesProxy.Tests/SourceGen/ObjectUpdateBuilderGeneratorTests.WriteCreateObjectData_V3_4_3_54261.verified.txt
+++ b/HermesProxy.Tests/SourceGen/ObjectUpdateBuilderGeneratorTests.WriteCreateObjectData_V3_4_3_54261.verified.txt
@@ -3050,9 +3050,10 @@ public partial class ObjectUpdateBuilder
         data.WriteUInt8(src.RaceId.GetValueOrDefault());
         data.WriteUInt8(src.SexId.GetValueOrDefault());
         data.WriteUInt8(src.ClassId.GetValueOrDefault());
-        data.WriteUInt32(0u);
+        WriteCreateCorpseCustomizationsCount(data, src);
         data.WriteUInt32(src.Flags.GetValueOrDefault());
         data.WriteInt32(src.FactionTemplate.GetValueOrDefault());
+        WriteCreateCorpseCustomizationsData(data, src);
     }
 
     internal void WriteUpdateCorpseData(HermesProxy.World.WorldPacket data)

--- a/HermesProxy/World/Enums/V3_4_3_54261/CorpseField.cs
+++ b/HermesProxy/World/Enums/V3_4_3_54261/CorpseField.cs
@@ -1,4 +1,4 @@
-using HermesProxy.World.Objects;
+﻿using HermesProxy.World.Objects;
 using HermesProxy.World.Objects.Version.Attributes;
 
 namespace HermesProxy.World.Enums.V3_4_3_54261;
@@ -65,11 +65,13 @@ public enum CorpseField
     [DescriptorUpdateField(nameof(CorpseData.ClassId), DescriptorType.UInt8, bit: 9)]
     CORPSE_FIELD_CLASS_ID,
 
-    // Customizations.size(). Always 0: the proxy converts legacy appearance bytes into
-    // CorpseData.Customizations but has never shipped them, and bit 1 (the matching dynamic
-    // field) is likewise never set. Sending a non-zero count here without also writing the
-    // payload below would desync the stream.
-    [DescriptorCreatePlaceholder(DescriptorType.UInt32)]
+    // Customizations.size(). Counts the non-null entries UpdateHandler populated from the
+    // legacy CORPSE_FIELD_BYTES_1/_2 appearance bytes; the payload is written after
+    // FactionTemplate below, matching TC CorpseData::WriteCreate. A native 3.4.3 server
+    // always ships these (5 entries for a human corpse) — see
+    // refs/native-captures/wrathion_343_corpse_bones_20260829.pkt packet 2639.
+    [DescriptorCreatePlaceholder(DescriptorType.UInt32,
+        CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateCorpseCustomizationsCount))]
     CORPSE_CUSTOMIZATIONS_COUNT,
 
     [DescriptorCreateField(nameof(CorpseData.Flags), DescriptorType.UInt32)]
@@ -79,4 +81,10 @@ public enum CorpseField
     [DescriptorCreateField(nameof(CorpseData.FactionTemplate), DescriptorType.Int32)]
     [DescriptorUpdateField(nameof(CorpseData.FactionTemplate), DescriptorType.Int32, bit: 11)]
     CORPSE_FIELD_FACTION_TEMPLATE,
+
+    // Customizations payload — 2x UInt32 per non-null entry, written last, after
+    // FactionTemplate. Count is emitted above between Class and Flags.
+    [DescriptorCreatePlaceholder(DescriptorType.UInt32,
+        CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateCorpseCustomizationsData))]
+    CORPSE_CUSTOMIZATIONS_DATA_CUSTOM,
 }

--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -825,6 +825,31 @@ public partial class ObjectUpdateBuilder
         }
     }
 
+    internal void WriteCreateCorpseCustomizationsCount(WorldPacket data, CorpseData src)
+    {
+        int customizationCount = 0;
+        if (src.Customizations != null)
+        {
+            for (int i = 0; i < src.Customizations.Length; i++)
+                if (src.Customizations[i] != null) customizationCount++;
+        }
+        data.WriteUInt32((uint)customizationCount);
+    }
+
+    internal void WriteCreateCorpseCustomizationsData(WorldPacket data, CorpseData src)
+    {
+        if (src.Customizations == null) return;
+        for (int m = 0; m < src.Customizations.Length; m++)
+        {
+            var choice = src.Customizations[m];
+            if (choice != null)
+            {
+                data.WriteUInt32(choice.ChrCustomizationOptionID);
+                data.WriteUInt32(choice.ChrCustomizationChoiceID);
+            }
+        }
+    }
+
     internal void WriteCreatePlayerQuestLog(WorldPacket data, PlayerData src)
     {
         // Owner-gated by generator (placeholder declares OwnerOnly = true). Iterates


### PR DESCRIPTION
## Problem

`WriteCreateCorpseData` emitted a hardcoded `Customizations.size() = 0` and no payload, so a corpse never carried the dead player's appearance choices. A native 3.4.3 server always sends them.

The data was already being built and then discarded: `UpdateHandler` converts the legacy `CORPSE_FIELD_BYTES_1` / `_2` appearance bytes into `CorpseData.Customizations`, and the descriptor wrote a literal zero over it.

## Verified against native ground truth

Captured from Wrathion (native V3_4_3, no proxy in the path), dying and resurrecting so `ConvertCorpseToBones` fired — archived at `refs/native-captures/wrathion_343_corpse_bones_20260829.pkt`, packet 2639:

```
UpdateType: CreateObject2
Object Guid: 0x38000442400000000000000000000001 Corpse/0 Map: 530 Low: 1
DisplayID: 16125
RaceID: 11  Sex: 0  Class: 1
FactionTemplate: 1629
(Customizations) [0] OptionID: 128  ChoiceID: 18027
(Customizations) [1] OptionID: 129  ChoiceID: 18047
(Customizations) [2] OptionID: 130  ChoiceID: 28662
(Customizations) [3] OptionID: 131  ChoiceID: 18058
(Customizations) [4] OptionID: 132  ChoiceID: 18072
```

Extracting the corpse section from the raw `.pkt` bytes and diffing it against our writer fed the same field values now yields a **byte-identical 148-byte block**. Field order matches TC's `CorpseData::WriteCreate` — count between `Class` and `Flags`, payload after `FactionTemplate`.

## Change

`WriteCreateCorpseCustomizationsCount` / `WriteCreateCorpseCustomizationsData`, mirroring the existing `PlayerData` pattern, wired into `CorpseField.cs` in place of the `0u` placeholder:

```csharp
data.WriteUInt8(src.ClassId...);
WriteCreateCorpseCustomizationsCount(data, src);   // was: data.WriteUInt32(0u)
data.WriteUInt32(src.Flags...);
data.WriteInt32(src.FactionTemplate...);
WriteCreateCorpseCustomizationsData(data, src);    // new
```

## Test gap this closes

`CorpseDynamicObjectSectionEquivalenceTests` compares the generated writer against a frozen hand-port. The hand-port **also** hardcoded `size = 0`, and no scenario populated the array — so both sides agreed on shipping nothing and the test could never have caught this. Oracle updated, plus a new scenario using the capture's exact values.

Generator snapshot regenerated; the only delta is the intended one:

```
-        data.WriteUInt32(0u);
+        WriteCreateCorpseCustomizationsCount(data, src);
+        WriteCreateCorpseCustomizationsData(data, src);
```

## Scope — this does NOT fix #190

The corpse `CreateObject2` still crashes the client with `reason=7`; reproduced on AzerothCore with this change in place. #186's corpse hold still suppresses these creates, so the new bytes are dormant until that hold can be removed.

This is a correctness fix that gets the bytes right for that day, and closes the test gap now. Full suite 955/955.

Refs #190.

Incidentally: WowPacketParser mis-decodes this packet — it shows `Items` as all-zero when the wire carries four populated entries, and `Flags: 1` where the wire says `0`. The byte-level comparison above is what the verification rests on, not the parsed view.
