### PR TITLE
fix(v3_4_3): read the ready-check answer bits and end a check that times out

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/GroupHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/GroupHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Logging;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server;
 using HermesProxy.World.Server.Packets;
@@ -464,6 +465,9 @@ public partial class WorldClient
             ready.PartyIndex = GetSession().GameState.GetCurrentPartyIndex();
             ready.PartyGUID = GetSession().GameState.GetCurrentGroupGuid();
             SendPacketToClient(ready);
+
+            GetSession().GameState.GroupReadyCheckResponses = 0;
+            ArmReadyCheckDeadline(ready.Duration);
         }
         else
         {
@@ -477,6 +481,7 @@ public partial class WorldClient
             if (GetSession().GameState.GroupReadyCheckResponses >= GetSession().GameState.GetCurrentGroupSize())
             {
                 GetSession().GameState.GroupReadyCheckResponses = 0;
+                StopReadyCheckDeadline();
                 ReadyCheckCompleted completed = new ReadyCheckCompleted();
                 completed.PartyIndex = GetSession().GameState.GetCurrentPartyIndex();
                 completed.PartyGUID = GetSession().GameState.GetCurrentGroupGuid();
@@ -493,6 +498,11 @@ public partial class WorldClient
         ready.PartyIndex = GetSession().GameState.GetCurrentPartyIndex();
         ready.PartyGUID = GetSession().GameState.GetCurrentGroupGuid();
         SendPacketToClient(ready);
+
+        // A check that ends without a full set of answers used to leave the counter
+        // non-zero, so the next one completed early.
+        GetSession().GameState.GroupReadyCheckResponses = 0;
+        ArmReadyCheckDeadline(ready.Duration);
     }
 
     [PacketHandler(Opcode.MSG_RAID_READY_CHECK_CONFIRM, ClientVersionBuild.V2_0_1_6180)]
@@ -508,6 +518,7 @@ public partial class WorldClient
         if (GetSession().GameState.GroupReadyCheckResponses >= GetSession().GameState.GetCurrentGroupSize())
         {
             GetSession().GameState.GroupReadyCheckResponses = 0;
+            StopReadyCheckDeadline();
             ReadyCheckCompleted completed = new ReadyCheckCompleted();
             completed.PartyIndex = GetSession().GameState.GetCurrentPartyIndex();
             completed.PartyGUID = GetSession().GameState.GetCurrentGroupGuid();
@@ -518,10 +529,78 @@ public partial class WorldClient
     [PacketHandler(Opcode.MSG_RAID_READY_CHECK_FINISHED, ClientVersionBuild.V2_0_1_6180)]
     void HandleRaidReadyCheckFinished(WorldPacket packet)
     {
+        GetSession().GameState.GroupReadyCheckResponses = 0;
+        StopReadyCheckDeadline();
+
         ReadyCheckCompleted ready = new ReadyCheckCompleted();
         ready.PartyIndex = GetSession().GameState.GetCurrentPartyIndex();
         ready.PartyGUID = GetSession().GameState.GetCurrentGroupGuid();
         SendPacketToClient(ready);
+    }
+
+    // The modern client waits for the server to end a ready check once the Duration it
+    // was given lapses. Legacy 3.3.5a has no server-side timer: MSG_RAID_READY_CHECK_FINISHED
+    // travels *up* from the leader's own client, which the modern client never sends, so
+    // the legacy server never broadcasts it and a check nobody answers stays pending
+    // forever. Synthesize the deadline here instead.
+    // Armed on the packet thread, disposed from either that thread or the timer's own
+    // callback, so every swap goes through Interlocked - a plain read-then-dispose can
+    // drop a timer another thread has just armed.
+    private System.Threading.Timer? _readyCheckTimer;
+
+    private void ArmReadyCheckDeadline(ulong durationMs)
+    {
+        // Fire on the duration boundary, the way a native server ends the check
+        // (Group::UpdateReadyCheck, READYCHECK_DURATION = 35000). Landing late means the
+        // client has already torn its ready-check frame down and the completion arrives
+        // with nothing left to close.
+        long dueMs = (long)durationMs;
+        var timer = new System.Threading.Timer(OnReadyCheckDeadline, dueMs, dueMs, System.Threading.Timeout.Infinite);
+        System.Threading.Interlocked.Exchange(ref _readyCheckTimer, timer)?.Dispose();
+    }
+
+    private void StopReadyCheckDeadline()
+    {
+        System.Threading.Interlocked.Exchange(ref _readyCheckTimer, null)?.Dispose();
+    }
+
+    private void OnReadyCheckDeadline(object? state)
+    {
+        StopReadyCheckDeadline();
+
+        // An escaped exception on a timer thread has no handler above it and would take
+        // the whole proxy down, so nothing in here is allowed to propagate.
+        try
+        {
+            if (_closing || !IsConnected())
+                return;
+
+            var gameState = GetSession().GameState;
+            uint responses = gameState.GroupReadyCheckResponses;
+            uint expected = gameState.GetCurrentGroupSize();
+            gameState.GroupReadyCheckResponses = 0;
+
+            // Everyone answered in time - the response counter already completed the check.
+            if (responses >= expected)
+                return;
+
+            WowGuid128 partyGuid = gameState.GetCurrentGroupGuid();
+
+            // The group broke up while the check was running; there is nothing to complete.
+            if (partyGuid == null || partyGuid.IsEmpty())
+                return;
+
+            WorldClientLogMessages.ReadyCheckDeadlineLapsed(_melLog, _sourceFile, _netDirNone, (long)state!, responses, expected);
+
+            ReadyCheckCompleted completed = new ReadyCheckCompleted();
+            completed.PartyIndex = gameState.GetCurrentPartyIndex();
+            completed.PartyGUID = partyGuid;
+            SendPacketToClient(completed);
+        }
+        catch (Exception ex)
+        {
+            WorldClientLogMessages.ReadyCheckDeadlineFailed(_melLog, _sourceFile, _netDirNone, ex);
+        }
     }
 
     [PacketHandler(Opcode.MSG_RAID_TARGET_UPDATE)]

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -179,6 +179,7 @@ public partial class WorldClient
     {
         _closing = true;
         StopKeepAliveTimer();
+        StopReadyCheckDeadline();
 
         // Unhook before closing so the receive loop does not treat this as an
         // unexpected drop and call OnDisconnect (that nulls AuthClient, which

--- a/HermesProxy/World/Logging/WorldClientLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldClientLogMessages.cs
@@ -1,4 +1,5 @@
-﻿using HermesProxy.World.Enums;
+﻿using System;
+using HermesProxy.World.Enums;
 using Microsoft.Extensions.Logging;
 
 namespace HermesProxy.World.Logging;
@@ -194,4 +195,26 @@ internal static partial class WorldClientLogMessages
         string NetDir,
         uint QuestId,
         int Slot);
+
+    [LoggerMessage(
+        EventId = 217,
+        Level = LogLevel.Debug,
+        Message = "Ready check deadline lapsed after {DurationMs} ms with {Responses} of {Expected} answers; completing it for the client.")]
+    public static partial void ReadyCheckDeadlineLapsed(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        long DurationMs,
+        uint Responses,
+        uint Expected);
+
+    [LoggerMessage(
+        EventId = 218,
+        Level = LogLevel.Error,
+        Message = "Ready check deadline callback failed.")]
+    public static partial void ReadyCheckDeadlineFailed(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        Exception Exception);
 }

--- a/HermesProxy/World/Server/PacketHandlers/GroupHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/GroupHandler.cs
@@ -118,10 +118,14 @@ public partial class WorldSocket
         packet.WriteBool(raid.IsReady);
         SendPacketToServer(packet);
 
+        // The legacy server broadcasts MSG_RAID_READY_CHECK_CONFIRM to the leader and
+        // assistants only, so a plain member never sees its own answer come back. Echo it
+        // locally under the real party GUID - a placeholder GUID does not match the party
+        // the client is tracking, so the echo was discarded.
         ReadyCheckResponse ready = new ReadyCheckResponse();
         ready.Player = GetSession().GameState.CurrentPlayerGuid;
         ready.IsReady = raid.IsReady;
-        ready.PartyGUID = WowGuid128.Create(HighGuidType703.Party, 1000);
+        ready.PartyGUID = GetSession().GameState.GetCurrentGroupGuid();
         SendPacket(ready);
     }
 

--- a/HermesProxy/World/Server/Packets/GroupPackets.cs
+++ b/HermesProxy/World/Server/Packets/GroupPackets.cs
@@ -628,6 +628,15 @@ class DoReadyCheck : ClientPacket
 
     public override void Read()
     {
+        if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+        {
+            // V3_4_3 wire layout: a HasPartyIndex bit first, then the optional byte.
+            bool hasPartyIndex = _worldPacket.HasBit();
+            if (hasPartyIndex)
+                PartyIndex = _worldPacket.ReadInt8();
+            return;
+        }
+
         PartyIndex = _worldPacket.ReadInt8();
     }
 
@@ -670,6 +679,22 @@ class ReadyCheckResponseClient : ClientPacket
 
     public override void Read()
     {
+        if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+        {
+            // V3_4_3 wire layout: a HasPartyIndex bit, then IsReady, then the optional
+            // PartyIndex byte - the same bits-first shape as PartyInviteResponse above.
+            // Reading PartyIndex first consumed the bit byte and then took the MSB of the
+            // (always zero) index byte as IsReady, so every answer reached the group as
+            // "not ready". Observed bytes: Ready = C0 00, Not Ready = 80 00. WPP's
+            // V3_4_0 parser orders these bits the other way round, but it is registered
+            // at V3_4_4_59817 and does not hold for 54261.
+            bool hasPartyIndex = _worldPacket.HasBit();
+            IsReady = _worldPacket.HasBit();
+            if (hasPartyIndex)
+                PartyIndex = _worldPacket.ReadUInt8();
+            return;
+        }
+
         PartyIndex = _worldPacket.ReadUInt8();
         IsReady = _worldPacket.HasBit();
     }


### PR DESCRIPTION
Raid ready check (#210) was wired end to end but had never been driven in game. Two real 3.4.3 clients against TrinityCore 3.3.5a turned up three defects; all three paths — accept, decline, timeout — now render correctly on the leader's frames.

## The answer bits were read in the wrong place

`CMSG_READY_CHECK_RESPONSE` is bits-first on this build. `ReadyCheckResponseClient` read `PartyIndex` as a leading byte, which consumed the bit byte, and then took the MSB of the (always zero) index byte as `IsReady` — so **every answer reached the group as "not ready"**, and the leader saw "away" no matter what the member clicked.

The packet is 2 bytes. Only one bit moves between the two answers:

| click | byte 0 | bits |
|---|---|---|
| Ready | `0xC0` | `1100 0000` |
| Not Ready | `0x80` | `1000 0000` |

Wrathion's native 3.4.3 reader (`PartyPackets.cpp:388`) confirms which bit is which:

```cpp
uint8 index = 0;
_worldPacket >> index;
if (index & 128)                            // HasPartyIndex
{
    PartyIndex.emplace();
    IsReady = (index & 64) ? true : false;  // IsReady
}
```

WowPacketParser's `V3_4_0` parser orders those two bits the other way round, but it is registered at `V3_4_4_59817` and does not hold for 54261 — worth knowing, because it means WPP mis-renders this packet in a 3.4.3 capture. `CMSG_DO_READY_CHECK` has the same bits-first shape and is corrected alongside it.

Both are gated on `V3_4_3_54261`. V1_14 and V2_5 keep the byte-first layout that WPP's `V6_0_2` and `V7_0_3` parsers describe.

## A check nobody answered never ended

Legacy 3.3.5a has no server-side ready-check timer. `MSG_RAID_READY_CHECK_FINISHED` travels *up* from the leader's own client — `WorldSession::HandleRaidReadyCheckFinishedOpcode` is a CMSG handler — and the modern client never sends it, so the legacy server never broadcasts it and the check stayed pending forever.

The proxy now synthesizes the deadline, firing on the duration boundary the way native does:

```cpp
void Group::UpdateReadyCheck(uint32 diff)
{
    if (!m_readyCheckStarted) return;
    m_readyCheckTimer -= Milliseconds(diff);
    if (m_readyCheckTimer <= Milliseconds::zero())
        EndReadyCheck();          // broadcasts ReadyCheckCompleted
}
#define READYCHECK_DURATION 35000
```

Landing even a second late means the client has already torn its ready-check frame down and the completion arrives with nothing left to close.

The timer is swapped through `Interlocked` because it is armed on the packet thread and disposed from its own callback, and the callback swallows everything — an exception escaping a timer thread has no handler above it and would take the proxy down. It is stopped at both completion sites, on `MSG_RAID_READY_CHECK_FINISHED`, on re-arm, and in `Disconnect()` beside `StopKeepAliveTimer()`.

## Two smaller ones

`GroupReadyCheckResponses` is now reset when a check *starts*. A check that ended without a full set of answers left it non-zero, so the next one completed early — the timeout path above was about to expose this in any group of three or more.

The local echo of the player's own answer carried a placeholder party GUID (`Party/1000`) rather than the real one (`RaidGroup/1`), so the client discarded it.

## A limit the proxy cannot fix

That echo exists because `Group::BroadcastReadyCheck` sends the confirm to the **leader and assistants only**. A plain member never sees its own answer come back — and it never sees anyone else's either. Both TrinityCore and AzerothCore behave this way, and since the bytes never reach the member's session there is nothing to translate. Native 3.3.5a clients had the same blind spot; the modern client just makes it more visible.

`SMSG_READY_CHECK_ERROR` (legacy `0x408`) is deliberately left unmapped, and the `HPSG001` build warning about it is noise. No server emits it: TrinityCore and AzerothCore both declare it `STATUS_NEVER` with no emitter anywhere, and native 3.4.3 dropped the opcode entirely. The permission check just `return`s bare, and AzerothCore's battleground gate sends a chat notification (`LANG_BG_READY_CHECK_ERROR`) rather than the opcode. Our V3_4_3 entry is `0u` — the dead legacy-named alias, not a real modern opcode.

## Testing

TrinityCore 3.3.5a, two real 3.4.3 clients in a party (`test-loop2.ps1 -LocalTc` plus `second-client.ps1`). Ready, Not Ready and the unanswered 35 s timeout each verified on the leader's frames. `dotnet test` 1007 passed, 0 failed.

Not exercised: ready check inside a raid rather than a party, and the AzerothCore backend.

Refs #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124qGatxkc1Nxos98YeRtXw

