### PR TITLE
fix(ci): ignore pre-release tags when computing the release version

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -56,7 +56,17 @@ jobs:
             # --abbrev=0` returns the lower of two tags pointing at the
             # same commit (this once produced v4.3.8 → auto_bump=v4.3.9,
             # which collided with the already-published v4.3.9 release).
-            latest=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1)
+            # Exact vMAJOR.MINOR.PATCH only. PreRelease.yml publishes tags shaped
+            # v<floor>-<branch-slug>-<sha7>, which this glob also matches. While the
+            # floor sat below the newest release those sorted underneath it and did no
+            # harm; the moment the floor is raised above it (4.3.0 -> 4.4.0) a
+            # v4.4.0-feature-... tag sorts FIRST and the patch parse below dies on a
+            # non-numeric component ("value too great for base"). The step then exits
+            # mid-script under set -e, tag= is never written, and every build job
+            # silently receives an empty -p:Version=, failing inside GetAssemblyVersion.
+            latest=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' \
+                     | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                     | sort -V | tail -1 || true)
             latest="${latest:-v0.0.0}"
             # Strip 'v' prefix and normalize to major.minor.patch
             version="${latest#v}"
@@ -81,6 +91,12 @@ jobs:
             winner=$(printf "%s\n%s\n" "$auto_bump" "$floor" | sort -V | tail -1)
             tag="v${winner}"
             echo "Latest tag: $latest → auto=$auto_bump, floor(GitVersion.yml)=$floor → $tag"
+          fi
+          # Never hand an empty version downstream: without this the build jobs get
+          # -p:Version= and fail deep inside the SDK rather than here.
+          if [ -z "$tag" ]; then
+            echo "::error::Version computation produced an empty tag - refusing to build."
+            exit 1
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
The v4.4.0 release from #238 failed. Every build job reported

```
error MSB4044: The "GetAssemblyVersion" task was not given a value for the
required parameter "NuGetVersion"  [Framework/Framework.csproj]
```

which is a symptom three steps removed from the cause.

## Cause

The `version` job picks the newest release tag with

```bash
git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1
```

That glob also matches the tags `PreRelease.yml` publishes on every push to a feature branch, shaped `v<floor>-<branch-slug>-<sha7>`.

This was harmless while the floor sat below the newest release: every pre-release was `v4.3.0-…`, which version-sort places *under* `v4.3.29`. Raising the floor to 4.4.0 minted `v4.4.0-feature-wotlk-classic-v3-4-3-5f1a667`, which sorts **above** every real release tag, so `head -1` returned a pre-release.

The parse below then reached

```bash
patch="0-feature-wotlk-classic-v3-4-3-5f1a667"
next_patch=$((patch + 1))     # bash: value too great for base
```

Under `set -e` the step exited before writing `tag=`. The job still reported **success** with an empty output, so each build job got `-p:Version=` empty and failed inside the SDK four jobs later.

## Fix

- Match exact `vMAJOR.MINOR.PATCH` tags only, so pre-release tags can never be selected regardless of where the floor sits.
- Refuse to continue on an empty tag, so a future miscomputation fails in the `version` job with a clear message instead of silently producing unversioned builds.

Verified against the live tag list: `v4.3.29 → auto=4.3.30, floor=4.4.0 → v4.4.0`.

Merging this re-triggers `Release.yml` with the corrected script and publishes **v4.4.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019p1wW7nkNtVwYdvxmo7PVq
