### PR TITLE
fix(v3_4_3): sail the Strand of the Ancients gunships instead of jumping

### DIFF
--- a/HermesProxy.Tests/World/ObjectUpdateTests.cs
+++ b/HermesProxy.Tests/World/ObjectUpdateTests.cs
@@ -103,6 +103,33 @@ public class ObjectUpdateConstructorTests
     }
 
     [Fact]
+    public void InitializePlaceholders_ValuesUpdateWithoutFlags_DoesNotFabricateFlags()
+    {
+        var session = CreateGlobalSession();
+        var gameState = (GameSessionData)RuntimeHelpers.GetUninitializedObject(typeof(GameSessionData));
+        gameState.WmoMapObjectGuids = [];
+        session.GameState = gameState;
+
+        var guid = WowGuid128.Create(HighGuidType703.GameObject, 0, 193182, 13);
+
+        var create = new ObjectUpdate(guid, UpdateTypeModern.CreateObject1, session);
+        create.GameObjectData.TypeID = (sbyte)GameObjectTypeModern.MOTransport;
+        create.GameObjectData.Flags = 0x8;
+        create.InitializePlaceholders();
+        Assert.Equal(0x100008u, create.GameObjectData.Flags!.Value);
+
+        // A Values delta that does not carry GAMEOBJECT_FLAGS must not publish one. Publishing
+        // MAP_OBJECT alone would clear every other bit on the client -- GO_FLAG_TRANSPORT (0x8)
+        // among them, which is what lets a player attach to the deck. TrinityCore sends
+        // exactly such a delta (ParentRotation + DynamicFlags) right after a boat's create.
+        var values = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+        values.ObjectData.DynamicFlags = 0;
+        values.InitializePlaceholders();
+
+        Assert.Null(values.GameObjectData.Flags);
+    }
+
+    [Fact]
     public void InitializePlaceholders_ValuesUpdateForUnknownGameObject_LeavesFlagsAlone()
     {
         var session = CreateGlobalSession();

--- a/HermesProxy.Tests/World/SynthesizedTransportTests.cs
+++ b/HermesProxy.Tests/World/SynthesizedTransportTests.cs
@@ -1,0 +1,46 @@
+using HermesProxy.World.Objects;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+public class SynthesizedTransportTests
+{
+    private static SynthesizedTransport WithDeadline(uint deadline) =>
+        new(60133, default, 0f, deadline, 25);
+
+    [Fact]
+    public void IsSailing_NoDeadlineScheduled_False()
+    {
+        var transport = new SynthesizedTransport(60133, default, 0f);
+
+        Assert.False(transport.IsSailing(now: 1000));
+    }
+
+    [Fact]
+    public void IsSailing_DeadlineAhead_True()
+    {
+        Assert.True(WithDeadline(154524).IsSailing(now: 94391));
+    }
+
+    [Fact]
+    public void IsSailing_DeadlineReached_False()
+    {
+        Assert.False(WithDeadline(154524).IsSailing(now: 154524));
+        Assert.False(WithDeadline(154524).IsSailing(now: 154525));
+    }
+
+    [Fact]
+    public void IsSailing_DeadlineAheadAcrossClockWrap_True()
+    {
+        // The proxy clock is ms since start and wraps after 49 days. A deadline stamped
+        // just past the wrap must still read as ahead of a clock just before it.
+        Assert.True(WithDeadline(100).IsSailing(now: uint.MaxValue - 50));
+    }
+
+    [Fact]
+    public void IsSailing_DeadlineJustPassedAcrossClockWrap_False()
+    {
+        // ...and the mirror image must not read as 49 days ahead.
+        Assert.False(WithDeadline(uint.MaxValue - 50).IsSailing(now: 100));
+    }
+}

--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -433,6 +433,19 @@ public sealed class GameSessionData
     // delta alone. Only transports and destructible buildings ever land here.
     public HashSet<WowGuid128> WmoMapObjectGuids = [];
 
+    // Type 11 GAMEOBJECT_TYPE_TRANSPORT objects whose parking and sailing the proxy drives
+    // itself, because the backend never relocates them (TrinityCore 3.3.5a leaves
+    // GameObjectRelocation commented out). Captured from the create: a later state flip
+    // arrives as a Values update carrying only GAMEOBJECT_BYTES_1, so the stop frame it has
+    // to sail to is no longer on the wire, and a rider's deck-relative offset can only be
+    // derived from where the deck actually is. Keyed by the modern guid; a struct value so
+    // registering a boat does not allocate.
+    public Dictionary<WowGuid128, SynthesizedTransport> SynthesizedTransports = [];
+
+    // The transport guid the client last reported in its own movement, so boarding and
+    // leaving can be logged as transitions rather than on every packet.
+    public WowGuid128 LastReportedTransportGuid;
+
     // gameobject_template.data[18] (destructibleData -> DestructibleModelData.db2 id) keyed by
     // GameObject entry, harvested from SMSG_QUERY_GAME_OBJECT_RESPONSE as it passes through.
     // A V3_4_3 client resolves a type-33 object's model through this id and will draw nothing

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -988,6 +988,22 @@ public partial class WorldClient
             // See: https://github.com/vmangos/core/commit/14b2598d8d9f0910cb1a492b81502296d272dad3
             if (guid == GetSession().GameState.CurrentPlayerGuid)
                 continue;
+            // A transport the proxy is sailing must not be range-destroyed under its rider.
+            // Native never sends OUT_OF_RANGE for a transport, and TrinityCore's own
+            // GameObject::IsTransport() comment says the same -- yet on a 3.3.5a core the
+            // boat's server-side position stays at spawn while the client carries the
+            // player away from it, and once past the visibility distance the core did drop
+            // it mid-crossing: the client removed the boat and the player fell into the sea
+            // (observed once in twelve crossings). Keep it; a later create is a no-op for a
+            // guid the client holds, and an explicit SMSG_DESTROY_OBJECT -- the round-2
+            // respawn -- still goes through HandleDestroyObject untouched.
+            if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261
+                && GetSession().GameState.SynthesizedTransports.ContainsKey(guid))
+            {
+                if (_melGoFields.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
+                    TransportLogMessages.OutOfRangeSuppressed(_melGoFields, guid.Low, guid.GetEntry());
+                continue;
+            }
             PrintString($"Guid = {objCount}", index, j);
             lock (GetSession().GameState.ObjectCacheLock)
             {
@@ -4049,6 +4065,47 @@ public partial class WorldClient
                     return (sbyte)((updates[bytes1Field].UInt32Value >> 8) & 0xFF);
 
                 return null;
+            }
+
+            // A transport's ParentRotation can arrive one packet after its create, and the
+            // client keeps whatever the first create said through every re-create. TrinityCore's
+            // Strand of the Ancients ResetObjs adds a boat to the map -- which broadcasts its
+            // create to anyone already in range -- and only then calls
+            // SetParentRotation(0, 0, 1, ~0) on it (BattlegroundSA.cpp), so that first create
+            // carries GameObject::Create's default and the correction follows as a Values with
+            // PARENTROTATION z and w. ParentRotation is what the client rotates the transport's
+            // path by: left stale, the boat carries its riders off in the wrong direction
+            // (reproduced by forcing the stale value on a good boat -- it sailed north instead
+            // of south). Unmasked components come from the field cache the read above just
+            // refreshed. Tracked transports only; for a destructible building this slot is a
+            // model id, not a rotation.
+            if (GAMEOBJECT_ROTATION >= 0 && updateData.CreateData == null
+                && ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+            {
+                // Mask bits first: almost no Values touches rotation, and the registry
+                // lookup behind them is the only cost worth avoiding on the common path.
+                bool rotationChanged = false;
+                for (int i = 0; i < 4; i++)
+                    rotationChanged |= updateMaskArray[GAMEOBJECT_ROTATION + i];
+                if (rotationChanged && GetSession().GameState.SynthesizedTransports.ContainsKey(guid))
+                {
+                    var cached = GetSession().GameState.GetCachedObjectFieldsLegacy(guid);
+                    var parentRotation = updateData.GameObjectData.ParentRotation;
+                    for (int i = 0; i < 4; i++)
+                    {
+                        int index = GAMEOBJECT_ROTATION + i;
+                        if (updateMaskArray[index])
+                            parentRotation[i] = updates[index].FloatValue;
+                        else if (cached != null && cached.TryGetValue(index, out var field))
+                            parentRotation[i] = field.FloatValue;
+                        else
+                            parentRotation[i] = i == 3 ? 1f : 0f;
+                    }
+                    if (_melGoFields.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
+                        TransportLogMessages.ParentRotationForwarded(_melGoFields, guid.Low, guid.GetEntry(),
+                            parentRotation[0]!.Value, parentRotation[1]!.Value,
+                            parentRotation[2]!.Value, parentRotation[3]!.Value);
+                }
             }
 
             if (GAMEOBJECT_ROTATION >= 0 && updateData.CreateData != null && updateData.CreateData.MoveInfo != null)

--- a/HermesProxy/World/Logging/TransportLogMessages.cs
+++ b/HermesProxy/World/Logging/TransportLogMessages.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Logging;
+
+namespace HermesProxy.World.Logging;
+
+/// <summary>
+/// Source-generated logging for the transports the proxy sails itself -- the Strand of the
+/// Ancients gunships on a backend that never relocates them -- and for the client's own
+/// account of boarding and leaving one.
+///
+/// The rider message is the diagnostic that decided how much of issue #197 had to be built:
+/// a 3.3.5a client attaches itself to a transport WMO it lands on and reports the transport
+/// guid in its own movement packets, and the V3_4_3 client turned out to do the same, so the
+/// passenger link needs no synthesis. It fires on attach and detach only, not on every
+/// movement packet, and logs the standing-on guid next to the transport guid because the two
+/// answer different questions: standing-on without transport means the client sees the
+/// object under the player but is not treating it as a transport.
+///
+/// Guids are logged as their raw low half, matching the other files in this directory; the
+/// record struct's generated ToString allocates. All Trace level. EventId 1110-1119 is
+/// reserved for this file.
+/// </summary>
+internal static partial class TransportLogMessages
+{
+    [LoggerMessage(
+        EventId = 1110,
+        Level = LogLevel.Trace,
+        Message = "[TransportSail] guidLow={GuidLow} entry={Entry} state={State} stopFrame={StopFrame} " +
+                  "now={Now} level={Level}")]
+    public static partial void SailScheduled(
+        ILogger logger, ulong guidLow, uint entry, int state, uint stopFrame, uint now, int level);
+
+    [LoggerMessage(
+        EventId = 1111,
+        Level = LogLevel.Trace,
+        Message = "[TransportSail] guidLow={GuidLow} entry={Entry} state={State} parked: no stop frame known, " +
+                  "level left expired")]
+    public static partial void SailUnknownStopFrame(ILogger logger, ulong guidLow, uint entry, int state);
+
+    [LoggerMessage(
+        EventId = 1112,
+        Level = LogLevel.Trace,
+        Message = "[TransportRider] {Opcode} transport {PreviousLow}/{PreviousHigh} -> {TransportLow}/{TransportHigh} " +
+                  "standingOnLow={StandingOnLow} offset=({X},{Y},{Z}) o={O} seat={Seat} world=({WorldX},{WorldY},{WorldZ})")]
+    public static partial void ClientTransportChanged(
+        ILogger logger, string opcode,
+        ulong previousLow, ulong previousHigh, ulong transportLow, ulong transportHigh, ulong standingOnLow,
+        float x, float y, float z, float o, sbyte seat,
+        float worldX, float worldY, float worldZ);
+
+    [LoggerMessage(
+        EventId = 1114,
+        Level = LogLevel.Trace,
+        Message = "[TransportSail] guidLow={GuidLow} entry={Entry} OUT_OF_RANGE from the backend suppressed; " +
+                  "transports are never range-destroyed")]
+    public static partial void OutOfRangeSuppressed(ILogger logger, ulong guidLow, uint entry);
+
+    [LoggerMessage(
+        EventId = 1113,
+        Level = LogLevel.Trace,
+        Message = "[TransportSail] guidLow={GuidLow} entry={Entry} parentRotation forwarded on Values: " +
+                  "({X},{Y},{Z},{W})")]
+    public static partial void ParentRotationForwarded(
+        ILogger logger, ulong guidLow, uint entry, float x, float y, float z, float w);
+}

--- a/HermesProxy/World/Objects/MovementInfo.cs
+++ b/HermesProxy/World/Objects/MovementInfo.cs
@@ -44,6 +44,12 @@ public sealed class MovementInfo
     public uint TransportTime;
     public uint TransportTime2;
     public sbyte TransportSeat = -1;
+    /// <summary>
+    /// V3_4_3 only: the GameObject the client reports standing on, sent alongside -- and
+    /// independently of -- the transport block. Read for diagnostics; nothing on the legacy
+    /// wire carries it.
+    /// </summary>
+    public WowGuid128 StandingOnGameObjectGuid;
     // System.Numerics.Quaternion's default (0,0,0,0) is a non-unit quaternion that
     // the V3_4_3 client rejects on Transport/GameObject CreateObject. Initializing
     // to Identity (0,0,0,1) gives a valid baseline for objects whose legacy server
@@ -86,6 +92,7 @@ public sealed class MovementInfo
         copy.TransportTime = this.TransportTime;
         copy.TransportTime2 = this.TransportTime2;
         copy.TransportSeat = this.TransportSeat;
+        copy.StandingOnGameObjectGuid = this.StandingOnGameObjectGuid;
         copy.Rotation = this.Rotation;
         copy.WalkSpeed = this.WalkSpeed;
         copy.RunSpeed = this.RunSpeed;
@@ -329,7 +336,7 @@ public sealed class MovementInfo
             ReadTransportInfoModern(data);
 
         if (hasStandingOnGameObjectGUID)
-            data.ReadPackedGuid128();
+            moveInfo.StandingOnGameObjectGuid = data.ReadPackedGuid128();
 
         if (ModernVersion.AddedInVersion(9, 2, 0, 1, 14, 1, 2, 5, 3))
         {

--- a/HermesProxy/World/Objects/SynthesizedTransport.cs
+++ b/HermesProxy/World/Objects/SynthesizedTransport.cs
@@ -1,0 +1,36 @@
+namespace HermesProxy.World.Objects;
+
+/// <summary>
+/// What the proxy remembers about a type 11 GAMEOBJECT_TYPE_TRANSPORT it parks and sails on
+/// the backend's behalf. See <c>GameSessionData.SynthesizedTransports</c>.
+/// </summary>
+/// <param name="StopFrame">
+/// The single stop frame emitted as <c>PauseTimes[0]</c> -- the path progress, in ms, of the
+/// far end of the route. Comes from the legacy GAMEOBJECT_LEVEL (gameobject_template.data[0]).
+/// It is also how long the sail takes: the client interpolates path progress in real time,
+/// so a boat parked at progress 0 needs exactly <c>StopFrame</c> ms to reach it.
+/// </param>
+/// <param name="Position">Stationary position from the create -- where the deck is while parked.</param>
+/// <param name="Orientation">Facing from the create, needed to turn a world position into a deck offset.</param>
+/// <param name="SailDeadline">
+/// The GameObjectData.Level written on the last state flip: the proxy-clock time at which the
+/// client parks the transport at <paramref name="SailTargetState"/>'s stop position. Zero when
+/// no sail has been scheduled. Republished on any create or flip that arrives before it
+/// passes, so a backend that re-sends the create every visibility pass -- TrinityCore 3.3.5a
+/// never adds type 11 to m_clientGUIDs (Player.cpp UpdateVisibilityOf_helper) -- cannot
+/// restart or cut short a sail in progress.
+/// </param>
+/// <param name="SailTargetState">The modern GO state that deadline was scheduled for.</param>
+public readonly record struct SynthesizedTransport(
+    uint StopFrame,
+    Vector3 Position,
+    float Orientation,
+    uint SailDeadline = 0,
+    sbyte SailTargetState = 0)
+{
+    /// <summary>
+    /// True while a scheduled sail has not yet reached its deadline. Signed comparison so a
+    /// deadline just past reads as expired rather than as 49 days away.
+    /// </summary>
+    public bool IsSailing(uint now) => SailDeadline != 0 && (int)(SailDeadline - now) > 0;
+}

--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -246,8 +246,14 @@ public partial class ObjectUpdateBuilder
             // what keeps every client seeing the boat in the same place. Matches the V1_14
             // and V2_5 builders. Only fall back to a local clock when the legacy server
             // sent nothing (non-transport objects that still set the bit).
+            //
+            // A transport the proxy parks and sails itself gets the proxy clock instead
+            // (ObjectUpdate.TransportServerTime): the client seeds the clock it compares
+            // GameObjectData.Level against from this field, and the sail deadline written
+            // into Level on the ships-start flip is stamped from the same clock.
             var pathProgress = _updateData.CreateData.MoveInfo.TransportPathTimer;
-            data.WriteUInt32(pathProgress != 0 ? pathProgress : (uint)Environment.TickCount);
+            data.WriteUInt32(_updateData.TransportServerTime
+                             ?? (pathProgress != 0 ? pathProgress : (uint)Environment.TickCount));
         }
 
         if (Has(CreateObjectBits.Vehicle))

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -3,6 +3,7 @@ using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Logging;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
@@ -11,6 +12,9 @@ namespace HermesProxy.World.Server;
 
 public partial class WorldSocket
 {
+    private static readonly Microsoft.Extensions.Logging.ILogger _melTransportRider =
+        Log.CreateMelLogger(Log.CategoryServer);
+
     // Handlers for CMSG opcodes coming from the modern client
     [PacketHandler(Opcode.CMSG_MOVE_CHANGE_TRANSPORT)]
     [PacketHandler(Opcode.CMSG_MOVE_FALL_LAND)]
@@ -50,10 +54,33 @@ public partial class WorldSocket
         if (opcode == 0)
             opcode = Opcodes.GetOpcodeValueForVersion("MSG_MOVE_SET_FACING", LegacyVersion.Build);
 
+        // The client attaches itself to a transport WMO it stands on, the way a 3.3.5a
+        // client does, and that is what the backend's Strand of the Ancients boarding relies
+        // on. Log the moment that changes -- boarding, leaving -- with the world position and
+        // the deck offset side by side. Not every packet: a rider sends a dozen a second.
+        var moveInfo = movement.MoveInfo;
+        var gameState = GetSession().GameState;
+        if (moveInfo.TransportGuid != gameState.LastReportedTransportGuid)
+        {
+            if (_melTransportRider.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
+            {
+                // Both halves: a HighGuid::Transport guid keeps its identity in High and
+                // has Low = 0, so Low alone reads as "0 -> 0" on AzerothCore.
+                TransportLogMessages.ClientTransportChanged(_melTransportRider, opcodeName,
+                    gameState.LastReportedTransportGuid.Low, gameState.LastReportedTransportGuid.High,
+                    moveInfo.TransportGuid.Low, moveInfo.TransportGuid.High,
+                    moveInfo.StandingOnGameObjectGuid.Low,
+                    moveInfo.TransportOffset.X, moveInfo.TransportOffset.Y, moveInfo.TransportOffset.Z,
+                    moveInfo.TransportOrientation, moveInfo.TransportSeat,
+                    moveInfo.Position.X, moveInfo.Position.Y, moveInfo.Position.Z);
+            }
+            gameState.LastReportedTransportGuid = moveInfo.TransportGuid;
+        }
+
         WorldPacket packet = new WorldPacket(opcode);
         if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_2_0_10192))
             packet.WritePackedGuid(movement.Guid.To64());
-        movement.MoveInfo.WriteMovementInfoLegacy(packet);
+        moveInfo.WriteMovementInfoLegacy(packet);
         SendPacketToServer(packet);
     }
 

--- a/HermesProxy/World/Server/Packets/UpdatePackets.cs
+++ b/HermesProxy/World/Server/Packets/UpdatePackets.cs
@@ -22,9 +22,12 @@ using Framework.IO;
 using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Logging;
 using HermesProxy.World.Objects;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace HermesProxy.World.Server.Packets;
 
@@ -101,6 +104,16 @@ public class ObjectUpdate
     /// gameobject_template.data[0] -- the same value native 3.4.3 sends as PauseTimes[0].
     /// </summary>
     public uint? TransportStopFrame;
+    /// <summary>
+    /// ServerTime for the create of a transport the proxy parks and sails itself. Native
+    /// 3.4.3 writes GameTime::GetGameTimeMS() there, and the client seeds the clock it
+    /// compares GameObjectData.Level against from it, so the two must share a source. A
+    /// backend that never relocates its type 11 transports hands us a free-running path
+    /// counter instead, which cannot be extended into a deadline. Null leaves the builder
+    /// forwarding the legacy path progress, which is right for a backend that moves the
+    /// boat itself.
+    /// </summary>
+    public uint? TransportServerTime;
     public DynamicObjectData DynamicObjectData = null!;
     public CorpseData CorpseData = null!;
 
@@ -183,7 +196,15 @@ public class ObjectUpdate
         else
             needsWmoFlag = wmoMapObjects.Contains(Guid);
 
-        if (needsWmoFlag)
+        // Only touch Flags where the whole value is being published: on the create, or on
+        // a Values that carries GAMEOBJECT_FLAGS. Fabricating Flags = MAP_OBJECT alone on a
+        // Values that does not carry the field ships a value with every other bit cleared,
+        // GO_FLAG_TRANSPORT (0x8) included -- and that bit is what lets the client attach a
+        // player to a GameObject. TrinityCore follows a freshly spawned boat's create with a
+        // Values carrying only ParentRotation and DynamicFlags in the same tick; with the
+        // flag fabricated there, a player landing on that boat was never attached and stood
+        // still while it sailed away. Native leaves Flags off such a Values entirely.
+        if (needsWmoFlag && (CreateData != null || GameObjectData.Flags != null))
             GameObjectData.Flags = (GameObjectData.Flags ?? 0) | ModernTransportFlag;
 
         if (ModernVersion.Build != ClientVersionBuild.V3_4_3_54261
@@ -214,18 +235,34 @@ public class ObjectUpdate
         if (GameObjectData.Level is > 0)
             TransportStopFrame = (uint)GameObjectData.Level.Value;
 
+        // Remember the boat from its create. The ships-start flip arrives later as a Values
+        // update carrying only GAMEOBJECT_BYTES_1, so the stop frame it has to sail to is
+        // no longer on the wire by then, and the deck position is what a rider's offset is
+        // measured from.
+        //
+        // One hash lookup per update: a create always writes its slot, a Values update only
+        // reads one that exists. The ref is not held across any other mutation of the map.
+        var transports = GlobalSession.GameState.SynthesizedTransports;
+        bool isCreate = CreateData?.MoveInfo != null;
+        ref SynthesizedTransport known = ref isCreate
+            ? ref CollectionsMarshal.GetValueRefOrAddDefault(transports, Guid, out _)
+            : ref CollectionsMarshal.GetValueRefOrNullRef(transports, Guid);
+        if (isCreate)
+        {
+            // A re-create keeps whatever sail is already under way (see below).
+            known = new SynthesizedTransport(
+                TransportStopFrame ?? known.StopFrame,
+                CreateData!.MoveInfo.Position,
+                CreateData.MoveInfo.Orientation,
+                known.SailDeadline,
+                known.SailTargetState);
+        }
+
         // GO_STATE_TRANSPORT_ACTIVE parks the transport at path position 0 -- its spawn --
         // and GO_STATE_TRANSPORT_STOPPED + n parks it at _stopFrames[n], which for the SotA
         // gunships is the landing beach. That maps cleanly onto the two phases a 3.3.5a core
         // expresses with the only states it has: GO_STATE_READY during the warm-up, and
         // GO_STATE_ACTIVE once TrinityCore's StartShips() calls DoorOpen() on the boats.
-        //
-        // The boat jumps between the two rather than sailing. Interpolating requires Level to
-        // be a deadline in the future -- the client animates only while `now < Level`
-        // (GameObject.cpp) -- and the ServerTime we forward is the legacy path-progress
-        // counter rather than the game clock the client compares against, so there is no
-        // shared time base to build that deadline on yet. Players are carried to the beach
-        // and can disembark, which is the gameplay outcome; the sail is cosmetic.
         //
         // Forwarding the raw door state is not an option: the client evaluates
         // `state - GO_STATE_TRANSPORT_ACTIVE`, so a raw 0 is stop-frame index -24 and an
@@ -240,18 +277,75 @@ public class ObjectUpdate
         // GameObjects and reads as a damaged transport.
         GameObjectData.PercentHealth = 255;
 
-        // Native's Level is a deadline in the game clock -- it interpolates the transport
-        // only while `now < Level` -- and synthesizing that deadline does make the boat sail,
-        // but a sailing boat leaves the player behind on a backend that never relocates it:
-        // nothing attaches the player to the deck and they drop into the water partway
-        // across. Playtested 2026-08-30; the boat also wandered somewhere invalid and
-        // vanished. Leaving Level expired keeps the transition instantaneous, which is the
-        // only variant where players actually arrive. Reinstating the sail needs the
-        // passenger link, which needs the proxy to simulate the path itself.
-        GameObjectData.Level = CreateData?.MoveInfo != null
-            ? (int)CreateData.MoveInfo.TransportPathTimer
-            : null;
+        // Level is a deadline in the game clock, not a period: the client interpolates the
+        // transport's path progress toward the state's stop frame only while `now < Level`,
+        // and parks it there otherwise (TrinityCore 3.4.3 GameObject.cpp). On a state change
+        // native sets Level = now + |pathProgress - stopPathProgress|, which the golden SotA
+        // capture confirms: the flip carried Level 227076 with the clock at 166942, a
+        // difference of 60134 against a stop frame of 60133.
+        //
+        // The client seeds `now` from the ServerTime it saw in the create, so both stamps
+        // come from the proxy clock. Native's own create shape is Level just below
+        // ServerTime -- already expired, boat parked at its spawn.
+        //
+        // A flip in either direction is a full traverse between the two stop positions, so
+        // the deadline is always now + stopFrame. That assumes the previous traverse had
+        // finished; a flip landing mid-sail would overshoot by whatever was left, which
+        // nothing in the SotA round timing produces.
+        //
+        // Whatever arrives while a sail is under way republishes the deadline already
+        // scheduled rather than stamping a new one. TrinityCore 3.3.5a never adds a type 11
+        // transport to m_clientGUIDs (Player.cpp UpdateVisibilityOf_helper, a deliberate
+        // hack so the Deeprun tram does not vanish under a rider), so every visibility pass
+        // re-sends the boat's full create -- once a second, observed live, all through the
+        // crossing. An expired Level on one of those would park the boat at the far end the
+        // instant the client honoured it. Same shape for a repeated flip.
+        //
+        // Only a transport with a stop frame gets any of this. A stop-frame-less type 11 --
+        // the Deeprun tram -- free-runs its path with no ServerTime create bit and nothing
+        // to sail to, and keeps the legacy path counter in Level exactly as before.
+        uint now = Time.GetMSTime();
+        sbyte state = GameObjectData.State ?? 0;
+        bool hasStopFrame = !Unsafe.IsNullRef(ref known) && known.StopFrame != 0;
+        bool sailing = hasStopFrame && known.IsSailing(now) && known.SailTargetState == state;
+        if (isCreate)
+        {
+            if (hasStopFrame)
+            {
+                TransportServerTime = now;
+                GameObjectData.Level = (int)(sailing ? known.SailDeadline : now);
+            }
+            else
+            {
+                GameObjectData.Level = (int)CreateData!.MoveInfo.TransportPathTimer;
+            }
+        }
+        else if (state is ModernTransportStateActive or ModernTransportStateStopped)
+        {
+            if (sailing)
+            {
+                GameObjectData.Level = (int)known.SailDeadline;
+            }
+            else if (hasStopFrame)
+            {
+                uint deadline = now + known.StopFrame;
+                GameObjectData.Level = (int)deadline;
+                known = known with { SailDeadline = deadline, SailTargetState = state };
+                if (_melTransport.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
+                    TransportLogMessages.SailScheduled(_melTransport, Guid.Low, Guid.GetEntry(),
+                        state, known.StopFrame, now, (int)deadline);
+            }
+            else if (_melTransport.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
+            {
+                // Nothing to sail to; Level stays off the wire and the state flip is
+                // instantaneous, as before.
+                TransportLogMessages.SailUnknownStopFrame(_melTransport, Guid.Low, Guid.GetEntry(), state);
+            }
+        }
     }
+
+    private static readonly Microsoft.Extensions.Logging.ILogger _melTransport =
+        Log.CreateMelLogger(Log.CategoryServer);
 
     public void InitializePlaceholders()
     {


### PR DESCRIPTION
The Strand of the Ancients gunships now sail from their spawn to the landing beach and carry their riders, on a backend that never moves them (TrinityCore 3.3.5a). Before this they jumped from spawn to dock at ships-start, and the player was teleported alongside.

Validated on the final build across both boats in both states — the pooled boat and the one TrinityCore had just spawned when the player arrived:

| | pooled | freshly spawned |
|---|---|---|
| The Graceful Maiden (193182, east) | attach, south, beach | attach, rotation corrected, south, beach |
| The Frostbreaker (193185, west) | attach, south, beach | attach, rotation corrected, south, beach |

## What #197 assumed, and what is actually true

#197 scoped this as a transport simulator in the proxy: track the `TransportAnimation` path, simulate the boat's position over time, and convert world ↔ deck coordinates in both directions for as long as the player is aboard. That reasoning was built on the observation that a synthesized sail left the player behind in the water.

None of it is needed. Three things the golden Wrathion capture and the live playtest settled:

**1. The V3_4_3 client attaches itself to a transport WMO it lands on**, the same way a 3.3.5a client does — which is exactly what TrinityCore's `BattlegroundSA::TeleportToEntrancePosition` relies on: it teleports attackers to Z=15 above the deck with Slow Fall and lets the client do the rest. The very first `CMSG_MOVE_FALL_LAND` after that teleport already carried the boat's guid:

```
[TransportRider] MSG_MOVE_FALL_LAND transportLow=13 offset=(4.509033,-1.5004272,9.446093) o=3.394514
```

That offset is byte-identical to the native capture's `TransportData` for the same deck spot. There is no passenger link to synthesize.

**2. The client owns the path.** It animates the boat from `TransportAnimation.db2`, carries the rider, recomputes the rider's world position, and sends *both* the absolute and the deck-relative position in every movement packet. The proxy forwards the absolute one; TrinityCore's `MovementHandler` cannot resolve the transport guid to a `Transport` (type 11 gets a plain GameObject guid there), calls `transport.Reset()` and uses the absolute position as-is. No coordinate conversion in either direction.

**3. The sail is three fields** on the ships-start Values update. From the golden capture, packet 2889:

```
[0] UpdateType: Values   Guid: <boat>
[0] DynamicFlags: 0
[0] Level: 227076
[0] State: 25
```

`State 25` is `GO_STATE_TRANSPORT_STOPPED + 0`: the client targets `PauseTimes[0]` (the stop frame, 60133 for these boats) and interpolates its path progress there, finishing when its clock reaches `Level`. At that flip the clock read 166942, and `227076 − 166942 = 60134` — `Level = now + |pathProgress − stopFrame|`, which is precisely what TrinityCore 3.4.3's `GameObject.cpp` does on a state change.

## The time base

The client seeds the clock it compares `Level` against from the `ServerTime` in the transport's create. A 3.3.5a core puts its free-running `Transport.PathProgress` counter there, which cannot be extended into a deadline — that is the "no shared time base" the earlier attempt ran into.

For a transport the proxy parks and sails itself, the create now carries the proxy clock as `ServerTime` (`ObjectUpdate.TransportServerTime`), and the flip's `Level` is stamped from the same clock. A create is `Level = now` — expired, parked at spawn, native's own shape. A flip is `Level = now + stopFrame`. The stop frame, deck position and facing are remembered from the create (`GameSessionData.SynthesizedTransports`, a `readonly record struct` reached through `CollectionsMarshal` so a boat costs one hash lookup per update) because the flip arrives carrying only `GAMEOBJECT_BYTES_1`.

Only a transport with a stop frame gets any of this. A stop-frame-less type 11 — the Deeprun tram — keeps the legacy path counter in `Level` and `ServerTime` exactly as before, so two players behind two proxies still agree on its phase.

## TrinityCore re-sends the boat's create once a second — by design

Player.cpp on the 3.3.5 branch:

```cpp
template<>
inline void UpdateVisibilityOf_helper(GuidUnorderedSet& s64, GameObject* target, std::set<Unit*>& /*v*/)
{
    // @HACK: This is to prevent objects like deeprun tram from disappearing when player moves far from its spawn point while riding it
    if ((target->GetGOInfo()->type != GAMEOBJECT_TYPE_TRANSPORT))
        s64.insert(target->GetGUID());
}
```

Type 11 is never in `m_clientGUIDs`, so `HaveAtClient` is always false and every visibility pass re-sends the full create — observed at 1/s all through the crossing. A native 3.3.5a client gets the same stream. The client treats a create for a guid it already holds as a field refresh, but an expired `Level` on one of those would have parked the boat at the far end the instant the client honoured it. Re-creates and repeated flips now republish the deadline already scheduled while a sail is in progress.

## Three bugs found on the way

The first two only hit the first player into a fresh instance. Six of the eleven playtest rounds ended with the boat sailing away and the player standing on the deck's collision, unattached. The correlation that held every time: the failing boat was the one TrinityCore had flagged as **new** (`m_isNewObject` → legacy `CREATE_OBJECT2`) when the player arrived — which only happens for the first player into a freshly created instance, and only for whichever boat spawned in the same tick.

Every guess about *what* differs for a new boat was killed by an inverted experiment — an env-var hook that forced the suspect value onto a boat that worked:

| suspect | forced onto a working boat | result |
|---|---|---|
| modern `CreateObject2` vs `CreateObject1` | force `CreateObject2` | still attaches |
| stale first-create `ParentRotation` | force `(0,0,0.39,1)` | still attaches — **but sails north instead of south** |

What actually differed came out of the raw bytes. TrinityCore's `ResetObjs` adds a boat to the map — which broadcasts its create to anyone in range — and only *then* calls `SetParentRotation(0, 0, 1, ~0)` on it. The fix-up trails as a 32-byte Values, mask `0x7000` = `PARENTROTATION+2`, `PARENTROTATION+3`, `DYNAMIC`. Only a player already in range gets it. Two things go wrong with that Values:

**Bug 1 — PR #207's `GO_FLAG_MAP_OBJECT` guard.** It remembered WMO guids so the flag survives a Values that rewrites `GAMEOBJECT_FLAGS`. But it applied `Flags = (Flags ?? 0) | 0x100000` on *any* Values for a remembered guid, so a Values that did not carry Flags at all got a fabricated `Flags = 0x100000` — every other bit cleared, including `GO_FLAG_TRANSPORT (0x8)`, which is what lets the client attach a player to a GameObject. The flag is now only applied where Flags is actually being published: on a create, or on a Values that carries the field. The same guard was silently clearing the SotA gates' real flags on every Values too. Regression test `InitializePlaceholders_ValuesUpdateWithoutFlags_DoesNotFabricateFlags`.

**Bug 2 — the stale rotation.** `ParentRotation` is what the client rotates the transport's *path* by (not the attach — the inverted test proved that). Left at `GameObject::Create`'s default, the boat carried its riders off in the wrong direction. The proxy read `PARENTROTATION` only on creates; it now forwards it on a Values for tracked transports, filling unmasked components from the legacy field cache. It cannot be read off the existing `[GO field in]` trace, which only prints array bases — that blindness cost a fair amount of time here.

**Bug 3 — TrinityCore range-drops the boat mid-crossing.** The boat's *server-side* position never leaves spawn; the rider's server-side position follows the client's absolute coordinates across the bay. Once that distance passed the battleground visibility range — about 26 s and ~550 yards in — TrinityCore sent an `OUT_OF_RANGE` for the boat. The client removed it and the rider fell into the sea. It happened once in twelve crossings and reproduced with a quick leave-and-requeue. Native never range-destroys a transport, and TrinityCore's own `GameObject::IsTransport()` comment says "don't transmit an out of range packet for it", so a range removal for a transport the proxy is sailing is now dropped. An explicit `SMSG_DESTROY_OBJECT` — the round-2 respawn — is untouched. Verified on the reproduction: the packet arrived at the same second, was suppressed, and the boat carried the rider to the beach.

```
23:24:13 [TransportSail] guidLow=13 ... state=25 stopFrame=60133 now=273297 level=333430
23:24:39 [TransportSail] guidLow=13 ... OUT_OF_RANGE from the backend suppressed
23:25:15 [TransportRider] CHANGE_TRANSPORT 13 -> 0  world=(1601,-98)      ← beach
```

## Diagnostics

`World/Logging/TransportLogMessages.cs` (EventId 1110–1113, source-generated, Trace, `IsEnabled`-gated):

- `[TransportSail]` on every scheduled deadline, on a flip with no stop frame, and on a ParentRotation forwarded via Values
- `[TransportRider]` on attach and detach only — not every movement packet — logging `StandingOnGameObjectGUID` next to the transport guid, which separates "on the object but not a transport" from "not on it"

`MovementInfo` now retains `StandingOnGameObjectGuid` from the V3_4_3 movement block instead of discarding it.

## Not addressed

- **AzerothCore.** Its boats are `StaticTransport`s with a `HighGuid::Transport` guid that the server genuinely moves; the sail synthesis returns before touching them. The one thing AC's boats *do* see from this PR is the `GO_FLAG_MAP_OBJECT` guard fix: AC sends a `DynamicFlags` Values for its moving boat every tick, and each of those used to fabricate `Flags = 0x100000`; now they leave Flags alone. Checked live against the playerbots stack: the attacker spawned on the deck, attached on landing and was carried to the beach (an improvement on #198's "lands in the sea"); the boat still free-runs its loop from the create and snaps back every ~60 s (#198 item 3, untouched). The bots — server-side passengers, forwarded with deck offsets on a transport guid the client knows, no movement packets after, identical shape to the 08-30 AC log — were not drawn on the boat. An isolation run with the old guard restored changed nothing about boarding (AC's guid type is what the client keys on there), so that is pre-existing item-3 desync, not this PR. That run also produced an ERROR 132 after the client attached the player from *inside the hull* at water level — under the old behaviour, not the new; noted for item 3.
- **Isle of Conquest's 194675 Tram** has the same type 11 shape and should follow the same path, but was not tested.
- **Undercity elevator** is a stoppable type 11 with a stop frame; it now gets a real deadline per flip instead of an expired one, so it should animate rather than jump. Not re-tested after this change.
- The pre-existing interpolated `Log.Print($"[Transport] …")` traces in this area still `ToString()` a `WowGuid128` per call and are not touched here.

Fixes #197
Refs #198 — closes its items 1 and 2 (the entry drop, and the boat teleporting instead of sailing). Item 3 is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wjT6WuwE3sp2GQSzy1vns
