### PR TITLE
feat(sourcegen): express create-path field visibility as flags

### DIFF
--- a/HermesProxy.SourceGen/CLAUDE.md
+++ b/HermesProxy.SourceGen/CLAUDE.md
@@ -1,4 +1,4 @@
-# HermesProxy.SourceGen
+# HermesProxy.SourceGen — handbook
 
 Roslyn source generators. They emit code that lands directly on the wire, so a mistake here
 does not throw — it produces a subtly malformed packet that the client silently drops or
@@ -8,7 +8,7 @@ mis-renders. Treat every change as a wire-format change.
 
 | Generator | Emits | Driven by |
 |---|---|---|
-| `ObjectUpdateBuilderGenerator` | `WriteCreate{Section}Data` / `WriteUpdate{Section}Data` on the per-version `ObjectUpdateBuilder` | `[DescriptorSection]` enums in `World/Enums/<build>/*Field.cs` |
+| `ObjectUpdateBuilderGenerator` | `WriteCreate{Section}Data` / `WriteUpdate{Section}Data` / `HasAny{Section}FieldSet` on the per-version `ObjectUpdateBuilder` | `[DescriptorSection]` enums in `World/Enums/<build>/*Field.cs` |
 | `OpcodeTableGenerator` | Opcode lookup tables | per-version `Opcode.cs` enums |
 | `UpdateFieldTableGenerator` | Legacy update-field tables | per-version update-field enums |
 
@@ -16,61 +16,234 @@ Generated output lands in `HermesProxy/obj/Generated/HermesProxy.SourceGen/...`.
 debugging — it is the actual code that runs, and diffing it is usually faster than reasoning
 about the attributes.
 
-## The descriptor tree (V3_4_3)
+---
 
-WotLK Classic replaced the legacy DWORD-indexed update-field system with retail's
-descriptor/change-set model. There is no `UpdateFieldsArray` to port. Instead each section's
-`*Field.cs` enum **is** the wire definition:
+# Part 1 — How the descriptor generator is built
 
-**Declaration order is wire order.** The generator emits Create writes in the order members
-appear. Migrating a hand-written block is therefore a strict top-down walk — no bit arithmetic.
+Read this before changing `ObjectUpdateBuilderGenerator.cs`. The rest of the file is easy to
+edit and easy to break, and both come from the same property: it is a string emitter with no
+type checking between the attribute you write and the code that comes out.
 
-Attribute vocabulary (`World/Objects/Version/Attributes/DescriptorAttributes.cs`):
+## The pipeline
 
-- `[DescriptorSection]` — marks the enum, sets `MaskMode` / `BlockMaskShape`
-- `[DescriptorCreateField]` — a Create write from a source property. Supports `ArrayCount`,
-  `ArrayMode` (`Grouped` / `PerElement`), `DefaultExpression`, `DefaultExpressionByIndex`,
-  `OwnerOnly`, `Cast`, `CustomWriter`
-- `[DescriptorUpdateField]` — the Update-path equivalent, keyed by changesMask bit
-- `[DescriptorCreatePlaceholder]` — a constant write (natural zero, or an explicit literal like
-  `"1f"`). With `CustomWriter` set it becomes a **positioned hook**: the generator emits
-  `{CustomWriter}(data, src);` at that point in the sequence
-- `[DescriptorCreateBitsPlaceholder]` — `WriteBits(value, n)` (+ optional `FlushBits`)
-- `[DescriptorMaskMutator]`, `[DescriptorMaskPreamble]`, `[DescriptorUpdateBitsPreamble]`,
-  `[DescriptorUpdatePostFlush]`, `[DescriptorCustomField]` — Update-path shaping
+Four stages, one per named group of methods in the file:
 
-Members with no descriptor attribute are skipped, so an enum can carry non-wire entries.
+```
+[Descriptor*] attribute        World/Enums/<build>/*Field.cs   — what you write
+        │
+        │  Read*(AttributeData)                                — parse: named args → values
+        ▼
+  *Entry record                                                — the generator's own model
+        │
+        │  Emit*(StringBuilder, …)                             — print C# as text
+        ▼
+  *.g.cs                                                       — what actually runs
+```
 
-### When to reach for a CustomWriter
+* **`BuildModel`** walks every `V*` namespace under `HermesProxy.World.Enums` and picks up any
+  enum carrying `[DescriptorSection]`. There is no registry and no naming convention to satisfy —
+  adding the attribute is what wires a section in.
+* **`BuildSection`** walks the enum's members in **declaration order** and turns each decorated
+  member into an entry. Create-path entries land in one ordered `CreateSequence` list (a
+  `(Kind, Payload)` tuple stream, because fields, placeholders and bit-placeholders interleave);
+  Update-path entries land in separate lists keyed by changesMask bit.
+* **`Read*`** methods parse one `AttributeData` into one record. Constructor arguments are
+  positional (`attrData.ConstructorArguments[n]`); everything else is a `switch` over
+  `attrData.NamedArguments`.
+* **`Emit*`** methods print text. `EmitCreate` walks `CreateSequence` in order; `EmitUpdate`
+  branches on `MaskMode` into `EmitUpdateFlat` or `EmitUpdateBlocks`; `EmitHasAny` emits the
+  "is anything set" predicate.
 
-The declarative form cannot express:
+**Declaration order is wire order** on the Create path. The generator emits Create writes in the
+order members appear, so migrating a hand-written block is a strict top-down walk — no bit
+arithmetic. The Update path is the opposite: it is ordered by changesMask bit, and
+`WriteOrder` exists for the cases where write order and bit order disagree.
 
-- **computed values** — e.g. `GetModernInvSlot` fans legacy slot arrays into the modern flat layout
+## The mirrored-enum rule
+
+The generator targets `netstandard2.0` and loads into the compiler. It **cannot reference the
+HermesProxy assembly**, so every attribute enum exists twice:
+
+| Real | Mirror |
+|---|---|
+| `World/Objects/Version/Attributes/DescriptorAttributes.cs` | private enums at the bottom of `ObjectUpdateBuilderGenerator.cs` |
+
+The mirrors are matched **by ordinal**, not by name — `(DescriptorType)typeOrdinal.Value` casts
+the boxed constant straight across. So:
+
+> **Adding a member to `DescriptorType`, `MaskMode`, `ArrayMode` or `BlockMaskShape` means adding
+> it to both copies, at the same ordinal. Append; never insert or reorder.** An inserted member
+> silently reinterprets every existing declaration as its neighbour, and nothing errors — you get
+> wrong bytes.
+
+`FieldVisibility` is the exception: it is `[Flags]`, so the generator works with the raw `int`
+and names the flags only when printing the guard. Adding a flag there means one line in
+`GateFor`, and the real enum stays the single definition.
+
+## Emitting names
+
+The generator prints fully-qualified names, because the generated file has no `using`
+directives — the `*FullName` consts at the top of the class exist for exactly this. When you
+emit a reference to a type, add a const rather than inlining the string; that is what makes a
+namespace rename a one-line change.
+
+## Diagnostics
+
+`HPSG003` fires when a `SourceProperty` names a member the section's `DataType` does not have,
+and the field is skipped. That is the only structural check.
+
+There is no diagnostic for the failure mode that actually costs a debugging session: a field in
+the *wrong position*. Nothing in the generator knows the wire layout, so nothing can. That is
+what the equivalence tests are for — see Part 3.
+
+---
+
+# Part 2 — Adding a capability
+
+The recipe, in the order that keeps the build green at every step.
+
+1. **Write the declaration you wish existed** in a `*Field.cs` enum. Start from the shape you
+   want at the call site, not from the generator.
+2. **Add the attribute member** in `DescriptorAttributes.cs`. A named property (settable, default
+   = "off") if it is optional; a constructor argument only if it is mandatory. Document what the
+   *generated code* looks like, not what the property means — the next reader is trying to
+   predict output.
+3. **If it introduces an enum**, mirror it in the generator at matching ordinals, per the rule
+   above. Prefer flags handled as `int` (like `FieldVisibility`) over a mirrored enum when the
+   values are a set rather than a choice; it avoids the ordinal coupling entirely.
+4. **Parse it** — one `case` in the relevant `Read*` method, plus a local initialised to the
+   "off" value. `VisibilityOrdinal` shows the trap: a byte-backed enum boxes as `byte`, not
+   `int`, so `as int?` silently yields null and your feature does nothing.
+5. **Carry it on the record.** Prefer carrying the *resolved decision* over the raw input —
+   `CreateFieldEntry.Gate` is a `string?` holding the guard condition, not a pair of flags the
+   emit sites would each have to interpret. Emit sites should print, not decide.
+6. **Emit it.** Grep for the sibling feature and match its indentation handling; the create-path
+   emitters thread a `baseIndent` local through every branch, and a missed one produces
+   compiling, misindented, correct code that reviews badly.
+7. **Prove the wire did not move.** Part 3.
+
+## Where the seams are
+
+Some things belong in the generator and some do not. The split that has held so far:
+
+| Belongs in the generator | Belongs in the hand-written `ObjectUpdateBuilder` |
+|---|---|
+| per-field writes, order, masks, guards | the packet envelope around the values blob |
+| anything repeated across sections | anything that needs session state (`_gameState`) |
+| anything a section's enum can express | computed values, interleaved arrays, fallbacks |
+
+The envelope is the load-bearing case. Each version's `WriteToPacket` / `WriteValuesCreate`
+writes the object header, the visibility byte and (on 5.5-engine builds) the fragment mask, then
+calls the generated per-section methods. Keeping the envelope hand-written is what let 3.4.3 and
+2.5.6 differ structurally without the generator learning about either.
+
+For the third row, the house pattern is a **positioned hook**: a `DescriptorCreatePlaceholder`
+with `CustomWriter` set emits `{CustomWriter}(data, src);` at that point in the sequence, so the
+callback keeps its place in wire order while the enum stays the index of what gets written. See
+`UnitField`'s `UNIT_STATS_INTERLEAVED_CUSTOM` / `UNIT_POWER_INTERLEAVED_CUSTOM` and the thirteen
+`WriteCreateActivePlayer*` hooks.
+
+Reach for a hook when the declarative form cannot express:
+
+- **computed values** — `GetModernInvSlot` fans legacy slot arrays into the modern flat layout
 - **session fallbacks** — `?? _gameState.SummonedBattlePetGuid` is not a literal default
-- **interleaved arrays** — N parallel arrays woven through one index loop. `ArrayCount` writes
-  one array's elements consecutively, which is a different wire shape
+- **interleaved arrays** — N parallel arrays woven through one index loop. `ArrayCount` writes one
+  array's elements consecutively, which is a different wire shape
 
-Interleaving is common enough to have a house pattern: position a `DescriptorCreatePlaceholder`
-with `CustomWriter` at the right point and let the callback weave. See `UnitField`'s
-`UNIT_STATS_INTERLEAVED_CUSTOM` / `UNIT_POWER_INTERLEAVED_CUSTOM`, and ActivePlayer's four
-`WriteCreateActivePlayer*Interleaved` writers.
+## Attribute vocabulary
 
-## Safety net — use it, do not skip it
+Declared in `World/Objects/Version/Attributes/DescriptorAttributes.cs`.
 
-Two independent layers, and they catch different things:
+**Section**
 
-1. **Byte-equivalence tests** (`HermesProxy.Tests/SourceGen/*SectionEquivalenceTests.cs`) —
-   a frozen copy of the hand-port is kept in the test project as an oracle, and
+- `[DescriptorSection]` — marks the enum. `DataType`, `MaskMode` (`Blocks` / `Flat`), `MaskWidth`,
+  `BlockMaskShape` (`Bits` / `UInt32PlusBits16`), `Cascade`. `SectionName` defaults to `DataType`
+  minus its `Data` suffix and drives the emitted method names. Block count is not declared — the
+  generator derives it as `(maxBit / 32) + 1` from the highest `bit` any update field claims.
+
+**Create path**
+
+- `[DescriptorCreateField]` — a write from a source property. `ArrayCount`, `ArrayMode`
+  (`Grouped` / `PerElement`), `DefaultExpression`, `DefaultExpressionByIndex`, `Visibility`,
+  `Cast`, `CustomWriter`
+- `[DescriptorCreatePlaceholder]` — a constant write (natural zero, or a literal like `"1f"`).
+  `Count` repeats it in a loop, for the zero-fill runs like `QuestCompleted[875]`. With
+  `CustomWriter` set it becomes a positioned hook instead
+- `[DescriptorCreateBitsPlaceholder]` — `WriteBits(value, n)`, plus `FlushBits` unless `Flush=false`
+
+Arrays longer than `LoopEmitThreshold` (8) with a uniform fallback emit as a loop rather than
+unrolled writes.
+
+**Update path**
+
+- `[DescriptorUpdateField]` — keyed by changesMask `bit`. `ParentBit`, `WriteOrder`,
+  `CustomPredicate`, `MaskOnly`
+- `[DescriptorMaskPreamble]`, `[DescriptorMaskMutator]`, `[DescriptorUpdateBitsPreamble]`,
+  `[DescriptorUpdatePostFlush]`, `[DescriptorCustomField]` — mask shaping
+
+Members with no descriptor attribute are skipped, so an enum can carry non-wire entries
+(sentinels, unmapped slots).
+
+## Create-path visibility
+
+From the 5.5 engine on, the values blob for a create carries a leading visibility byte — the
+client's `UF::UpdateFieldFlag` (`Owner` 0x01, `PartyMember` 0x02, `UnitAll` 0x04, `Empath` 0x08) —
+and the client gates its own reads on it.
+
+**The byte is a contract, not a hint.** Declaring a bit obliges the writer to emit every field
+that bit gates. Declare `PartyMember` and skip one of its fields and the client reads the next
+group from the wrong offset, drifts, and faults. So visibility and field-filling are one job.
+
+`Visibility` on a create-path attribute says which groups a field belongs to. The generator emits
+the write under a test against the builder's `FieldVisibilityFlags`, which is the same byte that
+leads the blob — writer and reader gate on one value.
+
+V3_4_3 is on this model too. It only ever declares `Owner | PartyMember` or nothing, so its
+`FieldVisibilityFlags` follows `IsOwner` and the whole thing reads as a boolean; that is why a
+`bool OwnerOnly` sufficed until 2.5.6 split the groups apart into 0x01 / 0x03 / 0x07.
+
+---
+
+# Part 3 — The safety net
+
+Two independent layers, catching different things. Use both.
+
+1. **Byte-equivalence tests** (`HermesProxy.Tests/SourceGen/*SectionEquivalenceTests.cs`) — a
+   frozen copy of the hand-port is kept in the test project as an oracle, and
    `Assert.Equal(expected.GetData(), actual.GetData())` proves the generated writer produces
    identical bytes across a scenario matrix. This is what makes migration safe.
 2. **Verify snapshots** (`ObjectUpdateBuilderGeneratorTests.*.verified.txt`) — pin the generated
-   *source*. A deliberate generator change will fail these; inspect the `.received.txt` diff,
-   confirm it contains only what you intended, then accept it. Snapshots are UTF-8 **with BOM,
-   CRLF** — preserve that when accepting by hand or the whole file shows as changed.
+   *source*. A deliberate generator change fails these by design.
 
 A green equivalence test plus a snapshot diff limited to your intended lines is strong evidence.
 Neither alone is. And neither proves the *oracle* is right — for anything user-visible, finish
 with a play-test.
+
+## Accepting a snapshot
+
+Confirm before accepting, then accept minimally:
+
+```bash
+diff --strip-trailing-cr <verified>.txt <received>.txt | grep '^[<>]' | grep -v '<the change you meant>'
+```
+
+An empty result means the diff contains only what you intended. `--strip-trailing-cr` is not
+optional: snapshots are UTF-8 **with BOM, CRLF**, the received file is not, and a plain `diff`
+reports every line as changed and hides the real one.
+
+Then edit the `.verified.txt` **in place** (binary substitution preserves the CRLF and BOM)
+rather than moving `.received.txt` over it — a move rewrites the line endings and turns a 70-line
+review into an 8694-line one.
+
+## Building
+
+A running proxy or a live language server holds `HermesProxy.SourceGen.dll`, and MSBuild then
+fails the *copy* with MSB3021/3027 **while reporting no `error CS`**. Kill the holder
+(`csharp-ls`, `dotnet`) and rebuild; do not read the compiler text alone.
+
+---
+
+# Part 4 — State of the port
 
 ## ActivePlayer Create migration — done
 
@@ -80,21 +253,16 @@ wire order, delete the matching lines from the remainder, run the equivalence te
 snapshot diff. The remainder shrank 293 → 177 → 91 → 0 lines.
 
 What is left is thirteen named, single-purpose `WriteCreateActivePlayer*` hooks, positioned by
-`DescriptorCreatePlaceholder(CustomWriter = …)`. Each one exists for a shape the per-field form
+`DescriptorCreatePlaceholder(CustomWriter = …)`. Each exists for a shape the per-field form
 genuinely cannot express — interleaved parallel arrays (`Skill`, `DamageDone`,
 `WeaponMultipliers`, `Buyback`), session-sourced state (`Glyphs`, `HeirloomCounts`,
-`SummonedBattlePet`), computed values (`InvSlots`, `KnownTitlesCount`, `DynamicPayloads`),
-a nested struct with a non-zero default (`RestInfo`), a cast that has to precede the
-null-coalesce (`PvPTierMax`), and bit-level element framing (`PvpInfo`).
+`SummonedBattlePet`), computed values (`InvSlots`, `KnownTitlesCount`, `DynamicPayloads`), a
+nested struct with a non-zero default (`RestInfo`), a cast that has to precede the null-coalesce
+(`PvPTierMax`), and bit-level element framing (`PvpInfo`).
 
 `ActivePlayerSectionEquivalenceTests.WriteCreateActivePlayerData_HandPort` is the frozen
-pre-migration oracle. **Do not "fix" that copy** — its value is that it does not change. It
-still pins the whole Create wire, so future edits to these members stay honest.
-
-Two attribute features exist for this migration and are worth reusing:
-`DescriptorCreatePlaceholder.Count` emits a literal in a loop (the zero-fill runs like
-`QuestCompleted[875]`), and create-path arrays longer than 8 slots with a uniform fallback emit
-as a loop rather than unrolled writes.
+pre-migration oracle. **Do not "fix" that copy** — its value is that it does not change. It still
+pins the whole Create wire, so future edits to these members stay honest.
 
 Still worth doing: several literal zeros are marked `live property exists, TODO per-element
 read` — `NoReagentCostMask`, `BagSlotFlags`, `BankBagSlotFlags`, `QuestCompleted`,
@@ -102,16 +270,32 @@ read` — `NoReagentCostMask`, `BagSlotFlags`, `BankBagSlotFlags`, `QuestComplet
 action-bar-reset bug (`8087167e`) while the generated Update path was correct; now that the
 positions are named members, filling one in is a one-line change.
 
+## Wiring a new section
+
+All nine object sections a WotLK backend actually sends are wired on both paths. Corpse and
+DynamicObject were the last two, and wiring them was not just a refactor — neither had an Update
+path and their Values deltas were being parsed and then dropped.
+
+If you wire another section, remember the third step: it needs a probe in `IsEmptyValuesDelta`
+(`World/Server/Packets/UpdatePackets.cs`), or its single-field deltas are filtered as "empty"
+before the builder ever runs.
+
 ## Not yet wired
 
-All nine object sections that a WotLK backend actually sends are wired on both paths.
-Corpse and DynamicObject were the last two (see the migration note above); wiring them was
-not just a refactor, because neither had an Update path and their Values deltas were being
-parsed and then dropped. If you wire another section, remember the third step: a section
-needs a probe in `IsEmptyValuesDelta` (`World/Server/Packets/UpdatePackets.cs`) or its
-single-field deltas get filtered as "empty" before the builder runs.
+- All 12 `*DynamicField` enums — dynamic fields go through custom callbacks
+- `AreaTrigger` / `Conversation` / `SceneObject` — enums exist, nothing wired, likely dead for a
+  WotLK backend
 
+## Known gaps for the 5.5 engine (2.5.6)
 
-- All 12 `*DynamicField` enums are unwired; dynamic fields are handled via custom callbacks
-- `AreaTrigger` / `Conversation` / `SceneObject` — enums exist, nothing wired, likely dead for
-  a WotLK backend
+Capabilities a 5.5-engine port needs that are **not** in the generator yet:
+
+- **`HasAny*FieldSet` is visibility-blind.** It answers "is any field set", where the 5.5 model
+  needs "is any field set *within the declared groups*". An empty group that still declares its
+  bit is the contract violation described above.
+- **Fragment-wrapped update masks.** `MaskMode` covers flat and blocks. On 5.5 those sit inside a
+  per-fragment mask plus a `u32 updateTypeFlag`. The envelope is hand-written per version, but the
+  generator must not emit a bare blocks mask for a section that lives under a fragment.
+- **Empty-delta form.** `EmitUpdateBlocks` early-outs with `if (blocksMask == 0) return;`. On 5.5,
+  writing a zero mask tears `CGObject` down — the empty update has its own well-formed shape, so
+  the early-out needs to become a per-section emission mode.

--- a/HermesProxy.SourceGen/ObjectUpdateBuilderGenerator.cs
+++ b/HermesProxy.SourceGen/ObjectUpdateBuilderGenerator.cs
@@ -30,6 +30,7 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
     private const string UpdateFieldAttrFullName = "HermesProxy.World.Objects.Version.Attributes.DescriptorUpdateFieldAttribute";
     private const string CreatePlaceholderAttrFullName = "HermesProxy.World.Objects.Version.Attributes.DescriptorCreatePlaceholderAttribute";
     private const string CreateBitsPlaceholderAttrFullName = "HermesProxy.World.Objects.Version.Attributes.DescriptorCreateBitsPlaceholderAttribute";
+    private const string FieldVisibilityFullName = "HermesProxy.World.Objects.Version.Attributes.FieldVisibility";
     private const string CustomFieldAttrFullName = "HermesProxy.World.Objects.Version.Attributes.DescriptorCustomFieldAttribute";
     private const string MaskPreambleAttrFullName = "HermesProxy.World.Objects.Version.Attributes.DescriptorMaskPreambleAttribute";
     private const string UpdateBitsPreambleAttrFullName = "HermesProxy.World.Objects.Version.Attributes.DescriptorUpdateBitsPreambleAttribute";
@@ -378,7 +379,7 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
         string? defaultExpressionByIndex = null;
         int arrayCount = 0;
         int arrayMode = 0;
-        bool ownerOnly = false;
+        int visibility = 0;
         string? customWriter = null;
         string? cast = null;
         foreach (var named in attrData.NamedArguments)
@@ -389,7 +390,7 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
                 case "DefaultExpressionByIndex": defaultExpressionByIndex = named.Value.Value as string; break;
                 case "ArrayCount": arrayCount = (named.Value.Value as int?) ?? 0; break;
                 case "ArrayMode": arrayMode = (named.Value.Value as int?) ?? 0; break;
-                case "OwnerOnly": ownerOnly = (named.Value.Value as bool?) ?? false; break;
+                case "Visibility": visibility = VisibilityOrdinal(named.Value.Value); break;
                 case "CustomWriter": customWriter = named.Value.Value as string; break;
                 case "Cast": cast = named.Value.Value as string; break;
             }
@@ -412,7 +413,7 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
             arrayCount: arrayCount,
             arrayMode: (ArrayMode)arrayMode,
             defaultExpressionByIndex: defaultExpressionByIndex,
-            ownerOnly: ownerOnly,
+            gate: GateFor(visibility),
             customWriter: customWriter,
             cast: cast);
     }
@@ -498,20 +499,20 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
             ? (attrData.ConstructorArguments[1].Value as string) ?? ""
             : "";
 
-        bool ownerOnly = false;
+        int visibility = 0;
         string? customWriter = null;
         int count = 0;
         foreach (var named in attrData.NamedArguments)
         {
             switch (named.Key)
             {
-                case "OwnerOnly": ownerOnly = (named.Value.Value as bool?) ?? false; break;
+                case "Visibility": visibility = VisibilityOrdinal(named.Value.Value); break;
                 case "CustomWriter": customWriter = named.Value.Value as string; break;
                 case "Count": count = (named.Value.Value as int?) ?? 0; break;
             }
         }
 
-        return new CreatePlaceholderEntry((DescriptorType)typeOrdinal.Value, literal, ownerOnly, customWriter, count);
+        return new CreatePlaceholderEntry((DescriptorType)typeOrdinal.Value, literal, GateFor(visibility), customWriter, count);
     }
 
     private static CreateBitsPlaceholderEntry? ReadCreateBitsPlaceholder(AttributeData attrData)
@@ -528,17 +529,53 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
             return null;
 
         bool flush = true;
-        bool ownerOnly = false;
+        int visibility = 0;
         foreach (var named in attrData.NamedArguments)
         {
             switch (named.Key)
             {
                 case "Flush": flush = (named.Value.Value as bool?) ?? true; break;
-                case "OwnerOnly": ownerOnly = (named.Value.Value as bool?) ?? false; break;
+                case "Visibility": visibility = VisibilityOrdinal(named.Value.Value); break;
             }
         }
 
-        return new CreateBitsPlaceholderEntry(value.Value, bitCount.Value, flush, ownerOnly);
+        return new CreateBitsPlaceholderEntry(value.Value, bitCount.Value, flush, GateFor(visibility));
+    }
+
+    /// <summary>
+    /// Reads a <c>Visibility</c> named argument. The attribute's enum is byte-backed, so the boxed
+    /// constant is a <c>byte</c> rather than the <c>int</c> the other named arguments hand back.
+    /// </summary>
+    private static int VisibilityOrdinal(object? value) => value switch
+    {
+        byte b => b,
+        int i => i,
+        _ => 0,
+    };
+
+    /// <summary>
+    /// The condition guarding one create-path write, or null when it is unconditional.
+    /// <para>
+    /// The test reads the builder's <c>FieldVisibilityFlags</c> — the same byte that leads the
+    /// values blob — so the writer gates on exactly the value the client gates its reads on. Every
+    /// build that emits a visibility byte uses this, V3_4_3 included; there it resolves to
+    /// <c>Owner | PartyMember</c> or nothing, which is why a boolean sufficed before 2.5.6 split
+    /// the groups apart.
+    /// </para>
+    /// </summary>
+    private static string? GateFor(int visibility)
+    {
+        if (visibility == 0)
+            return null;
+
+        var groups = new List<string>();
+        if ((visibility & 0x01) != 0) groups.Add(FieldVisibilityFullName + ".Owner");
+        if ((visibility & 0x02) != 0) groups.Add(FieldVisibilityFullName + ".PartyMember");
+        if ((visibility & 0x04) != 0) groups.Add(FieldVisibilityFullName + ".UnitAll");
+        if ((visibility & 0x08) != 0) groups.Add(FieldVisibilityFullName + ".Empath");
+
+        string mask = groups.Count == 1 ? groups[0] : "(" + string.Join(" | ", groups) + ")";
+        return "(FieldVisibilityFlags & " + mask + ") != 0";
     }
 
     private static string Emit(VersionEntry version)
@@ -605,8 +642,8 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
             else if (kind == CreateSequenceKind.Placeholder)
             {
                 var p = (CreatePlaceholderEntry)payload;
-                if (p.OwnerOnly) sb.AppendLine("        if (IsOwner) {");
-                string indent = p.OwnerOnly ? "            " : "        ";
+                if (p.Gate != null) sb.Append("        if (").Append(p.Gate).AppendLine(") {");
+                string indent = p.Gate != null ? "            " : "        ";
                 if (!string.IsNullOrEmpty(p.CustomWriter))
                 {
                     sb.Append(indent).Append(p.CustomWriter).AppendLine("(data, src);");
@@ -628,16 +665,16 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
                           .Append(literal).AppendLine(");");
                     }
                 }
-                if (p.OwnerOnly) sb.AppendLine("        }");
+                if (p.Gate != null) sb.AppendLine("        }");
             }
             else // BitsPlaceholder
             {
                 var b = (CreateBitsPlaceholderEntry)payload;
-                if (b.OwnerOnly) sb.AppendLine("        if (IsOwner) {");
-                string indent = b.OwnerOnly ? "            " : "        ";
+                if (b.Gate != null) sb.Append("        if (").Append(b.Gate).AppendLine(") {");
+                string indent = b.Gate != null ? "            " : "        ";
                 sb.Append(indent).Append("data.WriteBits(").Append(b.Value).Append("u, ").Append(b.BitCount).AppendLine(");");
                 if (b.Flush) sb.Append(indent).AppendLine("data.FlushBits();");
-                if (b.OwnerOnly) sb.AppendLine("        }");
+                if (b.Gate != null) sb.AppendLine("        }");
             }
         }
         sb.AppendLine("    }");
@@ -648,15 +685,15 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
 
     private static void EmitCreateField(StringBuilder sb, CreateFieldEntry f)
     {
-        string baseIndent = f.OwnerOnly ? "            " : "        ";
-        if (f.OwnerOnly) sb.AppendLine("        if (IsOwner) {");
+        string baseIndent = f.Gate != null ? "            " : "        ";
+        if (f.Gate != null) sb.Append("        if (").Append(f.Gate).AppendLine(") {");
 
         // Scalar field-level CustomWriter: delegate to a builder method, no inline write.
         // Array CustomWriter routes via the per-element loop branch below.
         if (f.ArrayCount == 0 && !string.IsNullOrEmpty(f.CustomWriter))
         {
             sb.Append(baseIndent).Append(f.CustomWriter).AppendLine("(data, src);");
-            if (f.OwnerOnly) sb.AppendLine("        }");
+            if (f.Gate != null) sb.AppendLine("        }");
             return;
         }
 
@@ -696,7 +733,7 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
                     sb.Append(baseIndent).Append("for (int i = 0; i < ").Append(f.ArrayCount).AppendLine("; i++)");
                     sb.Append(baseIndent).Append("    data.").Append(WriteMethodNameFor(f.Type))
                       .Append("(").Append(expr).AppendLine(");");
-                    if (f.OwnerOnly) sb.AppendLine("        }");
+                    if (f.Gate != null) sb.AppendLine("        }");
                     return;
                 }
 
@@ -757,7 +794,7 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
               .Append(valueExpr).AppendLine(");");
         }
 
-        if (f.OwnerOnly) sb.AppendLine("        }");
+        if (f.Gate != null) sb.AppendLine("        }");
     }
 
     private static void EmitUpdate(StringBuilder sb, SectionEntry section)
@@ -1343,7 +1380,7 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
         int arrayCount,
         ArrayMode arrayMode,
         string? defaultExpressionByIndex,
-        bool ownerOnly,
+        string? gate,
         string? customWriter,
         string? cast)
     {
@@ -1353,7 +1390,7 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
         public int ArrayCount => arrayCount;
         public ArrayMode ArrayMode => arrayMode;
         public string? DefaultExpressionByIndex => defaultExpressionByIndex;
-        public bool OwnerOnly => ownerOnly;
+        public string? Gate => gate;
         public string? CustomWriter => customWriter;
         public string? Cast => cast;
     }
@@ -1392,9 +1429,9 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
 
     private sealed record UpdateBitsPreambleEntry(uint Value, int BitCount);
 
-    private sealed record CreatePlaceholderEntry(DescriptorType Type, string LiteralExpression, bool OwnerOnly, string? CustomWriter, int Count);
+    private sealed record CreatePlaceholderEntry(DescriptorType Type, string LiteralExpression, string? Gate, string? CustomWriter, int Count);
 
-    private sealed record CreateBitsPlaceholderEntry(uint Value, int BitCount, bool Flush, bool OwnerOnly);
+    private sealed record CreateBitsPlaceholderEntry(uint Value, int BitCount, bool Flush, string? Gate);
 
     private sealed class MemberEntry
     {

--- a/HermesProxy.Tests/SourceGen/ObjectUpdateBuilderGeneratorTests.WriteCreateObjectData_V3_4_3_54261.verified.txt
+++ b/HermesProxy.Tests/SourceGen/ObjectUpdateBuilderGeneratorTests.WriteCreateObjectData_V3_4_3_54261.verified.txt
@@ -3296,13 +3296,13 @@ public partial class ObjectUpdateBuilder
         data.WritePackedGuid128(src.ContainedIn ?? HermesProxy.World.WowGuid128.Empty);
         data.WritePackedGuid128(src.Creator ?? HermesProxy.World.WowGuid128.Empty);
         data.WritePackedGuid128(src.GiftCreator ?? HermesProxy.World.WowGuid128.Empty);
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteUInt32(src.StackCount.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteUInt32(src.Duration.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteInt32(src.SpellCharges != null && src.SpellCharges[0].HasValue ? src.SpellCharges[0]!.Value : 0);
             data.WriteInt32(src.SpellCharges != null && src.SpellCharges[1].HasValue ? src.SpellCharges[1]!.Value : 0);
             data.WriteInt32(src.SpellCharges != null && src.SpellCharges[2].HasValue ? src.SpellCharges[2]!.Value : 0);
@@ -3325,29 +3325,29 @@ public partial class ObjectUpdateBuilder
         WriteEnchantmentCreate(data, src.Enchantment, 12);
         data.WriteInt32((int)src.PropertySeed.GetValueOrDefault());
         data.WriteInt32((int)src.RandomProperty.GetValueOrDefault());
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteUInt32(src.Durability.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteUInt32(src.MaxDurability.GetValueOrDefault());
         }
         data.WriteUInt32(src.CreatePlayedTime.GetValueOrDefault());
         data.WriteInt32(0);
         data.WriteInt64(0L);
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteUInt64(0uL);
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteUInt8((byte)0);
         }
         data.WriteUInt32(0u);
         WriteCreateItemGemsSize(data, src);
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteUInt32(0u);
         }
         data.WriteUInt32(0u);
         data.WriteUInt32(0u);
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteUInt16((ushort)0);
         }
         WriteCreateItemGemsBody(data, src);
@@ -3521,7 +3521,7 @@ public partial class ObjectUpdateBuilder
         data.WriteInt32(0);
         data.WriteUInt32(src.DuelTeam.GetValueOrDefault());
         data.WriteInt32(src.GuildTimeStamp.GetValueOrDefault());
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             WriteCreatePlayerQuestLog(data, src);
         }
         WriteCreatePlayerVisibleItems(data, src);
@@ -3800,7 +3800,7 @@ public partial class ObjectUpdateBuilder
         data.WriteUInt32(0u);
         data.WritePackedGuid128(src.Charm ?? HermesProxy.World.WowGuid128.Empty);
         data.WritePackedGuid128(src.Summon ?? HermesProxy.World.WowGuid128.Empty);
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WritePackedGuid128(src.Critter ?? HermesProxy.World.WowGuid128.Empty);
         }
         data.WritePackedGuid128(src.CharmedBy ?? HermesProxy.World.WowGuid128.Empty);
@@ -3819,7 +3819,7 @@ public partial class ObjectUpdateBuilder
         WriteCreateUnitSexId(data, src);
         data.WriteUInt8((byte)src.DisplayPower.GetValueOrDefault());
         data.WriteUInt32(0u);
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             WriteCreateUnitOwnerFloatPairs(data, src);
         }
         WriteCreateUnitPowerInterleaved(data, src);
@@ -3840,7 +3840,7 @@ public partial class ObjectUpdateBuilder
         data.WriteUInt32(src.AuraState.GetValueOrDefault());
         data.WriteUInt32(src.AttackRoundBaseTime != null && src.AttackRoundBaseTime[0].HasValue ? src.AttackRoundBaseTime[0]!.Value : 0u);
         data.WriteUInt32(src.AttackRoundBaseTime != null && src.AttackRoundBaseTime[1].HasValue ? src.AttackRoundBaseTime[1]!.Value : 0u);
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             WriteCreateUnitRangedAttackTime(data, src);
         }
         data.WriteFloat(src.BoundingRadius ?? 0.389f);
@@ -3849,16 +3849,16 @@ public partial class ObjectUpdateBuilder
         data.WriteInt32(src.NativeDisplayID.GetValueOrDefault());
         data.WriteFloat(1f);
         data.WriteInt32(src.MountDisplayID.GetValueOrDefault());
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteFloat(src.MinDamage.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteFloat(src.MaxDamage.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteFloat(src.MinOffHandDamage.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteFloat(src.MaxOffHandDamage.GetValueOrDefault());
         }
         data.WriteUInt8(src.StandState.GetValueOrDefault());
@@ -3879,61 +3879,61 @@ public partial class ObjectUpdateBuilder
         data.WriteInt32(src.EmoteState.GetValueOrDefault());
         data.WriteInt16((short)0);
         data.WriteInt16((short)0);
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             WriteCreateUnitStatsInterleaved(data, src);
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             WriteCreateUnitResistances(data, src);
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             WriteCreateUnitPowerCostInterleaved(data, src);
         }
         WriteCreateUnitResistanceBuffModsInterleaved(data, src);
         data.WriteInt32(src.BaseMana.GetValueOrDefault());
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteInt32(src.BaseHealth.GetValueOrDefault());
         }
         data.WriteUInt8(src.SheatheState.GetValueOrDefault());
         data.WriteUInt8(src.PvpFlags.GetValueOrDefault());
         data.WriteUInt8(src.PetFlags.GetValueOrDefault());
         data.WriteUInt8(src.ShapeshiftForm.GetValueOrDefault());
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteInt32(src.AttackPower.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteInt32(src.AttackPowerModPos.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteInt32(src.AttackPowerModNeg.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteFloat(src.AttackPowerMultiplier.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteInt32(src.RangedAttackPower.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteInt32(src.RangedAttackPowerModPos.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteInt32(src.RangedAttackPowerModNeg.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteFloat(src.RangedAttackPowerMultiplier.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteInt32(0);
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteFloat(0f);
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteFloat(src.MinRangedDamage.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteFloat(src.MaxRangedDamage.GetValueOrDefault());
         }
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WriteFloat(src.MaxHealthModifier ?? 1f);
         }
         data.WriteFloat(src.HoverHeight.GetValueOrDefault());
@@ -3956,7 +3956,7 @@ public partial class ObjectUpdateBuilder
         data.WriteInt32(0);
         data.WriteFloat(0f);
         data.WriteUInt32(0u);
-        if (IsOwner) {
+        if ((FieldVisibilityFlags & HermesProxy.World.Objects.Version.Attributes.FieldVisibility.Owner) != 0) {
             data.WritePackedGuid128(HermesProxy.World.WowGuid128.Empty);
         }
         WriteCreateUnitChannelObjectsBody(data, src);

--- a/HermesProxy/World/Enums/V3_4_3_54261/ItemField.cs
+++ b/HermesProxy/World/Enums/V3_4_3_54261/ItemField.cs
@@ -1,4 +1,4 @@
-using HermesProxy.World.Objects;
+﻿using HermesProxy.World.Objects;
 using HermesProxy.World.Objects.Version.Attributes;
 
 namespace HermesProxy.World.Enums.V3_4_3_54261;
@@ -53,16 +53,16 @@ public enum ItemField
     ITEM_GIFT_CREATOR,
 
     // Owner-only region: StackCount, Duration, then SpellCharges[5] per-element.
-    [DescriptorCreateField(nameof(ItemData.StackCount), DescriptorType.UInt32, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(ItemData.StackCount), DescriptorType.UInt32, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(ItemData.StackCount), DescriptorType.UInt32, bit: 7, ParentBit = 0)]
     ITEM_STACK_COUNT,
 
-    [DescriptorCreateField(nameof(ItemData.Duration), DescriptorType.UInt32, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(ItemData.Duration), DescriptorType.UInt32, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(ItemData.Duration), DescriptorType.UInt32, bit: 8, ParentBit = 0)]
     ITEM_DURATION,
 
     [DescriptorCreateField(nameof(ItemData.SpellCharges), DescriptorType.Int32,
-                           ArrayCount = 5, ArrayMode = ArrayMode.PerElement, OwnerOnly = true)]
+                           ArrayCount = 5, ArrayMode = ArrayMode.PerElement, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(ItemData.SpellCharges), DescriptorType.Int32, bit: 24,
                            ArrayCount = 5, ArrayMode = ArrayMode.PerElement, ParentBit = 23)]
     ITEM_SPELL_CHARGES,
@@ -92,11 +92,11 @@ public enum ItemField
     ITEM_RANDOM_PROPERTY,
 
     // Owner-only durability pair.
-    [DescriptorCreateField(nameof(ItemData.Durability), DescriptorType.UInt32, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(ItemData.Durability), DescriptorType.UInt32, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(ItemData.Durability), DescriptorType.UInt32, bit: 12, ParentBit = 0)]
     ITEM_DURABILITY,
 
-    [DescriptorCreateField(nameof(ItemData.MaxDurability), DescriptorType.UInt32, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(ItemData.MaxDurability), DescriptorType.UInt32, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(ItemData.MaxDurability), DescriptorType.UInt32, bit: 13, ParentBit = 0)]
     ITEM_MAX_DURABILITY,
 
@@ -130,10 +130,10 @@ public enum ItemField
     [DescriptorCreatePlaceholder(DescriptorType.Int64)]
     ITEM_PAD_INT64,
 
-    [DescriptorCreatePlaceholder(DescriptorType.UInt64, OwnerOnly = true)]
+    [DescriptorCreatePlaceholder(DescriptorType.UInt64, Visibility = FieldVisibility.Owner)]
     ITEM_PAD_OWNER_UINT64,
 
-    [DescriptorCreatePlaceholder(DescriptorType.UInt8, OwnerOnly = true)]
+    [DescriptorCreatePlaceholder(DescriptorType.UInt8, Visibility = FieldVisibility.Owner)]
     ITEM_PAD_OWNER_UINT8,
 
     // ArtifactPowers.size() — stays zero-size; artifacts do not exist in this content
@@ -148,7 +148,7 @@ public enum ItemField
     ITEM_GEMS_SIZE_CREATE,
 
     // DynamicFlags2
-    [DescriptorCreatePlaceholder(DescriptorType.UInt32, OwnerOnly = true)]
+    [DescriptorCreatePlaceholder(DescriptorType.UInt32, Visibility = FieldVisibility.Owner)]
     ITEM_PAD_OWNER_UINT32,
 
     // ItemBonusKey: Int32 ItemID + UInt32 BonusListIDs.size() (always 0 here).
@@ -159,7 +159,7 @@ public enum ItemField
     ITEM_PAD_UINT32_4,
 
     // DEBUGItemLevel
-    [DescriptorCreatePlaceholder(DescriptorType.UInt16, OwnerOnly = true)]
+    [DescriptorCreatePlaceholder(DescriptorType.UInt16, Visibility = FieldVisibility.Owner)]
     ITEM_PAD_OWNER_UINT16,
 
     // Gems payload — ArtifactPowers[] elements would precede it, but that field is

--- a/HermesProxy/World/Enums/V3_4_3_54261/PlayerField.cs
+++ b/HermesProxy/World/Enums/V3_4_3_54261/PlayerField.cs
@@ -1,4 +1,4 @@
-using HermesProxy.World.Objects;
+﻿using HermesProxy.World.Objects;
 using HermesProxy.World.Objects.Version.Attributes;
 
 namespace HermesProxy.World.Enums.V3_4_3_54261;
@@ -97,7 +97,7 @@ public enum PlayerField
     PLAYER_GUILD_TIMESTAMP,
 
     // QuestLog Create — owner-gated 25× quest entries (custom writer drops the hand-port trace log).
-    [DescriptorCreatePlaceholder(DescriptorType.Int64, OwnerOnly = true, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreatePlayerQuestLog))]
+    [DescriptorCreatePlaceholder(DescriptorType.Int64, Visibility = FieldVisibility.Owner, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreatePlayerQuestLog))]
     PLAYER_QUEST_LOG_CUSTOM,
 
     // VisibleItems Create — 19× always-write (zero fallback for null entries).

--- a/HermesProxy/World/Enums/V3_4_3_54261/UnitField.cs
+++ b/HermesProxy/World/Enums/V3_4_3_54261/UnitField.cs
@@ -1,4 +1,4 @@
-using HermesProxy.World.Objects;
+﻿using HermesProxy.World.Objects;
 using HermesProxy.World.Objects.Version.Attributes;
 
 namespace HermesProxy.World.Enums.V3_4_3_54261;
@@ -61,7 +61,7 @@ public enum UnitField
     [DescriptorCreateField(nameof(UnitData.Summon), DescriptorType.PackedGuid128)]
     [DescriptorUpdateField(nameof(UnitData.Summon), DescriptorType.PackedGuid128, bit: 12)]
     UNIT_SUMMON,
-    [DescriptorCreateField(nameof(UnitData.Critter), DescriptorType.PackedGuid128, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.Critter), DescriptorType.PackedGuid128, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.Critter), DescriptorType.PackedGuid128, bit: 13)]
     UNIT_CRITTER_OWNER,
     [DescriptorCreateField(nameof(UnitData.CharmedBy), DescriptorType.PackedGuid128)]
@@ -129,7 +129,7 @@ public enum UnitField
 
     // ---- Owner float pairs + Power interleaved (Create-only via custom writer) ----
 
-    [DescriptorCreatePlaceholder(DescriptorType.Float, OwnerOnly = true, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitOwnerFloatPairs))]
+    [DescriptorCreatePlaceholder(DescriptorType.Float, Visibility = FieldVisibility.Owner, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitOwnerFloatPairs))]
     UNIT_OWNER_FLOAT_PAIRS_CUSTOM,
 
     [DescriptorCreatePlaceholder(DescriptorType.Int32, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitPowerInterleaved))]
@@ -200,7 +200,7 @@ public enum UnitField
 
     // ---- RangedAttackRoundBaseTime owner-only Create (bow-fallback) ----
 
-    [DescriptorCreatePlaceholder(DescriptorType.UInt32, OwnerOnly = true, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitRangedAttackTime))]
+    [DescriptorCreatePlaceholder(DescriptorType.UInt32, Visibility = FieldVisibility.Owner, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitRangedAttackTime))]
     UNIT_RANGED_ATTACK_ROUND_TIME_CUSTOM,
 
     // ---- BoundingRadius / CombatReach / NativeDisplayID / MountDisplayID + padding ----
@@ -228,16 +228,16 @@ public enum UnitField
 
     // ---- Damage fields (owner-only Create, unconditional Update) ----
 
-    [DescriptorCreateField(nameof(UnitData.MinDamage), DescriptorType.Float, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.MinDamage), DescriptorType.Float, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.MinDamage), DescriptorType.Float, bit: 52)]
     UNIT_MIN_DAMAGE,
-    [DescriptorCreateField(nameof(UnitData.MaxDamage), DescriptorType.Float, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.MaxDamage), DescriptorType.Float, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.MaxDamage), DescriptorType.Float, bit: 53)]
     UNIT_MAX_DAMAGE,
-    [DescriptorCreateField(nameof(UnitData.MinOffHandDamage), DescriptorType.Float, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.MinOffHandDamage), DescriptorType.Float, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.MinOffHandDamage), DescriptorType.Float, bit: 54)]
     UNIT_MIN_OFF_HAND_DAMAGE,
-    [DescriptorCreateField(nameof(UnitData.MaxOffHandDamage), DescriptorType.Float, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.MaxOffHandDamage), DescriptorType.Float, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.MaxOffHandDamage), DescriptorType.Float, bit: 55)]
     UNIT_MAX_OFF_HAND_DAMAGE,
 
@@ -299,13 +299,13 @@ public enum UnitField
 
     // ---- Stats/Resistances/PowerCost/ResBuffMods interleaved groups (Create custom-writer placeholders) ----
 
-    [DescriptorCreatePlaceholder(DescriptorType.Int32, OwnerOnly = true, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitStatsInterleaved))]
+    [DescriptorCreatePlaceholder(DescriptorType.Int32, Visibility = FieldVisibility.Owner, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitStatsInterleaved))]
     UNIT_STATS_INTERLEAVED_CUSTOM,
 
-    [DescriptorCreatePlaceholder(DescriptorType.Int32, OwnerOnly = true, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitResistances))]
+    [DescriptorCreatePlaceholder(DescriptorType.Int32, Visibility = FieldVisibility.Owner, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitResistances))]
     UNIT_RESISTANCES_CUSTOM,
 
-    [DescriptorCreatePlaceholder(DescriptorType.Int32, OwnerOnly = true, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitPowerCostInterleaved))]
+    [DescriptorCreatePlaceholder(DescriptorType.Int32, Visibility = FieldVisibility.Owner, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitPowerCostInterleaved))]
     UNIT_POWER_COST_INTERLEAVED_CUSTOM,
 
     [DescriptorCreatePlaceholder(DescriptorType.Int32, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitResistanceBuffModsInterleaved))]
@@ -317,7 +317,7 @@ public enum UnitField
     [DescriptorUpdateField(nameof(UnitData.BaseMana), DescriptorType.Int32, bit: 75)]
     UNIT_BASE_MANA,
 
-    [DescriptorCreateField(nameof(UnitData.BaseHealth), DescriptorType.Int32, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.BaseHealth), DescriptorType.Int32, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.BaseHealth), DescriptorType.Int32, bit: 76)]
     UNIT_BASE_HEALTH_OWNER,
 
@@ -338,43 +338,43 @@ public enum UnitField
 
     // ---- AttackPower block (owner-only Create, unconditional Update) ----
 
-    [DescriptorCreateField(nameof(UnitData.AttackPower), DescriptorType.Int32, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.AttackPower), DescriptorType.Int32, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.AttackPower), DescriptorType.Int32, bit: 81)]
     UNIT_ATTACK_POWER,
-    [DescriptorCreateField(nameof(UnitData.AttackPowerModPos), DescriptorType.Int32, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.AttackPowerModPos), DescriptorType.Int32, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.AttackPowerModPos), DescriptorType.Int32, bit: 82)]
     UNIT_ATTACK_POWER_MOD_POS,
-    [DescriptorCreateField(nameof(UnitData.AttackPowerModNeg), DescriptorType.Int32, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.AttackPowerModNeg), DescriptorType.Int32, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.AttackPowerModNeg), DescriptorType.Int32, bit: 83)]
     UNIT_ATTACK_POWER_MOD_NEG,
-    [DescriptorCreateField(nameof(UnitData.AttackPowerMultiplier), DescriptorType.Float, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.AttackPowerMultiplier), DescriptorType.Float, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.AttackPowerMultiplier), DescriptorType.Float, bit: 84)]
     UNIT_ATTACK_POWER_MULTIPLIER,
-    [DescriptorCreateField(nameof(UnitData.RangedAttackPower), DescriptorType.Int32, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.RangedAttackPower), DescriptorType.Int32, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.RangedAttackPower), DescriptorType.Int32, bit: 85)]
     UNIT_RANGED_ATTACK_POWER,
-    [DescriptorCreateField(nameof(UnitData.RangedAttackPowerModPos), DescriptorType.Int32, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.RangedAttackPowerModPos), DescriptorType.Int32, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.RangedAttackPowerModPos), DescriptorType.Int32, bit: 86)]
     UNIT_RANGED_ATTACK_POWER_MOD_POS,
-    [DescriptorCreateField(nameof(UnitData.RangedAttackPowerModNeg), DescriptorType.Int32, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.RangedAttackPowerModNeg), DescriptorType.Int32, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.RangedAttackPowerModNeg), DescriptorType.Int32, bit: 87)]
     UNIT_RANGED_ATTACK_POWER_MOD_NEG,
-    [DescriptorCreateField(nameof(UnitData.RangedAttackPowerMultiplier), DescriptorType.Float, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.RangedAttackPowerMultiplier), DescriptorType.Float, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.RangedAttackPowerMultiplier), DescriptorType.Float, bit: 88)]
     UNIT_RANGED_ATTACK_POWER_MULTIPLIER,
 
-    [DescriptorCreatePlaceholder(DescriptorType.Int32, OwnerOnly = true)]
+    [DescriptorCreatePlaceholder(DescriptorType.Int32, Visibility = FieldVisibility.Owner)]
     UNIT_PAD_INT32_OWNER,
-    [DescriptorCreatePlaceholder(DescriptorType.Float, OwnerOnly = true)]
+    [DescriptorCreatePlaceholder(DescriptorType.Float, Visibility = FieldVisibility.Owner)]
     UNIT_PAD_FLOAT_OWNER,
 
-    [DescriptorCreateField(nameof(UnitData.MinRangedDamage), DescriptorType.Float, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.MinRangedDamage), DescriptorType.Float, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.MinRangedDamage), DescriptorType.Float, bit: 91)]
     UNIT_MIN_RANGED_DAMAGE,
-    [DescriptorCreateField(nameof(UnitData.MaxRangedDamage), DescriptorType.Float, OwnerOnly = true)]
+    [DescriptorCreateField(nameof(UnitData.MaxRangedDamage), DescriptorType.Float, Visibility = FieldVisibility.Owner)]
     [DescriptorUpdateField(nameof(UnitData.MaxRangedDamage), DescriptorType.Float, bit: 92)]
     UNIT_MAX_RANGED_DAMAGE,
-    [DescriptorCreateField(nameof(UnitData.MaxHealthModifier), DescriptorType.Float, OwnerOnly = true, DefaultExpression = "1f")]
+    [DescriptorCreateField(nameof(UnitData.MaxHealthModifier), DescriptorType.Float, Visibility = FieldVisibility.Owner, DefaultExpression = "1f")]
     [DescriptorUpdateField(nameof(UnitData.MaxHealthModifier), DescriptorType.Float, bit: 93)]
     UNIT_MAX_HEALTH_MODIFIER,
 
@@ -447,7 +447,7 @@ public enum UnitField
     [DescriptorCreatePlaceholder(DescriptorType.UInt32)]
     UNIT_PAD_16,
 
-    [DescriptorCreatePlaceholder(DescriptorType.PackedGuid128, OwnerOnly = true)]
+    [DescriptorCreatePlaceholder(DescriptorType.PackedGuid128, Visibility = FieldVisibility.Owner)]
     UNIT_PAD_GUID_OWNER,
 
     [DescriptorCreatePlaceholder(DescriptorType.PackedGuid128, CustomWriter = nameof(HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.WriteCreateUnitChannelObjectsBody))]

--- a/HermesProxy/World/Objects/Version/Attributes/DescriptorAttributes.cs
+++ b/HermesProxy/World/Objects/Version/Attributes/DescriptorAttributes.cs
@@ -181,11 +181,14 @@ public sealed class DescriptorCreateFieldAttribute : Attribute
     public ArrayMode ArrayMode { get; set; }
 
     /// <summary>
-    /// When true, generator wraps this field's Create-path write in <c>if (IsOwner) { … }</c>.
-    /// Matches the existing <c>ObjectUpdateBuilder.IsOwner</c> property used by the hand-port.
-    /// Update path is unaffected — it relies on field presence (<c>.HasValue</c>) alone.
+    /// Viewer groups this write belongs to — the client's <c>UF::UpdateFieldFlag</c>. The generator
+    /// emits the write under a test against the builder's <c>FieldVisibilityFlags</c>, which is the
+    /// same byte that leads the values blob, so writer and reader gate on one value. Unset means
+    /// unconditional.
     /// </summary>
-    public bool OwnerOnly { get; set; }
+    public FieldVisibility Visibility { get; set; }
+    /// <remarks>Create path only. The Update path gates on field presence
+    /// (<c>.HasValue</c>) alone.</remarks>
 
     /// <summary>
     /// Optional method name on <c>ObjectUpdateBuilder</c> to delegate the wire write to.
@@ -506,9 +509,12 @@ public sealed class DescriptorCreatePlaceholderAttribute : Attribute
     public string LiteralExpression { get; }
 
     /// <summary>
-    /// When true, generator wraps this placeholder write in <c>if (IsOwner) { … }</c>.
+    /// Viewer groups this write belongs to — the client's <c>UF::UpdateFieldFlag</c>. The generator
+    /// emits the write under a test against the builder's <c>FieldVisibilityFlags</c>, which is the
+    /// same byte that leads the values blob, so writer and reader gate on one value. Unset means
+    /// unconditional.
     /// </summary>
-    public bool OwnerOnly { get; set; }
+    public FieldVisibility Visibility { get; set; }
 
     /// <summary>
     /// Repeat count. When greater than 1 the generator emits a <c>for</c> loop writing the
@@ -552,8 +558,13 @@ public sealed class DescriptorCreateBitsPlaceholderAttribute : Attribute
     /// <summary>When true, generator emits <c>FlushBits()</c> immediately after the bits write.</summary>
     public bool Flush { get; set; } = true;
 
-    /// <summary>When true, wraps the bit-write (and optional flush) in <c>if (IsOwner) { … }</c>.</summary>
-    public bool OwnerOnly { get; set; }
+    /// <summary>
+    /// Viewer groups this bit-write (and its optional flush) belongs to — the client's <c>UF::UpdateFieldFlag</c>. The generator
+    /// emits the write under a test against the builder's <c>FieldVisibilityFlags</c>, which is the
+    /// same byte that leads the values blob, so writer and reader gate on one value. Unset means
+    /// unconditional.
+    /// </summary>
+    public FieldVisibility Visibility { get; set; }
 }
 
 /// <summary>
@@ -572,4 +583,32 @@ public enum DescriptorType
     Int16,
     UInt16,
     PackedGuid128,
+}
+
+/// <summary>
+/// The client's <c>UF::UpdateFieldFlag</c>: which viewer groups a create-path field belongs to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// From 5.5.0 (2.5.6 / 3.4.x-successor engines) the values blob for a create carries a leading
+/// visibility byte and the client gates its own reads on it. The byte is a <b>contract, not a
+/// hint</b>: declaring a bit obliges the writer to emit every field that bit gates, or the client
+/// reads the next group from the wrong offset, drifts, and faults. So visibility and field-filling
+/// are one job, and a field's <see cref="DescriptorCreateFieldAttribute.Visibility"/> is what tells
+/// the generator which of the declared groups it belongs to.
+/// </para>
+/// <para>
+/// V3_4_3 writes the same byte and always writes <c>Owner | PartyMember</c> or nothing, so it reads
+/// as a single boolean there — but it is the same mechanism, and expressing it as flags is what lets
+/// 2.5.6 split the groups apart (0x01 / 0x03 / 0x07) without a second vocabulary.
+/// </para>
+/// </remarks>
+[Flags]
+public enum FieldVisibility : byte
+{
+    None = 0x00,
+    Owner = 0x01,
+    PartyMember = 0x02,
+    UnitAll = 0x04,
+    Empath = 0x08,
 }

--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -11,6 +11,7 @@
 using Framework.GameMath;
 using Framework.Util;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Objects.Version.Attributes;
 using HermesProxy.World.Server;
 using HermesProxy.World.Server.Packets;
 using System;
@@ -73,6 +74,16 @@ public partial class ObjectUpdateBuilder
         _realObjectType == ObjectTypeBCC.ActivePlayer ||
         _realObjectType == ObjectTypeBCC.Item ||
         _realObjectType == ObjectTypeBCC.Container;
+
+    /// <summary>
+    /// The values blob's leading visibility byte, and the gate the generated create writers test
+    /// per field. This build only ever declares both groups or neither — PartyMember is what makes
+    /// QuestLog visible, and nothing here is party-visible without also being owner-visible — so
+    /// the whole byte follows <see cref="IsOwner"/>. Builds that separate the groups override the
+    /// flags per object instead.
+    /// </summary>
+    private FieldVisibility FieldVisibilityFlags =>
+        IsOwner ? FieldVisibility.Owner | FieldVisibility.PartyMember : FieldVisibility.None;
 
     private bool IsGameObjectOwner
     {
@@ -1483,8 +1494,7 @@ public partial class ObjectUpdateBuilder
         var effectiveMask = _objectTypeMask;
         bool trace = _objectType == ObjectTypeBCC.ActivePlayer;
 
-        // Owner=0x01, PartyMember=0x02 (needed for QuestLog visibility).
-        byte updateFieldFlags = (byte)(IsOwner ? 0x03 : 0);
+        byte updateFieldFlags = (byte)FieldVisibilityFlags;
         data.WriteUInt8(updateFieldFlags);
 
         int p0 = data.GetData().Length;


### PR DESCRIPTION
Groundwork in `ObjectUpdateBuilderGenerator` for the 2.5.6 / 5.5-engine port (#108). No behaviour change on any current backend.

## What and why

From the 5.5 engine on, the values blob for a create carries a leading visibility byte — the client's `UF::UpdateFieldFlag` (`Owner` 0x01, `PartyMember` 0x02, `UnitAll` 0x04, `Empath` 0x08) — and the client gates its own reads on it.

The byte is a **contract, not a hint**. Declaring a bit obliges the writer to emit every field that bit gates; skip one and the client reads the next group from the wrong offset, drifts, and faults. Visibility and field-filling are one job, so the generator has to know per field which groups it belongs to.

`OwnerOnly` could not express that — one boolean over a four-group space. It becomes a `Visibility` flags property, and the boolean carried through the generator becomes the guard *condition* it produced, so emit sites print rather than decide.

## Why `OwnerOnly` is deleted rather than kept alongside

V3_4_3 is already on this model. `WriteValuesCreate` writes:

```csharp
byte updateFieldFlags = (byte)(IsOwner ? 0x03 : 0);
```

It just never declares more than `Owner | PartyMember` or nothing, so a boolean covered it. 2.5.6 splits the groups apart (0x01 / 0x03 / 0x07), and keeping both spellings would mean maintaining two ways to say one thing across every descriptor the port adds.

So V3_4_3's builder now derives `FieldVisibilityFlags` from `IsOwner`, the leading byte is written from it instead of a literal `0x03`, and the 35 field declarations say `Visibility = FieldVisibility.Owner` (25 `UnitField`, 9 `ItemField`, 1 `PlayerField`).

## The wire does not move

Equivalent by construction:

| before | after |
|---|---|
| `if (IsOwner)` | `if ((FieldVisibilityFlags & FieldVisibility.Owner) != 0)` |
| `IsOwner ? 0x03 : 0` | `(byte)(Owner \| PartyMember)` |

Checked rather than assumed — the generated `V3_4_3_54261.ObjectUpdateBuilder.g.cs` was diffed against a pre-change baseline:

- **70 changed lines, all 35 guard pairs, nothing else.** No field, order, mask or literal moved.
- Build clean, **1016/1016 tests pass**, including the per-section byte-equivalence tests against the frozen hand-port oracles.
- The Verify snapshot is re-baselined to the same 70 lines.

**Not playtested.** The equivalence proof above is why: the generated writers are byte-identical in every scenario the matrix covers, so there is no new wire behaviour for a session to exercise. Worth one 3.4.3 login anyway before merge if you want belt and braces.

## Handbook

`HermesProxy.SourceGen/CLAUDE.md` is rewritten. The old note described the descriptor vocabulary but not the machine behind it, so adding a capability meant re-deriving the generator's shape from 1400 lines of string emission — and it still documented `OwnerOnly`.

It now covers:

- the four-stage pipeline — `attribute → Read* → *Entry → Emit* → .g.cs`
- **the mirrored-enum rule** — the generator is `netstandard2.0` and cannot reference HermesProxy, so `DescriptorType` / `MaskMode` / `ArrayMode` / `BlockMaskShape` exist twice and are matched **by ordinal**. Insert a member and every existing declaration silently reinterprets as its neighbour: no error, wrong bytes
- the recipe for adding a capability, and the seam deciding what belongs in the generator versus the hand-written builder (the envelope stays hand-written — that is what lets 3.4.3 and 2.5.6 differ structurally without the generator knowing about either)
- two traps that each cost a round in this session: `--strip-trailing-cr` when reviewing a Verify snapshot (without it a 70-line diff reads as 8694), and MSB3021/3027 reporting a *copy* failure with no `error CS` when something holds the generator DLL

## Still missing for a 5.5-engine port

Listed at the end of the handbook, not attempted here:

- `HasAny*FieldSet` is visibility-blind — it answers "is any field set" where the model needs "within the declared groups"
- fragment-wrapped update masks — `MaskMode` covers flat and blocks; on 5.5 those sit inside a per-fragment mask plus a `u32 updateTypeFlag`
- empty-delta form — `EmitUpdateBlocks` early-outs on a zero mask, which on 5.5 tears `CGObject` down

Refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019p1wW7nkNtVwYdvxmo7PVq
