### PR TITLE
fix(v3_4_3): write ProposedRoles as a byte in SMSG_PARTY_INVITE

### DIFF
--- a/HermesProxy/World/Server/Packets/GroupPackets.cs
+++ b/HermesProxy/World/Server/Packets/GroupPackets.cs
@@ -136,7 +136,18 @@ class PartyInvite : ServerPacket
         _worldPacket.WritePackedGuid128(InviterGUID);
         _worldPacket.WritePackedGuid128(InviterBNetAccountId);
         _worldPacket.WriteUInt16(Unk1);
-        _worldPacket.WriteUInt32(ProposedRoles);
+
+        // WotLK Classic narrowed ProposedRoles to a single byte. V1_14 and V2_5 still read the
+        // full uint32 -- WowPacketParser reads it as a byte in its V3_4_0/V4_4_0 modules and as
+        // an int32 in every earlier one, and CypherCore ClassicWOTLK writes a byte. Sending four
+        // bytes to a 3.4.3 client shifts everything after it, and since InviterName is declared
+        // by the 6-bit length prefix above but written last, the client reads the name from the
+        // wrong offset and renders it empty. Issue #199.
+        if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+            _worldPacket.WriteUInt8((byte)ProposedRoles);
+        else
+            _worldPacket.WriteUInt32(ProposedRoles);
+
         _worldPacket.WriteInt32(LfgSlots.Count);
         _worldPacket.WriteInt32(LfgCompletedMask);
 


### PR DESCRIPTION
Fixes #199.

## Symptom

On a V3_4_3 client a party invite renders with no inviter:

```
[] has invited you to join a group
```

## Cause

WotLK Classic narrowed `ProposedRoles` in `SMSG_PARTY_INVITE` to a single byte. HermesProxy wrote a `uint32`, so the three surplus bytes shifted every field after them. `InviterName` is declared by the 6-bit length prefix near the top of the packet but written **last**, so the client read it from the wrong offset and got nothing.

## Version gating

The issue originally proposed narrowing `PartyInvite.ProposedRoles` to `byte`. That would have been wrong — V1_14 and V2_5 really do use the full `uint32`:

| WowPacketParser module | `SMSG_PARTY_INVITE` `ProposedRoles` |
|---|---|
| V6_0_2 / V7_0_3 (inherited by the 1.13 and 2.5 modules) | `ReadInt32` — 4 bytes |
| V3_4_0_45166 | `ReadByte` — 1 byte |
| V4_4_0_54481 | `ReadByte` — 1 byte |

The width narrowed at WotLK Classic, so the write is gated on `V3_4_3_54261` and the field stays `uint`.

`ProposedRoles` carries the LFG role bitmask (leader/tank/healer/damage), so the value never exceeds a byte and the cast cannot lose information.

The inbound path is untouched — `GroupHandler` reads `ProposedRoles` as a `uint32` from the legacy 3.3.5a `SMSG_GROUP_INVITE`, which is correct for that wire format. Only the modern write width was wrong.

## Verification

Two clients on TrinityCore 3.3.5a:

- invite now shows the inviter's name
- accepting forms the group: `CMSG_PARTY_INVITE_RESPONSE` -> `CMSG_GROUP_ACCEPT` -> `SMSG_GROUP_LIST` -> `SMSG_PARTY_UPDATE`, no errors

980 tests pass.

## Cross-checked against a native 3.4.3 capture

Confirmed independently against a Wrathion sniff (`World_5_man_party_join_dungeon_finder`, detected build V3_4_3_54261), re-parsed with upstream TrinityCore/WowPacketParser at master (ea494ff6c):

```
QuestSessionActive: False
InviterCfgRealmID: 0
ProposedRoles: 0 (None)
LfgCompletedMask: 0
InviterName: Sbeve
```

The byte accounting closes exactly on the packet's stated 52-byte length with `ProposedRoles` as a single byte:

| field | bytes |
|---|---|
| 6 flag bits + 6-bit name length (+ IsCrossFaction) | 2 |
| InviterVirtualRealmAddress | 4 |
| IsLocal + IsInternalRealm + two 8-bit string lengths | 3 |
| RealmNameActual + RealmNameNormalized ("Lineagedr") | 18 |
| InviterGuid, packed | 5 |
| InviterBNetAccountID, packed | 4 |
| InviterCfgRealmID | 2 |
| **ProposedRoles** | **1** |
| LfgSlots count | 4 |
| LfgCompletedMask | 4 |
| InviterName ("Sbeve") | 5 |
| **total** | **52** |

So the width this PR writes matches what a native 3.4.3 server actually sends, and `LfgCompletedMask` sits where the current writer already puts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWBzvvDaCR9sWCVisaPpGK
