### PR TITLE
fix(v3_4_3): bridge CMSG_ITEM_TEXT_QUERY so mail letters open

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MailHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MailHandler.cs
@@ -164,6 +164,23 @@ public partial class WorldClient
     [PacketHandler(Opcode.SMSG_QUERY_ITEM_TEXT_RESPONSE)]
     void HandleQueryItemTextResponse(WorldPacket packet)
     {
+        // 3.3.0 moved letter bodies from the item_text table onto the item itself, and the
+        // packet changed with it: a leading "no text" byte, the item GUID, then the string.
+        // Before that it was a bare item_text id and the body was only ever used to fill in
+        // a pending mail list, never sent to the client on its own.
+        if (LegacyVersion.AddedInVersion(ClientVersionBuild.V3_3_0_10958))
+        {
+            QueryItemTextResponse response = new QueryItemTextResponse();
+            response.Valid = packet.ReadUInt8() == 0; // 0 means the item has text
+            if (response.Valid)
+            {
+                response.Id = packet.ReadGuid().To128(GetSession().GameState);
+                response.Text = packet.ReadCString();
+            }
+            SendPacketToClient(response);
+            return;
+        }
+
         uint itemTextId = packet.ReadUInt32();
         string text = packet.ReadCString();
 

--- a/HermesProxy/World/Server/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/QueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Framework.Constants;
 using Framework.Logging;
+using HermesProxy.Enums;
 using HermesProxy.World;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
@@ -16,6 +17,23 @@ public partial class WorldSocket
         WorldPacket packet = new WorldPacket(Opcode.CMSG_QUERY_TIME);
         SendPacketToServer(packet);
     }
+    // Opening a letter created from a mail (CMSG_MAIL_CREATE_TEXT_ITEM) makes the client
+    // query the item's body text. The opcode was mapped on both sides and the response was
+    // already handled, but nothing forwarded the request, so the letter never opened.
+    // Legacy took a uint32 item_text id before 3.3.0 and an item GUID from 3.3.0 on; the
+    // modern client only ever sends a GUID, so this bridge is 3.3.0+ only. On older cores
+    // the body still arrives through the mail-list path in MailHandler.
+    [PacketHandler(Opcode.CMSG_ITEM_TEXT_QUERY)]
+    void HandleItemTextQuery(ItemTextQuery query)
+    {
+        if (!LegacyVersion.AddedInVersion(ClientVersionBuild.V3_3_0_10958))
+            return;
+
+        WorldPacket packet = new WorldPacket(Opcode.CMSG_ITEM_TEXT_QUERY);
+        packet.WriteGuid(query.Id.To64());
+        SendPacketToServer(packet);
+    }
+
     [PacketHandler(Opcode.CMSG_QUERY_QUEST_INFO)]
     void HandleQueryQuestInfo(QueryQuestInfo queryQuest)
     {

--- a/HermesProxy/World/Server/Packets/QueryPackets.cs
+++ b/HermesProxy/World/Server/Packets/QueryPackets.cs
@@ -967,3 +967,37 @@ public class WhoEntry
     public int AreaID;
     public bool IsGM;
 }
+
+class ItemTextQuery : ClientPacket
+{
+    public ItemTextQuery(WorldPacket packet) : base(packet) { }
+
+    public override void Read()
+    {
+        Id = _worldPacket.ReadPackedGuid128();
+    }
+
+    public WowGuid128 Id = WowGuid128.Empty;
+}
+
+class QueryItemTextResponse : ServerPacket
+{
+    public QueryItemTextResponse() : base(Opcode.SMSG_QUERY_ITEM_TEXT_RESPONSE) { }
+
+    public override void Write()
+    {
+        _worldPacket.WriteBit(Valid);
+        _worldPacket.FlushBits();
+
+        // ItemTextCache is written unconditionally, even when Valid is false.
+        _worldPacket.WriteBits(Text.GetByteCount(), 13);
+        _worldPacket.FlushBits();
+        _worldPacket.WriteString(Text);
+
+        _worldPacket.WritePackedGuid128(Id);
+    }
+
+    public WowGuid128 Id = WowGuid128.Empty;
+    public bool Valid;
+    public string Text = string.Empty;
+}


### PR DESCRIPTION
A letter created from a mail (`CMSG_MAIL_CREATE_TEXT_ITEM`) could not be read. Clicking it in the bags produced only:

```
21:34:07 | D | P | WorldSocket | C>P S | Received opcode "CMSG_ITEM_TEXT_QUERY" (12997).
21:34:07 | W | P | WorldSocket | C>P S | No handler for opcode "CMSG_ITEM_TEXT_QUERY" (12997) (Got unknown packet from ModernClient)
```

The opcode was mapped on **both** sides (legacy `0x243`, modern `12997`) and the response was already handled, so nothing looked missing in the tables — there was simply no `[PacketHandler]` registration to forward the client's request. Worth noting as the mirror image of the false positive in #210: there, a `0u` enum entry looked like a gap and wasn't; here, fully-populated tables hid a real one. Neither the enum nor the build warnings tell you whether a handler exists.

## The 3.3.0 layout change

3.3.0 moved letter bodies out of the `item_text` table and onto the item itself, and changed both packets with it:

| | pre-3.3 legacy | 3.3.0+ legacy | modern V3_4_3 |
|---|---|---|---|
| CMSG | `uint32` item_text id | `uint64` item GUID | packed GUID |
| SMSG | id + string | `uint8` no-text flag, GUID, string | `bit Valid`, `ItemTextCache`, GUID |

The existing response handler only understood the pre-3.3 form. It is used to fill in a pending mail list on older cores and still works there, because those cores also still send the old layout — the new branch is selected on `V3_3_0_10958` and forwards to the client instead of caching. The modern client only ever sends a GUID, so the CMSG bridge is 3.3.0+ only; on older backends the body continues to arrive through the mail-list path.

Note the legacy flag byte is inverted relative to the modern bit: legacy `0` means *has* text, so `Valid = (byte == 0)`.

Layouts confirmed against native — Wrathion `QueryPackets.cpp`:

```cpp
void ItemTextQuery::Read()  { _worldPacket >> Id; }

WorldPacket const* QueryItemTextResponse::Write()
{
    _worldPacket.WriteBit(Valid);
    _worldPacket.FlushBits();
    _worldPacket << Item;   // ItemTextCache: WriteBits(len, 13), FlushBits, WriteString
    _worldPacket << Id;
    return &_worldPacket;
}
```

`ItemTextCache` is written unconditionally, even when `Valid` is false, so the outgoing layout is fixed. The legacy side matches TrinityCore 3.3.5a `WorldSession::HandleItemTextQuery`.

## Testing

Found while verifying #216 on TrinityCore 3.3.5a with two real 3.4.3 clients. Before: `No handler`, letter never opens. After: `CMSG_ITEM_TEXT_QUERY` → legacy `579` → `SMSG_QUERY_ITEM_TEXT_RESPONSE` → modern `10526`, and the letter reads correctly.

The AzerothCore pass on #216 did not hit this because no letter item was ever created there.

`dotnet test` 1007 passed, 0 failed.

Refs #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124qGatxkc1Nxos98YeRtXw
