### PR TITLE
fix(v3_4_3): stop wiping quest objective counters at login and on turn-in

### DIFF
--- a/HermesProxy.Tests/World/Server/QuestLogProgressCacheTests.cs
+++ b/HermesProxy.Tests/World/Server/QuestLogProgressCacheTests.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HermesProxy;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+/// <summary>
+/// QuestLogProgress is one flat short[] sliced per log slot. A wrong stride would let one
+/// quest's counters land on another quest's row, which the client renders as the neighbour
+/// silently resetting to 0.
+/// </summary>
+public class QuestLogProgressCacheTests
+{
+    static GameSessionData CreateState()
+    {
+        var state = (GameSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GameSessionData));
+        // GetUninitializedObject skips field initializers, so seed the backing array.
+        typeof(GameSessionData)
+            .GetField(nameof(GameSessionData.QuestLogProgress), BindingFlags.Public | BindingFlags.Instance)!
+            .SetValue(state, new short[QuestConst.MaxQuestLogSize * QuestConst.MaxQuestCounts]);
+        return state;
+    }
+
+    static QuestLog LogWith(params ReadOnlySpan<(int Index, int Count)> counters)
+    {
+        var log = new QuestLog();
+        foreach (var (index, count) in counters)
+            log.ObjectiveProgress[index] = (short)count;
+        return log;
+    }
+
+    [Fact]
+    public void RestoreQuestLogProgress_ReadsBackOnlyItsOwnSlot()
+    {
+        var state = CreateState();
+        state.RememberQuestLogProgress(0, LogWith((0, 3)));
+        state.RememberQuestLogProgress(1, LogWith((0, 7), (1, 1)));
+        state.RememberQuestLogProgress(QuestConst.MaxQuestLogSize - 1, LogWith((0, 5)));
+
+        var slot0 = new QuestLog();
+        var slot1 = new QuestLog();
+        var last = new QuestLog();
+        state.RestoreQuestLogProgress(0, slot0);
+        state.RestoreQuestLogProgress(1, slot1);
+        state.RestoreQuestLogProgress(QuestConst.MaxQuestLogSize - 1, last);
+
+        Assert.Equal((short)3, slot0.ObjectiveProgress[0]);
+        Assert.Equal((short)0, slot0.ObjectiveProgress[1]);
+        Assert.Equal((short)7, slot1.ObjectiveProgress[0]);
+        Assert.Equal((short)1, slot1.ObjectiveProgress[1]);
+        Assert.Equal((short)5, last.ObjectiveProgress[0]);
+    }
+
+    [Fact]
+    public void RestoreQuestLogProgress_DoesNotOverwriteValuesPresentInTheUpdate()
+    {
+        var state = CreateState();
+        state.RememberQuestLogProgress(2, LogWith((0, 7), (1, 1)));
+
+        // Inbound update carried a fresh count for objective 0 but nothing for objective 1.
+        var inbound = LogWith((0, 9));
+        state.RestoreQuestLogProgress(2, inbound);
+
+        Assert.Equal((short)9, inbound.ObjectiveProgress[0]);
+        Assert.Equal((short)1, inbound.ObjectiveProgress[1]);
+    }
+
+    [Fact]
+    public void ClearQuestLogProgress_LeavesNeighbouringSlotsIntact()
+    {
+        var state = CreateState();
+        state.RememberQuestLogProgress(0, LogWith((0, 3)));
+        state.RememberQuestLogProgress(1, LogWith((0, 7)));
+        state.RememberQuestLogProgress(2, LogWith((0, 5)));
+
+        state.ClearQuestLogProgress(1);
+
+        var slot0 = new QuestLog();
+        var slot1 = new QuestLog();
+        var slot2 = new QuestLog();
+        state.RestoreQuestLogProgress(0, slot0);
+        state.RestoreQuestLogProgress(1, slot1);
+        state.RestoreQuestLogProgress(2, slot2);
+
+        Assert.Equal((short)3, slot0.ObjectiveProgress[0]);
+        Assert.Equal((short)0, slot1.ObjectiveProgress[0]);
+        Assert.Equal((short)5, slot2.ObjectiveProgress[0]);
+    }
+
+    [Fact]
+    public void RememberQuestLogProgress_WritesEveryCounterOfTheLastSlotInsideItsOwnRow()
+    {
+        var state = CreateState();
+        int lastSlot = QuestConst.MaxQuestLogSize - 1;
+        var full = new QuestLog();
+        for (int i = 0; i < QuestConst.MaxQuestCounts; i++)
+            full.ObjectiveProgress[i] = (short)(i + 1);
+
+        state.RememberQuestLogProgress(lastSlot, full);
+
+        var readBack = new QuestLog();
+        state.RestoreQuestLogProgress(lastSlot, readBack);
+        for (int i = 0; i < QuestConst.MaxQuestCounts; i++)
+            Assert.Equal((short)(i + 1), readBack.ObjectiveProgress[i]);
+
+        // The row before it must not have been touched by the write.
+        var previous = new QuestLog();
+        state.RestoreQuestLogProgress(lastSlot - 1, previous);
+        for (int i = 0; i < QuestConst.MaxQuestCounts; i++)
+            Assert.Equal((short)0, previous.ObjectiveProgress[i]);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(QuestConst.MaxQuestLogSize)]
+    [InlineData(int.MaxValue)]
+    public void OutOfRangeSlots_AreIgnoredRatherThanThrowing(int slot)
+    {
+        var state = CreateState();
+        var log = LogWith((0, 4));
+
+        state.RememberQuestLogProgress(slot, log);
+        state.ClearQuestLogProgress(slot);
+        state.RestoreQuestLogProgress(slot, log);
+
+        Assert.Equal((short)4, log.ObjectiveProgress[0]);
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -214,16 +214,26 @@ public sealed class GameSessionData
         }
     }
 
-    public void RestoreQuestLogProgress(int slot, QuestLog log)
+    /// <summary>
+    /// Fills counters the inbound update did not carry. A null counter means "not in this
+    /// update", so the cached value stands; a counter the server really cleared arrives as 0,
+    /// not null. Returns how many non-zero counters were recovered.
+    /// </summary>
+    public int RestoreQuestLogProgress(int slot, QuestLog log)
     {
         if ((uint)slot >= (uint)QuestConst.MaxQuestLogSize)
-            return;
+            return 0;
         Span<short> src = QuestLogProgressSlot(slot);
+        int recovered = 0;
         for (int i = 0; i < src.Length; i++)
         {
-            if (!log.ObjectiveProgress[i].HasValue)
-                log.ObjectiveProgress[i] = src[i];
+            if (log.ObjectiveProgress[i].HasValue)
+                continue;
+            log.ObjectiveProgress[i] = src[i];
+            if (src[i] != 0)
+                recovered++;
         }
+        return recovered;
     }
 
     public void RememberObjectiveCount(uint questId, QuestObjectiveType type, int objectId, short count)

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -4,6 +4,7 @@ using Framework.GameMath;
 using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Logging;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server;
 using HermesProxy.World.Server.Packets;
@@ -1759,12 +1760,21 @@ public partial class WorldClient
             questLog.QuestID = updates[index].Int32Value;
             // Cache the QuestID for this slot so partial state-only updates can
             // recover it. Mirrors the fork's behavior at WorldClient.cs:10857.
+            //
+            // A partial update can carry this field as 0 for a slot that still holds a
+            // quest — seen one second before a turn-in flips StateFlags. Treat 0 as "no
+            // information": overwriting the slot id with it, or reading it as "a different
+            // quest moved in", drops the cached counters the very next update needs and
+            // the client is told every objective is 0.
             int previousId = GetSession().GameState.QuestLogQuestIDs[i];
-            GetSession().GameState.QuestLogQuestIDs[i] = questLog.QuestID.Value;
-            if (previousId != questLog.QuestID.Value)
+            if (questLog.QuestID.Value != 0)
             {
-                GetSession().GameState.ForgetQuestState((uint)previousId);
-                GetSession().GameState.ClearQuestLogProgress(i);
+                GetSession().GameState.QuestLogQuestIDs[i] = questLog.QuestID.Value;
+                if (previousId != questLog.QuestID.Value)
+                {
+                    GetSession().GameState.ForgetQuestState((uint)previousId);
+                    GetSession().GameState.ClearQuestLogProgress(i);
+                }
             }
         }
         if ((updateMaskArray != null && updateMaskArray[index + stateOffset]) ||
@@ -1859,11 +1869,22 @@ public partial class WorldClient
         if (questLog?.QuestID != null && questLog.QuestID.Value != 0)
         {
             var state = GetSession().GameState;
-            bool sawProgress =
-                (progressOffset != -1 && updates.ContainsKey(index + progressOffset)) ||
-                (progressOffsetHi != -1 && updates.ContainsKey(index + progressOffsetHi));
-            if (!sawProgress)
-                state.RestoreQuestLogProgress(i, questLog);
+            // Unconditional: the restore only fills counters this update left null, i.e. ones
+            // the server did not send. Gating it on "did the update carry the progress field"
+            // was wrong twice over — the presence test did not match the decode's own guard
+            // (which honours updateMaskArray), so at login and at the turn-in flip it reported
+            // progress present while nothing had been decoded, and every counter went out as 0.
+            // V3_4_3 only: its writer emits all 24 counters with `?? 0`, so a counter this
+            // update did not carry would go out as 0. V1_14 / V2_5 write the quest log
+            // sparsely (SetUpdateField per index), where a null is skipped and the client
+            // keeps its own value — restoring there would write over it for no reason.
+            if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+            {
+                int recovered = state.RestoreQuestLogProgress(i, questLog);
+                if (recovered > 0)
+                    WorldClientLogMessages.QuestProgressRestored(
+                        _melLog, _sourceFile, _netDirRecv, (uint)questLog.QuestID.Value, i);
+            }
 
             QuestTemplate? template = GameData.GetQuestTemplate((uint)questLog.QuestID.Value);
             if (template != null)

--- a/HermesProxy/World/Logging/WorldClientLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldClientLogMessages.cs
@@ -183,4 +183,15 @@ internal static partial class WorldClientLogMessages
         bool ItemsMet,
         int Collect,
         bool Auto);
+
+    [LoggerMessage(
+        EventId = 216,
+        Level = LogLevel.Debug,
+        Message = "QuestLog progress restored from cache: quest={QuestId} slot={Slot}")]
+    public static partial void QuestProgressRestored(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        uint QuestId,
+        int Slot);
 }


### PR DESCRIPTION
Closes #204.

## Summary

Completing a mixed kill+item quest reset the kill counter in the client's tracker. Quest 2459 (Ferocitas the Dream Eater — 7× Gnarlpine Mystic, plus the Missing Jewel) reproduced it every time: kill all seven, acquire the jewel, and the tracker flipped to `0/7` while the item objective line disappeared. The same wipe hit the login snapshot, so a character logged in mid-quest saw its counters reset until the next kill.

`ReadQuestLogEntry` decided twice whether the inbound update carried objective progress, using two tests that disagreed. The decode honours `updateMaskArray` when one is present; the guard in front of the cache fallback checked only `updates`:

```csharp
bool sawProgress =
    (progressOffset != -1 && updates.ContainsKey(index + progressOffset)) ||
    (progressOffsetHi != -1 && updates.ContainsKey(index + progressOffsetHi));
if (!sawProgress)
    state.RestoreQuestLogProgress(i, questLog);
```

When a field key is present in `updates` with its mask bit clear, the guard reported progress present while the decode never ran. Every counter stayed `null`, and the V3_4_3 writer turns each `null` into `0` (`ObjectUpdateBuilder.cs:878`, `?? 0`). Instrumented at the moment of failure:

```
QuestLog decode: quest=2459 slot=1 sawProgress=true c0=-1 c1=-1 c2=-1 c3=-1 stage=wire
QuestLog decode: quest=2459 slot=1 sawProgress=true c0=-1 c1=-1 c2=1  c3=-1 stage=final
```

(`-1` = null.) Only the item objective got set, by the bag-count block below it. The resulting packet carried the kill counter as `0`:

```
[0] (QuestLog) [1] QuestID: 2459
[0] (QuestLog) [1] StateFlags: 1
[0] (QuestLog) [1] [1] ObjectiveProgress: 0     <- was 7
[0] (QuestLog) [1] [2] ObjectiveProgress: 1
```

Ordinary kill updates were never affected — those arrive with the mask bit set, decode correctly, and climb 1→7. That is why this only bit at login and at the completion flip.

## Fix

Drop the guard and call the restore unconditionally. `RestoreQuestLogProgress` only fills counters the update left `null`, which is precisely "the server did not send this one"; a counter the server genuinely cleared arrives as `0`, not `null`, so it is never overwritten. This also removes a third copy of a presence test that had already drifted out of sync with the decode once.

**Gated to `V3_4_3_54261`.** Its writer emits all 24 counters unconditionally, which is the entire reason the cache exists. V1_14 / V2_5 write the quest log sparsely (`SetUpdateField` per index, `null` skipped — `V1_14_0_40237/ObjectUpdateBuilder.cs:1138`), so the client keeps its own value there and a restore would write over it for nothing.

`RestoreQuestLogProgress` now returns how many **non-zero** counters it recovered, so the log line fires only when the cache actually saved something instead of on every quest-log entry.

## Test plan

- [x] TrinityCore 3.3.5a + V3_4_3_54261: `.quest add 2459` → kill 7× Gnarlpine Mystic → acquire item 8050. Kill counter holds at 7/7, item objective stays visible, and `QuestLog progress restored from cache: quest=2459 slot=1` fires at the flip — the first non-zero recovery observed across the whole investigation.
- [x] Same build, login snapshot with the quest already held: counters no longer reset.
- [x] cMaNGOS vanilla + V1_14 client, same quest and sequence: 7/7 survives the item flip, **0** restores (gate holding), 0 errors.
- [x] Zero exceptions and zero `OBJECT_UPDATE_FAILED` across every session.
- [x] 993/993 tests pass (986 + 7 new).

## Tests added

`QuestLogProgressCacheTests` covers the flat cache's slot isolation, which is what a wrong stride would break:

- per-slot read-back, including the last slot
- no cross-slot bleed when one slot is cleared
- the last slot's 24 counters written inside its own row, leaving the previous row untouched
- restore not clobbering values the update did carry
- out-of-range slots ignored rather than throwing

## Ruled out along the way

Recorded so they don't get re-investigated:

- **Stale client quest cache.** `questcache.wdb` is shared across configs in one WoW install, so a native run does prime it — but the client re-queries (`CMSG_QUERY_QUEST_INFO`) and the bug reproduced with a freshly-queried template.
- **`QuestID = 0` clearing the cache.** A transient `questId=0` in a partial update did reach `ClearQuestLogProgress(i)` through the `previousId != QuestID` test. A real defect, guarded in this PR, but not this bug — fixing it alone changed nothing.

## Separate issue, not addressed here

The `StorageIndex` values we advertise diverge from a real 3.4.3 server. Captured from Wrathion (native V3_4_3) for quest 2459:

| objective | native 3.4.3 | HermesProxy |
|---|---|---|
| Gnarlpine Mystic (7235) ×7 | 0 | 1 |
| Missing Jewel (8050) ×1 | 1 | 2 |

Native compacts objective indices and the kill counter climbs at `ObjectiveProgress[0]`. `QueryHandler.cs:207` uses the raw legacy `ReqCreatureOrGOIdN` column instead (changed in 78773779 to close #71 — same quest, same 0/7 symptom), and item objectives then continue from `objectiveCounter`. Advertised and written indices agree internally so nothing is visibly broken, but it leaves us distinguishable from a real server on the wire.
