### PR TITLE
fix(v3_4_3): drop the ReferAFriendBonus float so live reputation gains apply

### DIFF
--- a/HermesProxy/World/Server/Packets/ReputationPackets.cs
+++ b/HermesProxy/World/Server/Packets/ReputationPackets.cs
@@ -16,6 +16,7 @@
  */
 
 
+using HermesProxy.Enums;
 using System;
 using Framework.Constants;
 using Framework.GameMath;
@@ -90,9 +91,21 @@ class SetFactionStanding : ServerPacket, ISpanWritable
 {
     public SetFactionStanding() : base(Opcode.SMSG_SET_FACTION_STANDING, ConnectionType.Instance) { }
 
+    /// <summary>
+    /// V3_4_3 dropped the leading ReferAFriendBonus float - native writes only
+    /// BonusFromAchievementSystem before the count (Wrathion SetFactionStanding::Write, whose
+    /// packet class has no such field; WowPacketParser's V3_4_0 parser agrees). Writing both made
+    /// the client read the second float as the faction count, i.e. zero, so a live reputation gain
+    /// updated nothing and only appeared after a relog re-seeded standings from
+    /// SMSG_INITIALIZE_FACTIONS. Older builds still carry it - WPP's V6_0_2 parser, which covers
+    /// V1_14 and V2_5, reads both.
+    /// </summary>
+    private static bool HasReferAFriendBonus => ModernVersion.Build != ClientVersionBuild.V3_4_3_54261;
+
     public override void Write()
     {
-        _worldPacket.WriteFloat(ReferAFriendBonus);
+        if (HasReferAFriendBonus)
+            _worldPacket.WriteFloat(ReferAFriendBonus);
         _worldPacket.WriteFloat(BonusFromAchievementSystem);
 
         _worldPacket.WriteInt32(Factions.Count);
@@ -105,7 +118,7 @@ class SetFactionStanding : ServerPacket, ISpanWritable
 
     // Cap for faction standing changes - usually just a few at once
     private const int MaxFactions = 16;
-    // 2 floats(8) + count(4) + factions(8 each) + 1 bit
+    // up to 2 floats(8) + count(4) + factions(8 each) + 1 bit
     public int MaxSize => 8 + 4 + MaxFactions * 8 + 1;
 
     public int WriteToSpan(Span<byte> buffer)
@@ -114,7 +127,8 @@ class SetFactionStanding : ServerPacket, ISpanWritable
             return -1;
 
         var writer = new SpanPacketWriter(buffer);
-        writer.WriteFloat(ReferAFriendBonus);
+        if (HasReferAFriendBonus)
+            writer.WriteFloat(ReferAFriendBonus);
         writer.WriteFloat(BonusFromAchievementSystem);
         writer.WriteInt32(Factions.Count);
         foreach (FactionStandingData factionStanding in Factions)


### PR DESCRIPTION
Reputation only moved after a relog. @kasperfriend reported it on AzerothCore in #213 — *"Reputation for Orgrimmar didn't count live, only after relog"* — and it reproduces on TrinityCore.

## One float too many

`SMSG_SET_FACTION_STANDING` was written with two leading floats:

```csharp
_worldPacket.WriteFloat(ReferAFriendBonus);
_worldPacket.WriteFloat(BonusFromAchievementSystem);
_worldPacket.WriteInt32(Factions.Count);
```

V3_4_3 has only one. Native's packet class has no `ReferAFriendBonus` field at all:

```cpp
class SetFactionStanding final : public ServerPacket
{
    float BonusFromAchievementSystem = 0.0f;
    std::vector<FactionStandingData> Faction;
    bool ShowVisual = false;
};

WorldPacket const* SetFactionStanding::Write()
{
    _worldPacket << float(BonusFromAchievementSystem);
    _worldPacket << uint32(Faction.size());
    ...
}
```

So the client read our **second float as the faction count** — zero — and applied no standings. Everything looked correct again after a relog only because `SMSG_INITIALIZE_FACTIONS` re-seeds the whole list, which is exactly the reported symptom.

The field is gone only in the Classic line, so the write is gated rather than removed:

| WPP module | leading floats |
|---|---|
| `V6_0_2` — covers V1_14 / V2_5 | **two** (`ReferAFriendBonus` + `BonusFromAchievementSystem`) |
| `V3_4_0`, `V4_4_0` | **one** |

Worth noting the capture attached to #213 *looks* correct when parsed, showing both floats and sensible indices — but that is WowPacketParser applying its pre-3.4.4 parser to a 54261 sniff of our own output, so it shares the same wrong assumption. WPP's V3_4_0 parser, registered at `V3_4_4_59817`, reads a single float and agrees with native.

## Testing

TrinityCore 3.3.5a at Booty Bay. Standings now move live, including across a rank boundary and into negative territory after killing a faction NPC — `-562` rendered correctly, so the signed `int32` survives the trip intact.

Also exercised while there, all working: faction visibility on gossip (`SMSG_SET_FACTION_VISIBLE`), watched faction on the XP bar, at war and not at war, and setting a faction inactive. The watched faction, the standing and the at-war flag all survive a relog.

One thing worth recording for anyone testing this: a faction is only added to the panel from `HandleGossipHelloOpcode`, and only for an NPC carrying `UNIT_NPC_FLAG_GOSSIP`. Clicking or targeting a mob never adds it — that looked like a bug until the log showed no gossip packet had been sent at all.

Refs #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124qGatxkc1Nxos98YeRtXw
