### PR TITLE
fix(legacy): read the 5-byte server header WotLK cores use past 0x7FFF

### DIFF
--- a/HermesProxy.Tests/World/LegacyServerPacketHeaderTests.cs
+++ b/HermesProxy.Tests/World/LegacyServerPacketHeaderTests.cs
@@ -1,0 +1,138 @@
+using System;
+using HermesProxy.World;
+using HermesProxy.World.Client;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+/// <summary>
+/// Regression cover for issue #200: WotLK cores widen the server header from 4 bytes to 5 once a
+/// packet passes 0x7FFF, and HermesProxy used to read a fixed 4. The stray byte both mis-framed the
+/// packet and stalled the RC4 receive keystream, so every packet after the first large one decoded
+/// as garbage and the server dropped the connection. A level-80 character's
+/// <c>SMSG_ALL_ACHIEVEMENT_DATA</c> (~60 KB) reaches that size on any WotLK backend.
+/// </summary>
+public class LegacyServerPacketHeaderTests
+{
+    /// <summary>
+    /// Builds a header the way AzerothCore/TrinityCore 3.3.5a <c>ServerPktHeader</c> does.
+    /// <paramref name="size"/> counts the payload plus the 2-byte opcode.
+    /// </summary>
+    private static byte[] BuildServerHeader(uint size, ushort opcode)
+    {
+        var bytes = new byte[size > 0x7FFF ? 5 : 4];
+        int i = 0;
+
+        if (size > 0x7FFF)
+            bytes[i++] = (byte)(0x80 | ((size >> 16) & 0xFF));
+
+        bytes[i++] = (byte)((size >> 8) & 0xFF);
+        bytes[i++] = (byte)(size & 0xFF);
+        bytes[i++] = (byte)(opcode & 0xFF);
+        bytes[i] = (byte)((opcode >> 8) & 0xFF);
+
+        return bytes;
+    }
+
+    [Theory]
+    [InlineData(4u, (ushort)0x0236)]        // tiny packet
+    [InlineData(0x7FFFu, (ushort)0x047D)]   // exactly at the boundary — still the narrow header
+    public void Read_NarrowHeader_RoundTrips(uint size, ushort opcode)
+    {
+        var wire = BuildServerHeader(size, opcode);
+        Assert.Equal(LegacyServerPacketHeader.StructSize, wire.Length);
+        Assert.False(LegacyServerPacketHeader.IsLargePacket(wire[0]));
+
+        var header = new LegacyServerPacketHeader();
+        header.Read(wire, large: false);
+
+        Assert.Equal(size, header.Size);
+        Assert.Equal(opcode, header.Opcode);
+    }
+
+    [Theory]
+    [InlineData(0x8000u, (ushort)0x047D)]   // first size that widens the header
+    [InlineData(59942u, (ushort)0x047D)]    // the live SMSG_ALL_ACHIEVEMENT_DATA from issue #200
+    [InlineData(0x7FFFFFu, (ushort)0x0001)] // widest size the 3-byte field can express
+    public void Read_WideHeader_RoundTrips(uint size, ushort opcode)
+    {
+        var wire = BuildServerHeader(size, opcode);
+        Assert.Equal(LegacyServerPacketHeader.LargeStructSize, wire.Length);
+        Assert.True(LegacyServerPacketHeader.IsLargePacket(wire[0]));
+
+        var header = new LegacyServerPacketHeader();
+        header.Read(wire, large: true);
+
+        Assert.Equal(size, header.Size);
+        Assert.Equal(opcode, header.Opcode);
+    }
+
+    /// <summary>
+    /// The opcode moves one byte along in the wide form. Reading a wide header with the narrow
+    /// layout is exactly the bug: the size collapses to 0x80EA and the opcode becomes 0x7D26
+    /// (32038) — the value that showed up in both the reporter's log and the local repro.
+    /// </summary>
+    [Fact]
+    public void Read_WideHeaderWithNarrowLayout_ProducesTheIssue200Garbage()
+    {
+        var wire = BuildServerHeader(59942, 0x047D);
+
+        var header = new LegacyServerPacketHeader();
+        header.Read(wire, large: false);
+
+        Assert.NotEqual(59942u, header.Size);
+        Assert.Equal(32038, header.Opcode);
+    }
+
+    /// <summary>
+    /// The receive keystream has to advance over all five header bytes. <c>Decrypt</c> is pinned to
+    /// the narrow width and ignores anything shorter, so the trailing byte needs
+    /// <c>DecryptLargeHeaderByte</c> — without it the byte stays ciphertext and, worse, the stream
+    /// stays one byte behind for the rest of the session.
+    /// </summary>
+    [Fact]
+    public void DecryptLargeHeaderByte_KeepsTheKeystreamAlignedWithASingleFiveBytePass()
+    {
+        ReadOnlySpan<byte> sessionKey = "0123456789ABCDEF0123456789ABCDEF0123456789"u8;
+
+        // Reference: one crypt consuming the 5 header bytes as a single run, which is what the
+        // server did when it encrypted them.
+        var reference = new WotlkWorldCrypt();
+        reference.Initialize(sessionKey);
+        var wholeRun = new byte[8];
+        reference.Decrypt(wholeRun.AsSpan(0, 4));
+        reference.DecryptLargeHeaderByte(wholeRun.AsSpan(4, 1));
+
+        // Split the same 5 bytes the way the receive loop does, then keep going into the next
+        // header to prove the stream did not fall behind.
+        var split = new WotlkWorldCrypt();
+        split.Initialize(sessionKey);
+        var stream = new byte[8];
+        split.Decrypt(stream.AsSpan(0, 4));
+        split.DecryptLargeHeaderByte(stream.AsSpan(4, 1));
+
+        Assert.Equal(wholeRun[..5], stream[..5]);
+
+        // The 5th byte must actually have been transformed; a no-op would leave it at zero.
+        Assert.NotEqual(0, stream[4]);
+
+        // And the following header must decrypt identically on both, i.e. both consumed exactly 5.
+        reference.Decrypt(wholeRun.AsSpan(5, 3));
+        split.Decrypt(stream.AsSpan(5, 3));
+        Assert.Equal(wholeRun, stream);
+    }
+
+    /// <summary>Vanilla and TBC never see the wide header, so their crypts keep the no-op default.</summary>
+    [Fact]
+    public void DecryptLargeHeaderByte_IsANoOpForPreWotlkCrypts()
+    {
+        ReadOnlySpan<byte> sessionKey = "0123456789ABCDEF0123456789ABCDEF0123456789"u8;
+
+        LegacyWorldCrypt vanilla = new VanillaWorldCrypt();
+        vanilla.Initialize(sessionKey);
+        var untouched = new byte[1];
+        vanilla.DecryptLargeHeaderByte(untouched);
+
+        Assert.Equal(0, untouched[0]);
+    }
+}

--- a/HermesProxy/World/Client/LegacyWorldCrypt.cs
+++ b/HermesProxy/World/Client/LegacyWorldCrypt.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Security.Cryptography;
 
 namespace HermesProxy.World.Client;
@@ -8,6 +8,15 @@ public interface LegacyWorldCrypt
     void Initialize(ReadOnlySpan<byte> sessionKey);
     void Decrypt(Span<byte> data);
     void Encrypt(Span<byte> data);
+
+    /// <summary>
+    /// Advances the receive keystream over the extra size byte that WotLK cores prepend to a
+    /// server header once the packet passes 0x7FFF. <see cref="Decrypt"/> is fixed at the normal
+    /// header width and silently ignores anything shorter, so the trailing byte needs its own
+    /// call — skipping it leaves that byte as ciphertext and desyncs every packet that follows.
+    /// Vanilla and TBC never emit the wide header, so they keep the no-op default.
+    /// </summary>
+    void DecryptLargeHeaderByte(Span<byte> data) { }
 }
 
 public class VanillaWorldCrypt : LegacyWorldCrypt

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -248,7 +248,7 @@ public partial class WorldClient
         return true;
     }
 
-    private readonly byte[] _headerBuffer = new byte[LegacyServerPacketHeader.StructSize];
+    private readonly byte[] _headerBuffer = new byte[LegacyServerPacketHeader.LargeStructSize];
 
     private void HandleDisconnect(string reason)
     {
@@ -272,7 +272,9 @@ public partial class WorldClient
         {
             while (true)
             {
-                if (!await ReceiveBufferFully(_headerBuffer.AsMemory()))
+                // Explicit length: _headerBuffer is sized for the 5-byte large form, so an
+                // unbounded AsMemory() would read one byte too many on every ordinary packet.
+                if (!await ReceiveBufferFully(_headerBuffer.AsMemory(0, LegacyServerPacketHeader.StructSize)))
                 {
                     HandleDisconnect("header");
                     return;
@@ -281,32 +283,68 @@ public partial class WorldClient
                 if (_worldCrypt != null)
                     _worldCrypt.Decrypt(_headerBuffer.AsSpan(0, LegacyServerPacketHeader.StructSize));
 
+                // WotLK cores stretch the size field to 3 bytes for payloads over 0x7FFF and
+                // mark it with 0x80 on the first byte, so the header is 5 bytes rather than 4.
+                // The extra byte has to be pulled and decrypted in stream order: the crypt is
+                // an RC4 keystream, and skipping a byte desyncs every packet that follows, not
+                // just this one. Vanilla and TBC never set the marker (see LegacyServerPacketHeader),
+                // so leave their framing alone rather than trusting a stray high bit.
+                bool largeHeader = LegacyVersion.ExpansionVersion >= 3
+                                   && LegacyServerPacketHeader.IsLargePacket(_headerBuffer[0]);
+
+                if (largeHeader)
+                {
+                    if (!await ReceiveBufferFully(_headerBuffer.AsMemory(LegacyServerPacketHeader.StructSize, 1)))
+                    {
+                        HandleDisconnect("header");
+                        return;
+                    }
+
+                    if (_worldCrypt != null)
+                        _worldCrypt.DecryptLargeHeaderByte(_headerBuffer.AsSpan(LegacyServerPacketHeader.StructSize, 1));
+                }
+
                 LegacyServerPacketHeader header = new();
-                header.Read(_headerBuffer);
-                ushort packetSize = header.Size;
+                header.Read(_headerBuffer, largeHeader);
+                uint packetSize = header.Size;
+
+                if (largeHeader)
+                    WorldClientLogMessages.LargeHeaderReceived(_melLog, _sourceFile, _netDirRecv, packetSize, header.Opcode);
 
                 if (packetSize == 0)
                 {
                     continue;
                 }
 
+                // Size counts the 2-byte opcode. Anything smaller is a malformed frame, and
+                // feeding it to the copy below would rent a buffer and then read a negative
+                // length, so bail out instead of throwing deep inside the socket read.
+                if (packetSize < sizeof(ushort))
+                {
+                    WorldClientLogMessages.MalformedHeaderSize(_melLog, _sourceFile, _netDirRecv, packetSize, header.Opcode);
+                    HandleDisconnect("header");
+                    return;
+                }
+
                 // Rent a possibly-oversized buffer; WorldPacket(byte[], int length, isPooled:true)
                 // tracks the actual payload length and returns it to the pool on Dispose.
-                byte[] buffer = ArrayPool<byte>.Shared.Rent(packetSize);
+                byte[] buffer = ArrayPool<byte>.Shared.Rent((int)packetSize);
                 bool packetOwnsBuffer = false;
                 try
                 {
-                    // copy the opcode into the new buffer
-                    buffer[0] = _headerBuffer[2];
-                    buffer[1] = _headerBuffer[3];
+                    // copy the opcode into the new buffer. The wide header spends an extra
+                    // byte on the size, so the opcode sits one position further along.
+                    int opcodeOffset = largeHeader ? 3 : 2;
+                    buffer[0] = _headerBuffer[opcodeOffset];
+                    buffer[1] = _headerBuffer[opcodeOffset + 1];
 
-                    if (!await ReceiveBufferFully(buffer.AsMemory(2, packetSize - 2)))
+                    if (!await ReceiveBufferFully(buffer.AsMemory(2, (int)packetSize - 2)))
                     {
                         HandleDisconnect("payload");
                         return;
                     }
 
-                    using WorldPacket packet = new WorldPacket(buffer, packetSize, isPooled: true);
+                    using WorldPacket packet = new WorldPacket(buffer, (int)packetSize, isPooled: true);
                     packetOwnsBuffer = true;
                     packet.SetReceiveTime(Environment.TickCount);
                     HandlePacket(packet);

--- a/HermesProxy/World/Client/WotlkWorldCrypt.cs
+++ b/HermesProxy/World/Client/WotlkWorldCrypt.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 
@@ -40,6 +40,17 @@ public class WotlkWorldCrypt : LegacyWorldCrypt
             return;
 
         RC4Process(_recvState, data[..CRYPTED_RECV_LEN]);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecryptLargeHeaderByte(Span<byte> data)
+    {
+        if (!_isInitialized || data.IsEmpty)
+            return;
+
+        // Deliberately not length-clamped: the caller passes exactly the bytes the server
+        // encrypted beyond the standard header, and the RC4 stream has to consume all of them.
+        RC4Process(_recvState, data);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/HermesProxy/World/Logging/WorldClientLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldClientLogMessages.cs
@@ -1,4 +1,4 @@
-using HermesProxy.World.Enums;
+﻿using HermesProxy.World.Enums;
 using Microsoft.Extensions.Logging;
 
 namespace HermesProxy.World.Logging;
@@ -146,4 +146,26 @@ internal static partial class WorldClientLogMessages
         string NetDir,
         int Count,
         uint FirstEntry);
+
+    [LoggerMessage(
+        EventId = 214,
+        Level = LogLevel.Debug,
+        Message = "Large legacy packet: 5-byte header, size={Size} opcode={OpcodeId}")]
+    public static partial void LargeHeaderReceived(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        uint Size,
+        ushort OpcodeId);
+
+    [LoggerMessage(
+        EventId = 213,
+        Level = LogLevel.Error,
+        Message = "Malformed legacy header: size={Size} counts fewer bytes than the opcode it must contain (opcode={OpcodeId}). Dropping the connection rather than reading a desynced stream.")]
+    public static partial void MalformedHeaderSize(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        uint Size,
+        ushort OpcodeId);
 }

--- a/HermesProxy/World/Packet.cs
+++ b/HermesProxy/World/Packet.cs
@@ -398,17 +398,61 @@ public class PacketHeader
 
 public class LegacyServerPacketHeader
 {
+    // WotLK-era cores (AzerothCore/TrinityCore 3.3.5a ServerPktHeader) size the header
+    // by the payload: normally 2 bytes of big-endian size + 2 bytes of opcode, but once
+    // the size (which counts the opcode) passes 0x7FFF the size field grows to 3 bytes
+    // and the first one carries a 0x80 marker:
+    //
+    //     if (isLargePacket())                          // size > 0x7FFF
+    //         header[i++] = 0x80 | (0xFF & (size >> 16));
+    //     header[i++] = 0xFF & (size >> 8);
+    //     header[i++] = 0xFF & size;
+    //
+    // The whole header is encrypted (EncryptSend over getHeaderLength()), so consuming
+    // 4 bytes of a 5-byte header both mis-frames the packet and leaves the RC4 keystream
+    // one byte out of step — the stream never resynchronises. Issue #200: a guild roster
+    // large enough to cross 0x7FFF desynced the legacy socket, after which every opcode
+    // decoded as garbage and the server dropped the connection 60s later.
+    //
+    // Vanilla and TBC cores have no such branch and always emit the 4-byte form.
     public const int StructSize = sizeof(ushort) + sizeof(ushort);
-    public ushort Size;
+    public const int LargeStructSize = StructSize + 1;
+
+    public uint Size;
     public ushort Opcode;
-    public void Read(byte[] buffer)
+
+    public static bool IsLargePacket(byte firstSizeByte) => (firstSizeByte & 0x80) != 0;
+
+    public void Read(byte[] buffer) => Read(buffer, large: false);
+
+    public void Read(byte[] buffer, bool large)
     {
-        Size = BinaryPrimitives.ReadUInt16BigEndian(buffer);
-        Opcode = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(sizeof(ushort)));
+        if (large)
+        {
+            Size = (uint)(((buffer[0] & 0x7F) << 16) | (buffer[1] << 8) | buffer[2]);
+            Opcode = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(3));
+        }
+        else
+        {
+            Size = BinaryPrimitives.ReadUInt16BigEndian(buffer);
+            Opcode = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(sizeof(ushort)));
+        }
     }
+
     public void Write(ByteBuffer byteBuffer)
     {
-        byteBuffer.WriteUInt16(Size);
+        if (Size > 0x7FFF)
+        {
+            byteBuffer.WriteUInt8((byte)(0x80 | ((Size >> 16) & 0xFF)));
+            byteBuffer.WriteUInt8((byte)((Size >> 8) & 0xFF));
+            byteBuffer.WriteUInt8((byte)(Size & 0xFF));
+        }
+        else
+        {
+            // Big-endian, to mirror Read.
+            byteBuffer.WriteUInt8((byte)((Size >> 8) & 0xFF));
+            byteBuffer.WriteUInt8((byte)(Size & 0xFF));
+        }
         byteBuffer.WriteUInt16(Opcode);
     }
 };


### PR DESCRIPTION
Fixes #200.

## Symptom

One character on an account hangs at 95% loading forever; the others on the same account are fine. The proxy stays up, and the legacy server drops the connection exactly 60 seconds later.

## Root cause

Not a guild, MOTD, or locale problem — the legacy **server header framing**.

WotLK cores size the server-to-client header by the packet. Normally it is 2 bytes of big-endian size + 2 bytes of opcode, but once the size (which counts the opcode) passes `0x7FFF`, the size field grows to 3 bytes and the first one is marked with `0x80`. From AzerothCore's `ServerPktHeader.h`:

```cpp
bool isLargePacket() const { return size > 0x7FFF; }

if (isLargePacket())
    header[headerIndex++] = 0x80 | (0xFF & (size >> 16));
header[headerIndex++] = 0xFF & (size >> 8);
header[headerIndex++] = 0xFF & size;
header[headerIndex++] = 0xFF & cmd;
header[headerIndex++] = 0xFF & (cmd >> 8);
```

and the whole thing is encrypted — `_authCrypt.EncryptSend(header.header, header.getHeaderLength())`.

`LegacyServerPacketHeader` was fixed at 4 bytes. So the first packet to cross the threshold left one header byte unread. That does two things at once:

1. the packet is mis-framed, and
2. the RC4 **receive keystream falls one byte behind the server's** and never catches up.

The result is permanent, not per-packet. Every opcode after that point is decoded out of payload bytes, so nothing is handled, the proxy never answers properly, and the server times the session out.

TrinityCore 3.3.5a and mangos-wotlk carry the identical scheme. Vanilla and TBC do not — they always emit the 4-byte form.

## Why it took this long to surface

The packet that trips it is `SMSG_ALL_ACHIEVEMENT_DATA`, sent during world entry right after `SMSG_INITIALIZE_FACTIONS`:

```cpp
m_reputationMgr->SendInitialReputations();   // SMSG_INITIALIZE_FACTIONS
m_achievementMgr->SendAllAchievementData();  // SMSG_ALL_ACHIEVEMENT_DATA
```

AzerothCore sizes it as `completed * 8 + criteria * 38`. Each criteria-progress row costs roughly 25–38 bytes on the wire, so **about 1300 rows clears `0x7FFF`**. A long-played level 80 has thousands of them; a freshly created test character has a few dozen.

Every character used in this project's playtests is newly made, so the packet never got big enough to widen the header. That also explains the reporter's own log — `[CharEnum] legacy count=3`, and only the developed character froze.

Nothing about it is specific to Chinese servers or to guilds, which is where the investigation started.

## The signature in a log

Legacy 3.3.5a opcodes top out around 1311. Once the stream desyncs it starts producing values far outside that range:

```
SMSG_INITIALIZE_FACTIONS (290)      <- last correctly framed packet
MSG_NULL_ACTION (32038)
MSG_NULL_ACTION (9125)
MSG_NULL_ACTION (64106)
Socket Closed By GameWorldServer    <- 60s later
```

`32038` is diagnostic rather than random. Reading the wide header of a 59942-byte packet with the narrow layout gives size `0x80EA` and opcode `0x7D26` = 32038. The reporter's log shows the same shape with 35569 / 33123 / 15268 / 15620.

## The fix

Four parts, all required:

| # | Change |
|---|---|
| 1 | `LegacyServerPacketHeader` learns the wide form — `LargeStructSize`, `IsLargePacket`, `Read(buffer, large)` — and `Size` widens `ushort` -> `uint` |
| 2 | `ReceiveLoop` reads the standard header, tests the `0x80` marker, then pulls and decrypts the extra byte |
| 3 | `WotlkWorldCrypt.Decrypt` is pinned to the standard header width and ignores anything shorter, so a 1-byte call was a silent no-op. `DecryptLargeHeaderByte` advances the keystream properly; the interface default is a no-op for the pre-WotLK crypts |
| 4 | The opcode copied into the payload buffer moves from bytes 2-3 to 3-4 in the wide form |

Part 2 is gated on `LegacyVersion.ExpansionVersion >= 3`, so vanilla and TBC framing is untouched and a stray high bit in their size field is never reinterpreted as a marker.

Parts 3 and 4 are each independently sufficient to keep the bug alive, and both were caught in playtest rather than by the build — with 3 missing the stream still desyncs; with 4 missing the framing recovers but the packet is dropped as an unknown opcode and the achievements pane stays empty.

Also included: a malformed size below 2 bytes now closes the connection with a diagnostic instead of reading a negative length, and a wide header is traced at debug level.

## Verification

Reproduced and fixed on AzerothCore (`ac-worldserver`, playerbots stack), by loading a level 80 with 2440 criteria-progress rows to give a 59942-byte `SMSG_ALL_ACHIEVEMENT_DATA`:

```sql
INSERT IGNORE INTO acore_characters.character_achievement_progress (guid, criteria, counter, date)
  SELECT <guid>, criteria_id, 1, UNIX_TIMESTAMP()-86400
  FROM (SELECT DISTINCT criteria_id FROM acore_world.achievement_criteria_data) t;
```

**Before** — frozen at 95%, garbage opcodes 32038 / 9125 / 64106, connection dropped after 60s.

**After:**

```
Large legacy packet: 5-byte header, size=59942 opcode=1149
Received opcode "SMSG_ALL_ACHIEVEMENT_DATA" (1149).
Sending  opcode "SMSG_ALL_ACHIEVEMENT_DATA" (9584).
Received opcode "SMSG_LOAD_EQUIPMENT_SET" (1212).
Received opcode "SMSG_LOGIN_SET_TIME_SPEED" (66).
```

World entry completes, the achievements pane populates, and the only remaining unhandled opcodes are the three pre-existing benign ones (`SMSG_CACHE_VERSION`, `SMSG_LEARNED_DANCE_MOVES`, `SMSG_INSTANCE_DIFFICULTY`).

980 tests pass, including 8 new ones in `LegacyServerPacketHeaderTests` covering the narrow/wide round trip, the `0x7FFF` boundary, the exact 32038 mis-parse, and keystream alignment across the split decrypt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWBzvvDaCR9sWCVisaPpGK
