### PR TITLE
perf: cut packet hot-path allocation in the object-update and movement paths

### DIFF
--- a/HermesProxy.Benchmarks/CLAUDE.md
+++ b/HermesProxy.Benchmarks/CLAUDE.md
@@ -32,6 +32,7 @@ dotnet run --project HermesProxy.Benchmarks -c Release -- --list flat
 | `PacketDispatchBenchmarks.cs` | Inbound dispatch on real `ClientPacket`s: Activator path vs direct vs `SpanPacketReader` floor |
 | `SendPipelineBenchmarks.cs` | `ServerPacket` construct → `WritePacketData` → framed + encrypted wire bytes, per stage |
 | `PackedGuidBenchmarks.cs` | `WorldPacket` vs `PackedGuidHelper` packed-GUID encode/decode |
+| `MovementHandlerPrologueBenchmarks.cs` | `HandlePlayerMove` opcode translation: string/reflection round trip vs the prebuilt map |
 
 ## Conventions
 

--- a/HermesProxy.Benchmarks/MovementHandlerPrologueBenchmarks.cs
+++ b/HermesProxy.Benchmarks/MovementHandlerPrologueBenchmarks.cs
@@ -1,0 +1,128 @@
+using BenchmarkDotNet.Attributes;
+using HermesProxy.Enums;
+using HermesProxy.World.Enums;
+
+namespace HermesProxy.Benchmarks;
+
+/// <summary>
+/// Isolates the opcode-translation prologue that <c>WorldSocket.HandlePlayerMove</c> runs on
+/// every movement packet (MovementHandler.cs). The live <c>--metrics</c> allocation figure for
+/// CMSG_MOVE_* averaged ~18 KB per packet in a battleground, which the handler body — one
+/// pooled WorldPacket and a MovementInfo write — cannot account for. These benchmarks split
+/// the prologue into its three steps so the cost can be attributed instead of guessed at.
+///
+/// <c>Prologue_AsWritten</c> reproduces the handler exactly:
+///     string opcodeName = movement.GetUniversalOpcode().ToString();
+///     opcodeName = opcodeName.Replace("CMSG", "MSG");
+///     uint opcode = Opcodes.GetOpcodeValueForVersion(opcodeName, LegacyVersion.Build);
+///
+/// <c>Prologue_ArrayPath</c> is the comparison: the array-backed translation the rest of the
+/// proxy uses (the one OpcodeLookupBenchmarks covers), which needs no string round trip.
+/// </summary>
+[MemoryDiagnoser]
+[ShortRunJob]
+public class MovementHandlerPrologueBenchmarks
+{
+    private const int Iterations = 256;
+
+    private Opcode[] _movementOpcodes = null!;
+    private System.Collections.Frozen.FrozenDictionary<Opcode, Opcode> _clientMoveToLegacyMsg = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (global::HermesProxy.VersionBootstrap.ModernBuild == ClientVersionBuild.Zero)
+            global::HermesProxy.VersionBootstrap.ModernBuild = ClientVersionBuild.V3_4_3_54261;
+        if (global::HermesProxy.VersionBootstrap.LegacyBuild == ClientVersionBuild.Zero)
+            global::HermesProxy.VersionBootstrap.LegacyBuild = ClientVersionBuild.V3_3_5a_12340;
+
+        _ = global::HermesProxy.LegacyVersion.GetUniversalOpcode(0);
+        _ = global::HermesProxy.ModernVersion.GetUniversalOpcode(0);
+
+        // Same construction as WorldSocket.BuildClientMoveToLegacyMsg.
+        var map = new System.Collections.Generic.Dictionary<Opcode, Opcode>();
+        foreach (Opcode op in System.Enum.GetValues<Opcode>())
+        {
+            string n = op.ToString();
+            if (!n.StartsWith("CMSG_MOVE", System.StringComparison.Ordinal))
+                continue;
+            if (System.Enum.TryParse("MSG_" + n.Substring("CMSG_".Length), out Opcode legacyMsg))
+                map[op] = legacyMsg;
+        }
+        _clientMoveToLegacyMsg = System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(map);
+
+        // The opcodes that actually dominate the live C->S table, in the observed mix.
+        _movementOpcodes =
+        [
+            Opcode.CMSG_MOVE_SET_FACING_HEARTBEAT,
+            Opcode.CMSG_MOVE_HEARTBEAT,
+            Opcode.CMSG_MOVE_SET_FACING,
+            Opcode.CMSG_MOVE_STOP_STRAFE,
+            Opcode.CMSG_MOVE_SET_PITCH,
+            Opcode.CMSG_MOVE_STOP,
+            Opcode.CMSG_MOVE_START_STRAFE_LEFT,
+            Opcode.CMSG_MOVE_START_STRAFE_RIGHT,
+        ];
+    }
+
+    /// <summary>Exactly what HandlePlayerMove does today, once per movement packet.</summary>
+    [Benchmark(Baseline = true)]
+    public uint Prologue_AsWritten()
+    {
+        uint acc = 0;
+        for (int i = 0; i < Iterations; i++)
+        {
+            var universal = _movementOpcodes[i % _movementOpcodes.Length];
+            string opcodeName = universal.ToString();
+            opcodeName = opcodeName.Replace("CMSG", "MSG");
+            uint opcode = Opcodes.GetOpcodeValueForVersion(opcodeName, global::HermesProxy.LegacyVersion.Build);
+            if (opcode == 0)
+                opcode = Opcodes.GetOpcodeValueForVersion("MSG_MOVE_SET_FACING", global::HermesProxy.LegacyVersion.Build);
+            acc += opcode;
+        }
+        return acc;
+    }
+
+    /// <summary>Just the enum-name round trip, no version lookup.</summary>
+    [Benchmark]
+    public int Prologue_StringRoundTripOnly()
+    {
+        int acc = 0;
+        for (int i = 0; i < Iterations; i++)
+        {
+            var universal = _movementOpcodes[i % _movementOpcodes.Length];
+            string opcodeName = universal.ToString();
+            opcodeName = opcodeName.Replace("CMSG", "MSG");
+            acc += opcodeName.Length;
+        }
+        return acc;
+    }
+
+    /// <summary>Just the reflection-backed Enum.TryParse lookup, on a pre-built name.</summary>
+    [Benchmark]
+    public uint Prologue_VersionLookupOnly()
+    {
+        uint acc = 0;
+        for (int i = 0; i < Iterations; i++)
+            acc += Opcodes.GetOpcodeValueForVersion("MSG_MOVE_SET_FACING", global::HermesProxy.LegacyVersion.Build);
+        return acc;
+    }
+
+    /// <summary>The shipped replacement: prebuilt CMSG-&gt;MSG map, then the array lookup.</summary>
+    [Benchmark]
+    public uint Prologue_AsShipped()
+    {
+        uint acc = 0;
+        for (int i = 0; i < Iterations; i++)
+        {
+            var universal = _movementOpcodes[i % _movementOpcodes.Length];
+            uint opcode = _clientMoveToLegacyMsg.TryGetValue(universal, out Opcode legacyMsg)
+                ? global::HermesProxy.LegacyVersion.GetCurrentOpcode(legacyMsg)
+                : 0u;
+            if (opcode == 0)
+                opcode = global::HermesProxy.LegacyVersion.GetCurrentOpcode(Opcode.MSG_MOVE_SET_FACING);
+            acc += opcode;
+        }
+        return acc;
+    }
+}

--- a/HermesProxy.SourceGen/ObjectUpdateBuilderGenerator.cs
+++ b/HermesProxy.SourceGen/ObjectUpdateBuilderGenerator.cs
@@ -1236,14 +1236,30 @@ public sealed class ObjectUpdateBuilderGenerator : IIncrementalGenerator
         sb.Append("    internal bool HasAny").Append(section.SectionName).AppendLine("FieldSet()");
         sb.AppendLine("    {");
         sb.Append("        var src = ").Append(DataAccessor(section)).AppendLine(";");
-        sb.AppendLine("        if (src == null) return false;");
         // MaskMutator HasAnyPredicate: covers bits set by mutators that aren't tied
         // to any declared UpdateField presence check (e.g. ActivePlayer InvSlots fan
         // from GetModernInvSlot, GlyphsDirty from _gameState). Without these the
         // Update writer is skipped and the modern client never sees the change.
+        //
+        // Predicates that never read `src` are emitted BEFORE the null guard. They source
+        // from session state, so they hold even when the section object was never
+        // materialised -- ActivePlayerData is allocated lazily, and ordering
+        // `_gameState.ActiveGlyphsDirty` after `src == null` dropped the glyph section on
+        // any owner update that happened to set no ActivePlayerData field.
         foreach (var mm in section.MaskMutators)
         {
             if (string.IsNullOrEmpty(mm.HasAnyPredicate))
+                continue;
+            if (mm.HasAnyPredicate!.Contains("src"))
+                continue;
+            sb.Append("        if (").Append(mm.HasAnyPredicate).AppendLine(") return true;");
+        }
+        sb.AppendLine("        if (src == null) return false;");
+        foreach (var mm in section.MaskMutators)
+        {
+            if (string.IsNullOrEmpty(mm.HasAnyPredicate))
+                continue;
+            if (!mm.HasAnyPredicate!.Contains("src"))
                 continue;
             sb.Append("        if (").Append(mm.HasAnyPredicate).AppendLine(") return true;");
         }

--- a/HermesProxy.Tests/SourceGen/ObjectUpdateBuilderGeneratorTests.WriteCreateObjectData_V3_4_3_54261.verified.txt
+++ b/HermesProxy.Tests/SourceGen/ObjectUpdateBuilderGeneratorTests.WriteCreateObjectData_V3_4_3_54261.verified.txt
@@ -2816,9 +2816,9 @@ public partial class ObjectUpdateBuilder
     internal bool HasAnyActivePlayerFieldSet()
     {
         var src = _updateData.ActivePlayerData;
+        if (_gameState.ActiveGlyphsDirty) return true;
         if (src == null) return false;
         if (HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.HasAnyInvSlotMapped(src)) return true;
-        if (_gameState.ActiveGlyphsDirty) return true;
         if (HermesProxy.World.Objects.Version.V3_4_3_54261.ObjectUpdateBuilder.HasAnyKnownTitle(src.KnownTitles)) return true;
         if (src.Toys != null && src.Toys.Count > 0) return true;
         if (src.FarsightObject != null) return true;

--- a/HermesProxy.Tests/World/MonsterMoveTests.cs
+++ b/HermesProxy.Tests/World/MonsterMoveTests.cs
@@ -160,22 +160,54 @@ public class MonsterMoveWriteTests
         Assert.Equal(byteBufferData, spanBuffer[..written]);
     }
 
+    /// <summary>
+    /// A 20-point spline used to exceed the fixed cap of 16 and fall back to the ByteBuffer
+    /// path. MaxSize is now sized from the spline the packet actually carries, so this takes
+    /// the span path -- which makes byte-for-byte equivalence with Write() load-bearing for
+    /// long splines, not just short ones. Bot pathing in a battleground produces these
+    /// constantly (370 fallbacks in ten minutes before the change).
+    /// </summary>
     [Fact]
-    public void WriteToSpan_ExceedsMaxPoints_ReturnsMinus1()
+    public void WriteToSpan_LongSpline_TakesSpanPathAndMatchesWrite()
     {
         var spline = CreateSpline(SplineTypeModern.None);
         spline.SplineFlags = SplineFlagModern.UncompressedPath;
-        // Create more than MaxSplinePoints (16) points
         spline.SplinePoints = new List<Vector3>();
         for (int i = 0; i < 20; i++)
+            spline.SplinePoints.Add(new Vector3(i, i * 2f, i * 3f));
+
+        var packet1 = new MonsterMove(TestGuid, spline);
+        var packet2 = new MonsterMove(TestGuid, spline);
+
+        packet1.Write();
+        packet1.WritePacketData();
+        byte[] byteBufferData = packet1.GetData()!;
+
+        byte[] spanBuffer = new byte[packet2.MaxSize];
+        int written = packet2.WriteToSpan(spanBuffer);
+
+        Assert.True(written > 0, "a 20-point spline must no longer fall back");
+        Assert.Equal(byteBufferData.Length, written);
+        Assert.Equal(byteBufferData, spanBuffer[..written]);
+    }
+
+    /// <summary>
+    /// The -1 bail survives as a corruption guard: SplineCount is read unbounded off the
+    /// legacy wire, and a garbage count must fall back rather than drive a huge pooled rent.
+    /// </summary>
+    [Fact]
+    public void WriteToSpan_AbsurdSplineCount_FallsBack()
+    {
+        var spline = CreateSpline(SplineTypeModern.None);
+        spline.SplineFlags = SplineFlagModern.UncompressedPath;
+        spline.SplinePoints = new List<Vector3>();
+        for (int i = 0; i < 5000; i++)
             spline.SplinePoints.Add(new Vector3(i, i, i));
 
         var packet = new MonsterMove(TestGuid, spline);
 
-        byte[] spanBuffer = new byte[2048];
-        int written = packet.WriteToSpan(spanBuffer);
-
-        Assert.Equal(-1, written);
+        byte[] spanBuffer = new byte[packet.MaxSize];
+        Assert.Equal(-1, packet.WriteToSpan(spanBuffer));
     }
 
     [Fact]

--- a/HermesProxy.Tests/World/MovementOpcodeMappingTests.cs
+++ b/HermesProxy.Tests/World/MovementOpcodeMappingTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+/// <summary>
+/// WorldSocket.HandlePlayerMove translates the modern client's CMSG_MOVE_* opcode into the
+/// legacy MSG_MOVE_* wire value. That used to run, per movement packet, an enum ToString, a
+/// string Replace and a reflection-backed Enum.TryParse against the version's opcode enum;
+/// it now uses a prebuilt CMSG->MSG map plus LegacyVersion's array lookup.
+///
+/// These tests pin the two mechanisms to the same answer. Movement is the highest-rate client
+/// opcode, and a silent divergence here would send the backend the wrong opcode for a whole
+/// class of movement -- the sort of thing that shows up as rubber-banding, not as an error.
+/// </summary>
+public class MovementOpcodeMappingTests
+{
+    private static IEnumerable<Opcode> ClientMoveOpcodes()
+    {
+        foreach (Opcode op in Enum.GetValues<Opcode>())
+        {
+            if (op.ToString().StartsWith("CMSG_MOVE", StringComparison.Ordinal))
+                yield return op;
+        }
+    }
+
+    [Fact]
+    public void ArrayLookup_MatchesReflectionLookup_ForEveryClientMoveOpcode()
+    {
+        var divergences = new List<string>();
+        int compared = 0;
+
+        foreach (Opcode op in ClientMoveOpcodes())
+        {
+            // Exactly the string the old code built: Replace("CMSG", "MSG").
+            string legacyName = op.ToString().Replace("CMSG", "MSG");
+            uint viaReflection = Opcodes.GetOpcodeValueForVersion(legacyName, global::HermesProxy.LegacyVersion.Build);
+
+            if (!Enum.TryParse(legacyName, out Opcode universalMsg))
+            {
+                // No MSG_ twin in the universal enum means the new map has no entry and the
+                // handler falls back. That is only safe if the old path also found nothing.
+                if (viaReflection != 0)
+                    divergences.Add($"{op}: universal enum has no {legacyName}, but the version enum resolves it to {viaReflection}");
+                continue;
+            }
+
+            uint viaArray = global::HermesProxy.LegacyVersion.GetCurrentOpcode(universalMsg);
+            if (viaArray != viaReflection)
+                divergences.Add($"{op} -> {legacyName}: reflection={viaReflection} array={viaArray}");
+            compared++;
+        }
+
+        Assert.True(compared > 0, "no CMSG_MOVE_* opcodes were compared - the enum scan found nothing");
+        Assert.Empty(divergences);
+    }
+
+    [Fact]
+    public void FallbackOpcode_ResolvesIdentically()
+    {
+        Assert.Equal(
+            Opcodes.GetOpcodeValueForVersion("MSG_MOVE_SET_FACING", global::HermesProxy.LegacyVersion.Build),
+            global::HermesProxy.LegacyVersion.GetCurrentOpcode(Opcode.MSG_MOVE_SET_FACING));
+    }
+}

--- a/HermesProxy.Tests/World/ObjectUpdateTests.cs
+++ b/HermesProxy.Tests/World/ObjectUpdateTests.cs
@@ -173,7 +173,7 @@ public class ObjectUpdateConstructorTests
     }
 
     [Fact]
-    public void Constructor_PlayerGuid_InitializesUnitAndPlayerAndActivePlayerData()
+    public void Constructor_PlayerGuid_InitializesUnitAndPlayerDataButNotActivePlayerData()
     {
         var guid = WowGuid128.Create(HighGuidType703.Player, 1);
         var session = CreateGlobalSession();
@@ -182,7 +182,24 @@ public class ObjectUpdateConstructorTests
 
         Assert.NotNull(update.UnitData);
         Assert.NotNull(update.PlayerData);
-        Assert.NotNull(update.ActivePlayerData);
+        // ActivePlayerData is owner-only and ~32 KB, so the ctor leaves it null. Every other
+        // player in view -- every bot in a battleground -- would otherwise allocate a block
+        // the wire never carries.
+        Assert.Null(update.ActivePlayerData);
+    }
+
+    [Fact]
+    public void EnsureActivePlayerData_MaterialisesOnceAndIsIdempotent()
+    {
+        var guid = WowGuid128.Create(HighGuidType703.Player, 1);
+        var session = CreateGlobalSession();
+
+        var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
+
+        var first = update.EnsureActivePlayerData();
+        Assert.NotNull(first);
+        Assert.Same(first, update.ActivePlayerData);
+        Assert.Same(first, update.EnsureActivePlayerData());
     }
 
     [Fact]

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -613,8 +613,9 @@ public partial class WorldClient
     void HandleUpdateComboPoints(WorldPacket packet)
     {
         ObjectUpdate updateData = new ObjectUpdate(GetSession().GameState.CurrentPlayerGuid, UpdateTypeModern.Values, GetSession());
-        updateData.ActivePlayerData.ComboTarget = packet.ReadPackedGuid().To128(GetSession().GameState);
-        updateData.UnitData.ComboTarget = updateData.ActivePlayerData.ComboTarget;
+        var comboTarget = packet.ReadPackedGuid().To128(GetSession().GameState);
+        updateData.EnsureActivePlayerData().ComboTarget = comboTarget;
+        updateData.UnitData.ComboTarget = comboTarget;
         byte comboPoints = packet.ReadUInt8();
         sbyte powerSlot = ClassPowerTypes.GetPowerSlotForClass(GetSession().GameState.GetUnitClass(GetSession().GameState.CurrentPlayerGuid), PowerType.ComboPoints);
         if (powerSlot >= 0)

--- a/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
@@ -183,7 +183,7 @@ public partial class WorldClient
         if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
         {
             ObjectUpdate slotUpdate = new ObjectUpdate(GetSession().GameState.CurrentPlayerGuid, UpdateTypeModern.Values, GetSession());
-            slotUpdate.ActivePlayerData.NumStableSlots = numStableSlots;
+            slotUpdate.EnsureActivePlayerData().NumStableSlots = numStableSlots;
             UpdateObject slotPacket = new UpdateObject(GetSession().GameState);
             slotPacket.ObjectUpdates.Add(slotUpdate);
             SendPacketToClient(slotPacket);

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -23,6 +23,9 @@ public partial class WorldClient
     private static readonly Microsoft.Extensions.Logging.ILogger _melGoFields =
         Log.CreateMelLogger(Log.CategoryServer);
 
+    private static readonly Microsoft.Extensions.Logging.ILogger _melUpdateValues =
+        Log.CreateMelLogger(Log.CategoryServer);
+
     /// <summary>
     /// Writes a quaternion into GameObjectData's pre-allocated ParentRotation buffer. This runs
     /// once per GameObject create, so it must not allocate.
@@ -268,38 +271,50 @@ public partial class WorldClient
                     PowerUpdate powerUpdate = new PowerUpdate(guid);
                     ReadValuesUpdateBlock(packet, ref guid, updateData, auraUpdate, powerUpdate, i);
 
-                    // Trace per-Values-update so we can correlate legacy-side reads with
-                    // the modern-side WriteValuesUpdate output. We log:
-                    // - legacy GUID type (Transport, MOTransport, ItemContainer, GameObject,
-                    //   Player, Unit, etc.) and its 32-bit "entry/counter" — explains why
-                    //   client may never have a CreateObject for repeating guids
-                    // - which modern descriptor sections have ANY concrete field set (a
-                    //   non-empty delta is what would actually transmit data)
-                    bool isPlayer = guid == GetSession().GameState.CurrentPlayerGuid;
                     // Bag contents and stack counts arrive as Item/Container Values
                     // updates, which is how a sold or destroyed quest item shows up.
-                    if (guid.GetObjectType() == ObjectType.Item ||
-                        guid.GetObjectType() == ObjectType.Container)
+                    var valuesObjectType = guid.GetObjectType();
+                    if (valuesObjectType == ObjectType.Item ||
+                        valuesObjectType == ObjectType.Container)
                         GetSession().GameState.InventoryChangedSinceQuestResync = true;
-                    var valuesLegacyHigh = oldGuid.GetHighGuidTypeLegacy();
-                    uint legacyEntry = oldGuid.GetEntry();
-                    ulong legacyCounter = oldGuid.GetCounter();
-                    var u = updateData.UnitData;
-                    var o = updateData.ObjectData;
-                    var p = updateData.PlayerData;
-                    var a = updateData.ActivePlayerData;
-                    bool unitHasAnyField = u != null && (
-                        u.Health.HasValue || u.MaxHealth.HasValue || u.DisplayID.HasValue ||
-                        u.Level.HasValue || u.Flags.HasValue || u.AuraState.HasValue ||
-                        u.Charm != null || u.Summon != null || u.Target != null ||
-                        u.Power != null || u.MaxPower != null || u.Stats != null);
-                    bool playerHasAnyField = p != null && (
-                        p.PlayerFlags.HasValue || p.NativeSex.HasValue ||
-                        p.GuildRankID.HasValue || p.HonorLevel.HasValue ||
-                        p.DuelArbiter != null || p.WowAccount != null);
-                    bool activeHasAnyField = a != null && (
-                        a.Coinage.HasValue || a.XP.HasValue || a.NextLevelXP.HasValue ||
-                        ActivePlayerHasAnySlot(a));
+
+                    // Correlates legacy-side reads with the modern-side WriteValuesUpdate
+                    // output: the legacy GUID type and entry/counter (which explains why the
+                    // client may never have had a CreateObject for a repeating guid), and
+                    // which modern descriptor sections carry any concrete field -- a non-empty
+                    // delta being what actually transmits. Every argument below walks arrays
+                    // or reads through nullables, and this runs on every Values block of every
+                    // SMSG_UPDATE_OBJECT, so the whole thing sits behind an explicit gate
+                    // rather than relying on the LoggerMessage IsEnabled check.
+                    if (Log.IsTraceEnabled)
+                    {
+                        var u = updateData.UnitData;
+                        var o = updateData.ObjectData;
+                        var pd = updateData.PlayerData;
+                        var a = updateData.ActivePlayerData;
+                        bool unitHasAnyField = u != null && (
+                            u.Health.HasValue || u.MaxHealth.HasValue || u.DisplayID.HasValue ||
+                            u.Level.HasValue || u.Flags.HasValue || u.AuraState.HasValue ||
+                            u.Charm != null || u.Summon != null || u.Target != null ||
+                            u.Power != null || u.MaxPower != null || u.Stats != null);
+                        bool playerHasAnyField = pd != null && (
+                            pd.PlayerFlags.HasValue || pd.NativeSex.HasValue ||
+                            pd.GuildRankID.HasValue || pd.HonorLevel.HasValue ||
+                            pd.DuelArbiter != null || pd.WowAccount != null);
+                        bool activeHasAnyField = a != null && (
+                            a.Coinage.HasValue || a.XP.HasValue || a.NextLevelXP.HasValue ||
+                            ActivePlayerHasAnySlot(a));
+
+                        UpdateHandlerLogMessages.ValuesUpdateIn(
+                            _melUpdateValues, i, guid.Low, guid.High,
+                            oldGuid.GetHighGuidTypeLegacy(), oldGuid.GetEntry(), oldGuid.GetCounter(),
+                            guid == GetSession().GameState.CurrentPlayerGuid,
+                            o != null && (o.EntryID.HasValue || o.DynamicFlags.HasValue || o.Scale.HasValue),
+                            u != null, unitHasAnyField, u?.Health, u?.MaxHealth, u?.Flags ?? 0,
+                            pd != null, playerHasAnyField,
+                            a != null, activeHasAnyField,
+                            auraUpdate.Auras.Count, powerUpdate.Powers.Count);
+                    }
 
                     static bool ActivePlayerHasAnySlot(ActivePlayerData a)
                     {
@@ -323,15 +338,6 @@ public partial class WorldClient
                                 if (a.KeyringSlots[i] != null) return true;
                         return false;
                     }
-
-                    Log.Print(LogType.Trace,
-                        $"[UpdateValuesTrace][in] i={i} guid={guid} legacyHigh={valuesLegacyHigh} legacyEntry={legacyEntry} legacyCounter={legacyCounter} " +
-                        $"isPlayer={isPlayer} " +
-                        $"hasObj={(o != null && (o.EntryID.HasValue || o.DynamicFlags.HasValue || o.Scale.HasValue))} " +
-                        $"hasUnit={u != null} unitAnyField={unitHasAnyField} hp={u?.Health} maxHp={u?.MaxHealth} flags=0x{(u?.Flags ?? 0):X} " +
-                        $"hasPlayer={p != null} playerAnyField={playerHasAnyField} " +
-                        $"hasActive={a != null} activeAnyField={activeHasAnyField} " +
-                        $"auras={auraUpdate.Auras.Count} powers={powerUpdate.Powers.Count}");
 
                     if (powerUpdate.Powers.Count != 0)
                         SendPacketToClient(powerUpdate);
@@ -380,7 +386,7 @@ public partial class WorldClient
                     {
                         UpdateObject updateObject2 = new UpdateObject(GetSession().GameState);
                         ObjectUpdate updateData2 = new ObjectUpdate(guid, UpdateTypeModern.Values, GetSession());
-                        updateData2.ActivePlayerData.FarsightObject = WowGuid128.Empty;
+                        updateData2.EnsureActivePlayerData().FarsightObject = WowGuid128.Empty;
                         updateObject2.ObjectUpdates.Add(updateData2);
                         SendPacketToClient(updateObject2);
                     }
@@ -404,7 +410,7 @@ public partial class WorldClient
 
                     if (updateData.Guid == GetSession().GameState.CurrentPlayerGuid)
                     {
-                        GetSession().GameState.CurrentPlayerStorage.CompletedQuests.WriteAllCompletedIntoArray(updateData.ActivePlayerData.QuestCompleted);
+                        GetSession().GameState.CurrentPlayerStorage.CompletedQuests.WriteAllCompletedIntoArray(updateData.EnsureActivePlayerData().QuestCompleted);
                         HermesProxy.World.Server.CollectionSync.StampSummonedBattlePet(updateData, GetSession().GameState);
                     }
 
@@ -1102,6 +1108,12 @@ public partial class WorldClient
             });
     }
 
+    // [Conditional] rather than an #if body: the symbol is defined in no build, so with a
+    // live signature every call site still interpolated its string, allocated a params
+    // object[] and boxed the indexes into it before calling a method that does nothing.
+    // ReadValuesUpdateBlock alone hits these eleven times per field block. Conditional makes
+    // the compiler drop the call and its arguments outright.
+    [System.Diagnostics.Conditional("DEBUG_UPDATES")]
     private void PrintString(string txt, params object[] indexes)
     {
 #if DEBUG_UPDATES
@@ -1109,12 +1121,12 @@ public partial class WorldClient
 #endif
     }
 
-    private T PrintValue<T>(string name, T obj, params object[] indexes)
+    [System.Diagnostics.Conditional("DEBUG_UPDATES")]
+    private void PrintValue<T>(string name, T obj, params object[] indexes)
     {
 #if DEBUG_UPDATES
         Console.WriteLine("{0}{1}: {2}", GetIndexString(indexes), name, obj);
 #endif
-        return obj;
     }
 
     private Dictionary<int, UpdateField> ReadValuesUpdateBlock(WorldPacket packet, ref ObjectType type, object index, bool isCreating, Dictionary<int, UpdateField>? oldValues, out BitArray outUpdateMaskArray, out BitArray outActuallyChangedValuesMaskArray)
@@ -3331,11 +3343,11 @@ public partial class WorldClient
                     if (updateMaskArray[PLAYER_FIELD_INV_SLOT_HEAD + i * 2])
                     {
                         var slotGuid = GetSlotGuidValue(updates, PLAYER_FIELD_INV_SLOT_HEAD + i * 2);
-                        updateData.ActivePlayerData.InvSlots[i] = slotGuid;
+                        updateData.EnsureActivePlayerData().InvSlots[i] = slotGuid;
                         GetSession().GameState.InventoryChangedSinceQuestResync = true;
                         if (tracePlayer)
-                            Log.Print(LogType.Debug,
-                                $"[V343Trace][InvSlot] player slot={i} guid={slotGuid}");
+                            UpdateHandlerLogMessages.OwnerInvSlot(
+                                _melUpdateValues, i, slotGuid.Low, slotGuid.High);
                     }
                 }
             }
@@ -3346,7 +3358,7 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[PLAYER_FIELD_PACK_SLOT_1 + i * 2])
                     {
-                        updateData.ActivePlayerData.PackSlots[i] = GetSlotGuidValue(updates, PLAYER_FIELD_PACK_SLOT_1 + i * 2);
+                        updateData.EnsureActivePlayerData().PackSlots[i] = GetSlotGuidValue(updates, PLAYER_FIELD_PACK_SLOT_1 + i * 2);
                         GetSession().GameState.InventoryChangedSinceQuestResync = true;
                     }
                 }
@@ -3373,7 +3385,7 @@ public partial class WorldClient
                 for (int i = 0; i < bankSlots; i++)
                 {
                     if (updateMaskArray[PLAYER_FIELD_BANK_SLOT_1 + i * 2])
-                        updateData.ActivePlayerData.BankSlots[i] = GetSlotGuidValue(updates, PLAYER_FIELD_BANK_SLOT_1 + i * 2);
+                        updateData.EnsureActivePlayerData().BankSlots[i] = GetSlotGuidValue(updates, PLAYER_FIELD_BANK_SLOT_1 + i * 2);
                 }
             }
             int PLAYER_FIELD_BANKBAG_SLOT_1 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_BANKBAG_SLOT_1);
@@ -3383,7 +3395,7 @@ public partial class WorldClient
                 for (int i = 0; i < bankBagSlots; i++)
                 {
                     if (updateMaskArray[PLAYER_FIELD_BANKBAG_SLOT_1 + i * 2])
-                        updateData.ActivePlayerData.BankBagSlots[i] = GetSlotGuidValue(updates, PLAYER_FIELD_BANKBAG_SLOT_1 + i * 2);
+                        updateData.EnsureActivePlayerData().BankBagSlots[i] = GetSlotGuidValue(updates, PLAYER_FIELD_BANKBAG_SLOT_1 + i * 2);
                 }
             }
             int PLAYER_FIELD_VENDORBUYBACK_SLOT_1 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_VENDORBUYBACK_SLOT_1);
@@ -3392,7 +3404,7 @@ public partial class WorldClient
                 for (int i = 0; i < 12; i++)
                 {
                     if (updateMaskArray[PLAYER_FIELD_VENDORBUYBACK_SLOT_1 + i * 2])
-                        updateData.ActivePlayerData.BuyBackSlots[i] = GetSlotGuidValue(updates, PLAYER_FIELD_VENDORBUYBACK_SLOT_1 + i * 2);
+                        updateData.EnsureActivePlayerData().BuyBackSlots[i] = GetSlotGuidValue(updates, PLAYER_FIELD_VENDORBUYBACK_SLOT_1 + i * 2);
                 }
             }
             int PLAYER_FIELD_KEYRING_SLOT_1 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_KEYRING_SLOT_1);
@@ -3401,7 +3413,7 @@ public partial class WorldClient
                 for (int i = 0; i < 32; i++)
                 {
                     if (updateMaskArray[PLAYER_FIELD_KEYRING_SLOT_1 + i * 2])
-                        updateData.ActivePlayerData.KeyringSlots[i] = GetSlotGuidValue(updates, PLAYER_FIELD_KEYRING_SLOT_1 + i * 2);
+                        updateData.EnsureActivePlayerData().KeyringSlots[i] = GetSlotGuidValue(updates, PLAYER_FIELD_KEYRING_SLOT_1 + i * 2);
                 }
             }
 
@@ -3476,7 +3488,7 @@ public partial class WorldClient
             }
 
             if (restInfo != null)
-                updateData.ActivePlayerData.RestInfo[(byte)RestType.XP] = restInfo;
+                updateData.EnsureActivePlayerData().RestInfo[(byte)RestType.XP] = restInfo;
 
             int PLAYER_BYTES_3 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_BYTES_3);
             if (PLAYER_BYTES_3 >= 0 && updateMaskArray[PLAYER_BYTES_3])
@@ -3504,13 +3516,14 @@ public partial class WorldClient
             int PLAYER_FARSIGHT = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FARSIGHT);
             if (PLAYER_FARSIGHT >= 0 && updateMaskArray[PLAYER_FARSIGHT])
             {
-                updateData.ActivePlayerData.FarsightObject = GetGuidValue(updates, PlayerField.PLAYER_FARSIGHT).To128(GetSession().GameState);
+                updateData.EnsureActivePlayerData().FarsightObject = GetGuidValue(updates, PlayerField.PLAYER_FARSIGHT).To128(GetSession().GameState);
             }
             int PLAYER_FIELD_COMBO_TARGET = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_COMBO_TARGET);
             if (PLAYER_FIELD_COMBO_TARGET >= 0 && updateMaskArray[PLAYER_FIELD_COMBO_TARGET])
             {
-                updateData.ActivePlayerData.ComboTarget = GetGuidValue(updates, PlayerField.PLAYER_FIELD_COMBO_TARGET).To128(GetSession().GameState);
-                updateData.UnitData.ComboTarget = updateData.ActivePlayerData.ComboTarget;
+                var comboTarget = GetGuidValue(updates, PlayerField.PLAYER_FIELD_COMBO_TARGET).To128(GetSession().GameState);
+                updateData.EnsureActivePlayerData().ComboTarget = comboTarget;
+                updateData.UnitData.ComboTarget = comboTarget;
             }
             int PLAYER_FIELD_KNOWN_TITLES = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_KNOWN_TITLES);
             if (PLAYER_FIELD_KNOWN_TITLES >= 0)
@@ -3520,18 +3533,18 @@ public partial class WorldClient
                 for (int i = 0; i < count; i++)
                 {
                     if (updateMaskArray[PLAYER_FIELD_KNOWN_TITLES + i])
-                        updateData.ActivePlayerData.KnownTitles[i] = updates[PLAYER_FIELD_KNOWN_TITLES + i].UInt32Value;
+                        updateData.EnsureActivePlayerData().KnownTitles[i] = updates[PLAYER_FIELD_KNOWN_TITLES + i].UInt32Value;
                 }
             }
             int PLAYER_XP = LegacyVersion.GetUpdateField(PlayerField.PLAYER_XP);
             if (PLAYER_XP >= 0 && updateMaskArray[PLAYER_XP])
             {
-                updateData.ActivePlayerData.XP = updates[PLAYER_XP].Int32Value;
+                updateData.EnsureActivePlayerData().XP = updates[PLAYER_XP].Int32Value;
             }
             int PLAYER_NEXT_LEVEL_XP = LegacyVersion.GetUpdateField(PlayerField.PLAYER_NEXT_LEVEL_XP);
             if (PLAYER_NEXT_LEVEL_XP >= 0 && updateMaskArray[PLAYER_NEXT_LEVEL_XP])
             {
-                updateData.ActivePlayerData.NextLevelXP = updates[PLAYER_NEXT_LEVEL_XP].Int32Value;
+                updateData.EnsureActivePlayerData().NextLevelXP = updates[PLAYER_NEXT_LEVEL_XP].Int32Value;
             }
             int PLAYER_SKILL_INFO_1_1 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_SKILL_INFO_1_1);
             if (PLAYER_SKILL_INFO_1_1 >= 0)
@@ -3541,27 +3554,27 @@ public partial class WorldClient
                     int idIndex = PLAYER_SKILL_INFO_1_1 + i * 3;
                     if (updateMaskArray[idIndex])
                     {
-                        updateData.ActivePlayerData.Skill.SkillLineID[i] = (ushort)(updates[idIndex].UInt32Value & 0xFFFF);
-                        updateData.ActivePlayerData.Skill.SkillStep[i] = (ushort)((updates[idIndex].UInt32Value >> 16) & 0xFFFF);
+                        updateData.EnsureActivePlayerData().Skill.SkillLineID[i] = (ushort)(updates[idIndex].UInt32Value & 0xFFFF);
+                        updateData.EnsureActivePlayerData().Skill.SkillStep[i] = (ushort)((updates[idIndex].UInt32Value >> 16) & 0xFFFF);
             }
                     int valueIndex = idIndex + 1;
                     if (updateMaskArray[valueIndex])
                     {
-                        updateData.ActivePlayerData.Skill.SkillRank[i] = (ushort)(updates[valueIndex].UInt32Value & 0xFFFF);
-                        updateData.ActivePlayerData.Skill.SkillMaxRank[i] = (ushort)((updates[valueIndex].UInt32Value >> 16) & 0xFFFF);
+                        updateData.EnsureActivePlayerData().Skill.SkillRank[i] = (ushort)(updates[valueIndex].UInt32Value & 0xFFFF);
+                        updateData.EnsureActivePlayerData().Skill.SkillMaxRank[i] = (ushort)((updates[valueIndex].UInt32Value >> 16) & 0xFFFF);
                     }
                     int bonusIndex = valueIndex + 1;
                     if (updateMaskArray[bonusIndex])
                     {
-                        updateData.ActivePlayerData.Skill.SkillTempBonus[i] = (short)(updates[bonusIndex].Int32Value & 0xFFFF);
-                        updateData.ActivePlayerData.Skill.SkillPermBonus[i] = (ushort)((updates[bonusIndex].UInt32Value >> 16) & 0xFFFF);
+                        updateData.EnsureActivePlayerData().Skill.SkillTempBonus[i] = (short)(updates[bonusIndex].Int32Value & 0xFFFF);
+                        updateData.EnsureActivePlayerData().Skill.SkillPermBonus[i] = (ushort)((updates[bonusIndex].UInt32Value >> 16) & 0xFFFF);
                     }
                 }
             }
             int PLAYER_CHARACTER_POINTS1 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_CHARACTER_POINTS1);
             if (PLAYER_CHARACTER_POINTS1 >= 0 && updateMaskArray[PLAYER_CHARACTER_POINTS1])
             {
-                updateData.ActivePlayerData.CharacterPoints = updates[PLAYER_CHARACTER_POINTS1].Int32Value;
+                updateData.EnsureActivePlayerData().CharacterPoints = updates[PLAYER_CHARACTER_POINTS1].Int32Value;
             }
             // Glyph slot unlock bitmask. Bit N = slot N is unlocked. Legacy 3.3.5a server
             // sets bits as the player levels through 15/30/50/70/80 (final two slots both
@@ -3572,7 +3585,7 @@ public partial class WorldClient
             {
                 byte mask = (byte)(updates[PLAYER_GLYPHS_ENABLED].UInt32Value & 0xFF);
                 GetSession().GameState.GlyphsEnabled = mask;
-                updateData.ActivePlayerData.GlyphsEnabled = mask;
+                updateData.EnsureActivePlayerData().GlyphsEnabled = mask;
                 Log.Print(LogType.Network, $"[Glyphs] PLAYER_GLYPHS_ENABLED bitmask=0x{mask:X2}");
             }
             // PLAYER_FIELD_GLYPHS_1..6 (uint32 each). Legacy server sends these as Values
@@ -3629,52 +3642,52 @@ public partial class WorldClient
             int PLAYER_TRACK_CREATURES = LegacyVersion.GetUpdateField(PlayerField.PLAYER_TRACK_CREATURES);
             if (PLAYER_TRACK_CREATURES >= 0 && updateMaskArray[PLAYER_TRACK_CREATURES])
             {
-                updateData.ActivePlayerData.TrackCreatureMask = updates[PLAYER_TRACK_CREATURES].UInt32Value;
+                updateData.EnsureActivePlayerData().TrackCreatureMask = updates[PLAYER_TRACK_CREATURES].UInt32Value;
             }
             int PLAYER_TRACK_RESOURCES = LegacyVersion.GetUpdateField(PlayerField.PLAYER_TRACK_RESOURCES);
             if (PLAYER_TRACK_RESOURCES >= 0 && updateMaskArray[PLAYER_TRACK_RESOURCES])
             {
-                updateData.ActivePlayerData.TrackResourceMask[0] = updates[PLAYER_TRACK_RESOURCES].UInt32Value;
+                updateData.EnsureActivePlayerData().TrackResourceMask[0] = updates[PLAYER_TRACK_RESOURCES].UInt32Value;
             }
             int PLAYER_BLOCK_PERCENTAGE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_BLOCK_PERCENTAGE);
             if (PLAYER_BLOCK_PERCENTAGE >= 0 && updateMaskArray[PLAYER_BLOCK_PERCENTAGE])
             {
-                updateData.ActivePlayerData.BlockPercentage = updates[PLAYER_BLOCK_PERCENTAGE].FloatValue;
+                updateData.EnsureActivePlayerData().BlockPercentage = updates[PLAYER_BLOCK_PERCENTAGE].FloatValue;
             }
             int PLAYER_DODGE_PERCENTAGE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_DODGE_PERCENTAGE);
             if (PLAYER_DODGE_PERCENTAGE >= 0 && updateMaskArray[PLAYER_DODGE_PERCENTAGE])
             {
-                updateData.ActivePlayerData.DodgePercentage = updates[PLAYER_DODGE_PERCENTAGE].FloatValue;
+                updateData.EnsureActivePlayerData().DodgePercentage = updates[PLAYER_DODGE_PERCENTAGE].FloatValue;
             }
             int PLAYER_PARRY_PERCENTAGE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_PARRY_PERCENTAGE);
             if (PLAYER_PARRY_PERCENTAGE >= 0 && updateMaskArray[PLAYER_PARRY_PERCENTAGE])
             {
-                updateData.ActivePlayerData.ParryPercentage = updates[PLAYER_PARRY_PERCENTAGE].FloatValue;
+                updateData.EnsureActivePlayerData().ParryPercentage = updates[PLAYER_PARRY_PERCENTAGE].FloatValue;
             }
             int PLAYER_EXPERTISE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_EXPERTISE);
             if (PLAYER_EXPERTISE >= 0 && updateMaskArray[PLAYER_EXPERTISE])
             {
-                updateData.ActivePlayerData.MainhandExpertise = updates[PLAYER_EXPERTISE].Int32Value;
+                updateData.EnsureActivePlayerData().MainhandExpertise = updates[PLAYER_EXPERTISE].Int32Value;
             }
             int PLAYER_OFFHAND_EXPERTISE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_OFFHAND_EXPERTISE);
             if (PLAYER_OFFHAND_EXPERTISE >= 0 && updateMaskArray[PLAYER_OFFHAND_EXPERTISE])
             {
-                updateData.ActivePlayerData.OffhandExpertise = updates[PLAYER_OFFHAND_EXPERTISE].Int32Value;
+                updateData.EnsureActivePlayerData().OffhandExpertise = updates[PLAYER_OFFHAND_EXPERTISE].Int32Value;
             }
             int PLAYER_CRIT_PERCENTAGE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_CRIT_PERCENTAGE);
             if (PLAYER_CRIT_PERCENTAGE >= 0 && updateMaskArray[PLAYER_CRIT_PERCENTAGE])
             {
-                updateData.ActivePlayerData.CritPercentage = updates[PLAYER_CRIT_PERCENTAGE].FloatValue;
+                updateData.EnsureActivePlayerData().CritPercentage = updates[PLAYER_CRIT_PERCENTAGE].FloatValue;
             }
             int PLAYER_RANGED_CRIT_PERCENTAGE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_RANGED_CRIT_PERCENTAGE);
             if (PLAYER_RANGED_CRIT_PERCENTAGE >= 0 && updateMaskArray[PLAYER_RANGED_CRIT_PERCENTAGE])
             {
-                updateData.ActivePlayerData.RangedCritPercentage = updates[PLAYER_RANGED_CRIT_PERCENTAGE].FloatValue;
+                updateData.EnsureActivePlayerData().RangedCritPercentage = updates[PLAYER_RANGED_CRIT_PERCENTAGE].FloatValue;
             }
             int PLAYER_OFFHAND_CRIT_PERCENTAGE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_OFFHAND_CRIT_PERCENTAGE);
             if (PLAYER_OFFHAND_CRIT_PERCENTAGE >= 0 && updateMaskArray[PLAYER_OFFHAND_CRIT_PERCENTAGE])
             {
-                updateData.ActivePlayerData.OffhandCritPercentage = updates[PLAYER_OFFHAND_CRIT_PERCENTAGE].FloatValue;
+                updateData.EnsureActivePlayerData().OffhandCritPercentage = updates[PLAYER_OFFHAND_CRIT_PERCENTAGE].FloatValue;
             }
             int PLAYER_SPELL_CRIT_PERCENTAGE1 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_SPELL_CRIT_PERCENTAGE1);
             if (PLAYER_SPELL_CRIT_PERCENTAGE1 >= 0)
@@ -3682,13 +3695,13 @@ public partial class WorldClient
                 for (int i = 0; i < 7; i++)
                 {
                     if (updateMaskArray[PLAYER_SPELL_CRIT_PERCENTAGE1 + i])
-                        updateData.ActivePlayerData.SpellCritPercentage[i] = updates[PLAYER_SPELL_CRIT_PERCENTAGE1 + i].FloatValue;
+                        updateData.EnsureActivePlayerData().SpellCritPercentage[i] = updates[PLAYER_SPELL_CRIT_PERCENTAGE1 + i].FloatValue;
                 }
             }
             int PLAYER_SHIELD_BLOCK = LegacyVersion.GetUpdateField(PlayerField.PLAYER_SHIELD_BLOCK);
             if (PLAYER_SHIELD_BLOCK >= 0 && updateMaskArray[PLAYER_SHIELD_BLOCK])
             {
-                updateData.ActivePlayerData.ShieldBlock = updates[PLAYER_SHIELD_BLOCK].Int32Value;
+                updateData.EnsureActivePlayerData().ShieldBlock = updates[PLAYER_SHIELD_BLOCK].Int32Value;
             }
             int PLAYER_EXPLORED_ZONES_1 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_EXPLORED_ZONES_1);
             if (PLAYER_EXPLORED_ZONES_1 >= 0)
@@ -3700,18 +3713,18 @@ public partial class WorldClient
                     {
                         if ((i & 1) != 0)
                         {
-                            ulong oldValue = updateData.ActivePlayerData.ExploredZones[i / 2] != null ? (ulong)updateData.ActivePlayerData.ExploredZones[i / 2]! : 0;
-                            updateData.ActivePlayerData.ExploredZones[i / 2] = oldValue | ((ulong)updates[PLAYER_EXPLORED_ZONES_1 + i].UInt32Value << 32);
+                            ulong oldValue = updateData.EnsureActivePlayerData().ExploredZones[i / 2] != null ? (ulong)updateData.EnsureActivePlayerData().ExploredZones[i / 2]! : 0;
+                            updateData.EnsureActivePlayerData().ExploredZones[i / 2] = oldValue | ((ulong)updates[PLAYER_EXPLORED_ZONES_1 + i].UInt32Value << 32);
                         }
                         else
-                            updateData.ActivePlayerData.ExploredZones[i / 2] = updates[PLAYER_EXPLORED_ZONES_1 + i].UInt32Value;
+                            updateData.EnsureActivePlayerData().ExploredZones[i / 2] = updates[PLAYER_EXPLORED_ZONES_1 + i].UInt32Value;
                     }
                 }
             }
             int PLAYER_FIELD_COINAGE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_COINAGE);
             if (PLAYER_FIELD_COINAGE >= 0 && updateMaskArray[PLAYER_FIELD_COINAGE])
             {
-                updateData.ActivePlayerData.Coinage = updates[PLAYER_FIELD_COINAGE].UInt32Value;
+                updateData.EnsureActivePlayerData().Coinage = updates[PLAYER_FIELD_COINAGE].UInt32Value;
                 if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261 &&
                     guid == GetSession().GameState.CurrentPlayerGuid)
                 {
@@ -3770,7 +3783,7 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[PLAYER_FIELD_MOD_DAMAGE_DONE_POS + i])
                     {
-                        updateData.ActivePlayerData.ModDamageDonePos[i] = updates[PLAYER_FIELD_MOD_DAMAGE_DONE_POS + i].Int32Value;
+                        updateData.EnsureActivePlayerData().ModDamageDonePos[i] = updates[PLAYER_FIELD_MOD_DAMAGE_DONE_POS + i].Int32Value;
                     }
                 }
             }
@@ -3781,7 +3794,7 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + i])
                     {
-                        updateData.ActivePlayerData.ModDamageDoneNeg[i] = updates[PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + i].Int32Value;
+                        updateData.EnsureActivePlayerData().ModDamageDoneNeg[i] = updates[PLAYER_FIELD_MOD_DAMAGE_DONE_NEG + i].Int32Value;
                     }
                 }
             }
@@ -3792,29 +3805,29 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[PLAYER_FIELD_MOD_DAMAGE_DONE_PCT + i])
                     {
-                        updateData.ActivePlayerData.ModDamageDonePercent[i] = updates[PLAYER_FIELD_MOD_DAMAGE_DONE_PCT + i].FloatValue;
+                        updateData.EnsureActivePlayerData().ModDamageDonePercent[i] = updates[PLAYER_FIELD_MOD_DAMAGE_DONE_PCT + i].FloatValue;
                     }
                 }
             }
             int PLAYER_FIELD_MOD_HEALING_DONE_POS = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_MOD_HEALING_DONE_POS);
             if (PLAYER_FIELD_MOD_HEALING_DONE_POS >= 0 && updateMaskArray[PLAYER_FIELD_MOD_HEALING_DONE_POS])
             {
-                updateData.ActivePlayerData.ModHealingDonePos = updates[PLAYER_FIELD_MOD_HEALING_DONE_POS].Int32Value;
+                updateData.EnsureActivePlayerData().ModHealingDonePos = updates[PLAYER_FIELD_MOD_HEALING_DONE_POS].Int32Value;
             }
             int PLAYER_FIELD_MOD_TARGET_RESISTANCE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_MOD_TARGET_RESISTANCE);
             if (PLAYER_FIELD_MOD_TARGET_RESISTANCE >= 0 && updateMaskArray[PLAYER_FIELD_MOD_TARGET_RESISTANCE])
             {
-                updateData.ActivePlayerData.ModTargetResistance = updates[PLAYER_FIELD_MOD_TARGET_RESISTANCE].Int32Value;
+                updateData.EnsureActivePlayerData().ModTargetResistance = updates[PLAYER_FIELD_MOD_TARGET_RESISTANCE].Int32Value;
             }
             int PLAYER_FIELD_MOD_TARGET_PHYSICAL_RESISTANCE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_MOD_TARGET_PHYSICAL_RESISTANCE);
             if (PLAYER_FIELD_MOD_TARGET_PHYSICAL_RESISTANCE >= 0 && updateMaskArray[PLAYER_FIELD_MOD_TARGET_PHYSICAL_RESISTANCE])
             {
-                updateData.ActivePlayerData.ModTargetPhysicalResistance = updates[PLAYER_FIELD_MOD_TARGET_PHYSICAL_RESISTANCE].Int32Value;
+                updateData.EnsureActivePlayerData().ModTargetPhysicalResistance = updates[PLAYER_FIELD_MOD_TARGET_PHYSICAL_RESISTANCE].Int32Value;
             }
             int PLAYER_FIELD_BYTES = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_BYTES);
             if (PLAYER_FIELD_BYTES >= 0 && updateMaskArray[PLAYER_FIELD_BYTES])
             {
-                updateData.ActivePlayerData.LocalFlags = (byte)(updates[PLAYER_FIELD_BYTES].UInt32Value & 0xFF);
+                updateData.EnsureActivePlayerData().LocalFlags = (byte)(updates[PLAYER_FIELD_BYTES].UInt32Value & 0xFF);
 
                 if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
                 {
@@ -3833,30 +3846,31 @@ public partial class WorldClient
                     }
                 }
                 else
-                    updateData.ActivePlayerData.GrantableLevels = (byte)((updates[PLAYER_FIELD_BYTES].UInt32Value >> 8) & 0xFF);
+                    updateData.EnsureActivePlayerData().GrantableLevels = (byte)((updates[PLAYER_FIELD_BYTES].UInt32Value >> 8) & 0xFF);
                 
-                updateData.ActivePlayerData.MultiActionBars = (byte)((updates[PLAYER_FIELD_BYTES].UInt32Value >> 16) & 0xFF);
-                updateData.ActivePlayerData.LifetimeMaxRank = (byte)((updates[PLAYER_FIELD_BYTES].UInt32Value >> 24) & 0xFF);
-                Log.Print(LogType.Trace,
-                    $"[ActionBarTrace] PLAYER_FIELD_BYTES extracted: MultiActionBars=0x{updateData.ActivePlayerData.MultiActionBars:X2} " +
-                    $"({System.Convert.ToString(updateData.ActivePlayerData.MultiActionBars.Value, 2).PadLeft(8, '0')}b) raw32=0x{updates[PLAYER_FIELD_BYTES].UInt32Value:X8} guid={guid}");
+                updateData.EnsureActivePlayerData().MultiActionBars = (byte)((updates[PLAYER_FIELD_BYTES].UInt32Value >> 16) & 0xFF);
+                updateData.EnsureActivePlayerData().LifetimeMaxRank = (byte)((updates[PLAYER_FIELD_BYTES].UInt32Value >> 24) & 0xFF);
+                UpdateHandlerLogMessages.ActionBarBytes(
+                    _melUpdateValues,
+                    (byte)((updates[PLAYER_FIELD_BYTES].UInt32Value >> 16) & 0xFF),
+                    updates[PLAYER_FIELD_BYTES].UInt32Value, guid.Low, guid.High);
             }
             int PLAYER_AMMO_ID = LegacyVersion.GetUpdateField(PlayerField.PLAYER_AMMO_ID);
             if (PLAYER_AMMO_ID >= 0 && updateMaskArray[PLAYER_AMMO_ID])
             {
-                updateData.ActivePlayerData.AmmoID = updates[PLAYER_AMMO_ID].UInt32Value;
+                updateData.EnsureActivePlayerData().AmmoID = updates[PLAYER_AMMO_ID].UInt32Value;
             }
             int PLAYER_SELF_RES_SPELL = LegacyVersion.GetUpdateField(PlayerField.PLAYER_SELF_RES_SPELL);
             if (PLAYER_SELF_RES_SPELL >= 0 && updateMaskArray[PLAYER_SELF_RES_SPELL])
             {
                 uint spellId = updates[PLAYER_SELF_RES_SPELL].UInt32Value;
-                updateData.ActivePlayerData.SelfResSpells = new List<uint>();
-                updateData.ActivePlayerData.SelfResSpells.Add(spellId);
+                updateData.EnsureActivePlayerData().SelfResSpells = new List<uint>();
+                updateData.EnsureActivePlayerData().SelfResSpells.Add(spellId);
             }
             int PLAYER_FIELD_PVP_MEDALS = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_PVP_MEDALS);
             if (PLAYER_FIELD_PVP_MEDALS >= 0 && updateMaskArray[PLAYER_FIELD_PVP_MEDALS])
             {
-                updateData.ActivePlayerData.PvpMedals = updates[PLAYER_FIELD_PVP_MEDALS].UInt32Value;
+                updateData.EnsureActivePlayerData().PvpMedals = updates[PLAYER_FIELD_PVP_MEDALS].UInt32Value;
             }
             int PLAYER_FIELD_BUYBACK_PRICE_1 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_BUYBACK_PRICE_1);
             if (PLAYER_FIELD_BUYBACK_PRICE_1 >= 0)
@@ -3865,7 +3879,7 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[PLAYER_FIELD_BUYBACK_PRICE_1 + i])
                     {
-                        updateData.ActivePlayerData.BuybackPrice[i] = updates[PLAYER_FIELD_BUYBACK_PRICE_1 + i].UInt32Value;
+                        updateData.EnsureActivePlayerData().BuybackPrice[i] = updates[PLAYER_FIELD_BUYBACK_PRICE_1 + i].UInt32Value;
                     }
                 }
             }
@@ -3876,82 +3890,82 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[PLAYER_FIELD_BUYBACK_TIMESTAMP_1 + i])
                     {
-                        updateData.ActivePlayerData.BuybackTimestamp[i] = updates[PLAYER_FIELD_BUYBACK_TIMESTAMP_1 + i].UInt32Value;
+                        updateData.EnsureActivePlayerData().BuybackTimestamp[i] = updates[PLAYER_FIELD_BUYBACK_TIMESTAMP_1 + i].UInt32Value;
                     }
                 }
             }
             int PLAYER_FIELD_SESSION_KILLS = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_SESSION_KILLS);
             if (PLAYER_FIELD_SESSION_KILLS >= 0 && updateMaskArray[PLAYER_FIELD_SESSION_KILLS]) // vanilla
             {
-                updateData.ActivePlayerData.TodayHonorableKills = (ushort)(updates[PLAYER_FIELD_SESSION_KILLS].UInt32Value & 0xFFFF);
-                updateData.ActivePlayerData.TodayDishonorableKills = (ushort)((updates[PLAYER_FIELD_SESSION_KILLS].UInt32Value >> 16) & 0xFFFF);
+                updateData.EnsureActivePlayerData().TodayHonorableKills = (ushort)(updates[PLAYER_FIELD_SESSION_KILLS].UInt32Value & 0xFFFF);
+                updateData.EnsureActivePlayerData().TodayDishonorableKills = (ushort)((updates[PLAYER_FIELD_SESSION_KILLS].UInt32Value >> 16) & 0xFFFF);
             }
             int PLAYER_FIELD_KILLS = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_KILLS);
             if (PLAYER_FIELD_KILLS >= 0 && updateMaskArray[PLAYER_FIELD_KILLS]) // tbc
             {
-                updateData.ActivePlayerData.TodayHonorableKills = (ushort)(updates[PLAYER_FIELD_KILLS].UInt32Value & 0xFFFF);
-                updateData.ActivePlayerData.YesterdayHonorableKills = (ushort)((updates[PLAYER_FIELD_KILLS].UInt32Value >> 16) & 0xFFFF);
+                updateData.EnsureActivePlayerData().TodayHonorableKills = (ushort)(updates[PLAYER_FIELD_KILLS].UInt32Value & 0xFFFF);
+                updateData.EnsureActivePlayerData().YesterdayHonorableKills = (ushort)((updates[PLAYER_FIELD_KILLS].UInt32Value >> 16) & 0xFFFF);
             }
             int PLAYER_FIELD_YESTERDAY_KILLS = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_YESTERDAY_KILLS);
             if (PLAYER_FIELD_YESTERDAY_KILLS >= 0 && updateMaskArray[PLAYER_FIELD_YESTERDAY_KILLS]) // vanilla
             {
-                updateData.ActivePlayerData.YesterdayHonorableKills = (ushort)(updates[PLAYER_FIELD_YESTERDAY_KILLS].UInt32Value & 0xFFFF);
-                updateData.ActivePlayerData.YesterdayDishonorableKills = (ushort)((updates[PLAYER_FIELD_YESTERDAY_KILLS].UInt32Value >> 16) & 0xFFFF);
+                updateData.EnsureActivePlayerData().YesterdayHonorableKills = (ushort)(updates[PLAYER_FIELD_YESTERDAY_KILLS].UInt32Value & 0xFFFF);
+                updateData.EnsureActivePlayerData().YesterdayDishonorableKills = (ushort)((updates[PLAYER_FIELD_YESTERDAY_KILLS].UInt32Value >> 16) & 0xFFFF);
             }
             int PLAYER_FIELD_LAST_WEEK_KILLS = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_LAST_WEEK_KILLS);
             if (PLAYER_FIELD_LAST_WEEK_KILLS >= 0 && updateMaskArray[PLAYER_FIELD_LAST_WEEK_KILLS]) // vanilla
             {
-                updateData.ActivePlayerData.LastWeekHonorableKills = (ushort)(updates[PLAYER_FIELD_LAST_WEEK_KILLS].UInt32Value & 0xFFFF);
-                updateData.ActivePlayerData.LastWeekDishonorableKills = (ushort)((updates[PLAYER_FIELD_LAST_WEEK_KILLS].UInt32Value >> 16) & 0xFFFF);
+                updateData.EnsureActivePlayerData().LastWeekHonorableKills = (ushort)(updates[PLAYER_FIELD_LAST_WEEK_KILLS].UInt32Value & 0xFFFF);
+                updateData.EnsureActivePlayerData().LastWeekDishonorableKills = (ushort)((updates[PLAYER_FIELD_LAST_WEEK_KILLS].UInt32Value >> 16) & 0xFFFF);
             }
             int PLAYER_FIELD_THIS_WEEK_KILLS = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_THIS_WEEK_KILLS);
             if (PLAYER_FIELD_THIS_WEEK_KILLS >= 0 && updateMaskArray[PLAYER_FIELD_THIS_WEEK_KILLS]) // vanilla
             {
-                updateData.ActivePlayerData.ThisWeekHonorableKills = (ushort)(updates[PLAYER_FIELD_THIS_WEEK_KILLS].UInt32Value & 0xFFFF);
-                updateData.ActivePlayerData.ThisWeekDishonorableKills = (ushort)((updates[PLAYER_FIELD_THIS_WEEK_KILLS].UInt32Value >> 16) & 0xFFFF);
+                updateData.EnsureActivePlayerData().ThisWeekHonorableKills = (ushort)(updates[PLAYER_FIELD_THIS_WEEK_KILLS].UInt32Value & 0xFFFF);
+                updateData.EnsureActivePlayerData().ThisWeekDishonorableKills = (ushort)((updates[PLAYER_FIELD_THIS_WEEK_KILLS].UInt32Value >> 16) & 0xFFFF);
             }
             int PLAYER_FIELD_THIS_WEEK_CONTRIBUTION = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_THIS_WEEK_CONTRIBUTION); // vanilla
             if (PLAYER_FIELD_THIS_WEEK_CONTRIBUTION < 0)
                 PLAYER_FIELD_THIS_WEEK_CONTRIBUTION = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_TODAY_CONTRIBUTION); // tbc
             if (PLAYER_FIELD_THIS_WEEK_CONTRIBUTION >= 0 && updateMaskArray[PLAYER_FIELD_THIS_WEEK_CONTRIBUTION])
             {
-                updateData.ActivePlayerData.ThisWeekContribution = updates[PLAYER_FIELD_THIS_WEEK_CONTRIBUTION].UInt32Value;
+                updateData.EnsureActivePlayerData().ThisWeekContribution = updates[PLAYER_FIELD_THIS_WEEK_CONTRIBUTION].UInt32Value;
             }
             int PLAYER_FIELD_LIFETIME_HONORABLE_KILLS = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_LIFETIME_HONORABLE_KILLS);
             if (PLAYER_FIELD_LIFETIME_HONORABLE_KILLS >= 0 && updateMaskArray[PLAYER_FIELD_LIFETIME_HONORABLE_KILLS])
             {
-                updateData.ActivePlayerData.LifetimeHonorableKills = updates[PLAYER_FIELD_LIFETIME_HONORABLE_KILLS].UInt32Value;
+                updateData.EnsureActivePlayerData().LifetimeHonorableKills = updates[PLAYER_FIELD_LIFETIME_HONORABLE_KILLS].UInt32Value;
             }
             int PLAYER_FIELD_LIFETIME_DISHONORABLE_KILLS = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_LIFETIME_DISHONORABLE_KILLS);
             if (PLAYER_FIELD_LIFETIME_DISHONORABLE_KILLS >= 0 && updateMaskArray[PLAYER_FIELD_LIFETIME_DISHONORABLE_KILLS]) // vanilla
             {
-                updateData.ActivePlayerData.LifetimeDishonorableKills = updates[PLAYER_FIELD_LIFETIME_DISHONORABLE_KILLS].UInt32Value;
+                updateData.EnsureActivePlayerData().LifetimeDishonorableKills = updates[PLAYER_FIELD_LIFETIME_DISHONORABLE_KILLS].UInt32Value;
             }
             int PLAYER_FIELD_YESTERDAY_CONTRIBUTION = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_YESTERDAY_CONTRIBUTION);
             if (PLAYER_FIELD_YESTERDAY_CONTRIBUTION >= 0 && updateMaskArray[PLAYER_FIELD_YESTERDAY_CONTRIBUTION])
             {
-                updateData.ActivePlayerData.YesterdayContribution = updates[PLAYER_FIELD_YESTERDAY_CONTRIBUTION].UInt32Value;
+                updateData.EnsureActivePlayerData().YesterdayContribution = updates[PLAYER_FIELD_YESTERDAY_CONTRIBUTION].UInt32Value;
             }
             int PLAYER_FIELD_LAST_WEEK_CONTRIBUTION = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_LAST_WEEK_CONTRIBUTION);
             if (PLAYER_FIELD_LAST_WEEK_CONTRIBUTION >= 0 && updateMaskArray[PLAYER_FIELD_LAST_WEEK_CONTRIBUTION]) // vanilla
             {
-                updateData.ActivePlayerData.LastWeekContribution = updates[PLAYER_FIELD_LAST_WEEK_CONTRIBUTION].UInt32Value;
+                updateData.EnsureActivePlayerData().LastWeekContribution = updates[PLAYER_FIELD_LAST_WEEK_CONTRIBUTION].UInt32Value;
             }
             int PLAYER_FIELD_LAST_WEEK_RANK = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_LAST_WEEK_RANK);
             if (PLAYER_FIELD_LAST_WEEK_RANK >= 0 && updateMaskArray[PLAYER_FIELD_LAST_WEEK_RANK]) // vanilla
             {
-                updateData.ActivePlayerData.LastWeekRank = updates[PLAYER_FIELD_LAST_WEEK_RANK].UInt32Value;
+                updateData.EnsureActivePlayerData().LastWeekRank = updates[PLAYER_FIELD_LAST_WEEK_RANK].UInt32Value;
             }
             int PLAYER_FIELD_BYTES2 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_BYTES2);
             if (PLAYER_FIELD_BYTES2 >= 0 && updateMaskArray[PLAYER_FIELD_BYTES2])
             {
-                updateData.ActivePlayerData.PvPRankProgress = (byte)(updates[PLAYER_FIELD_BYTES2].UInt32Value & 0xFF);
-                updateData.ActivePlayerData.AuraVision = (byte)((updates[PLAYER_FIELD_BYTES2].UInt32Value >> 8) & 0xFF);
+                updateData.EnsureActivePlayerData().PvPRankProgress = (byte)(updates[PLAYER_FIELD_BYTES2].UInt32Value & 0xFF);
+                updateData.EnsureActivePlayerData().AuraVision = (byte)((updates[PLAYER_FIELD_BYTES2].UInt32Value >> 8) & 0xFF);
             }
             int PLAYER_FIELD_WATCHED_FACTION_INDEX = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_WATCHED_FACTION_INDEX);
             if (PLAYER_FIELD_WATCHED_FACTION_INDEX >= 0 && updateMaskArray[PLAYER_FIELD_WATCHED_FACTION_INDEX])
             {
-                updateData.ActivePlayerData.WatchedFactionIndex = updates[PLAYER_FIELD_WATCHED_FACTION_INDEX].Int32Value;
+                updateData.EnsureActivePlayerData().WatchedFactionIndex = updates[PLAYER_FIELD_WATCHED_FACTION_INDEX].Int32Value;
             }
             int PLAYER_FIELD_COMBAT_RATING_1 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_COMBAT_RATING_1);
             if (PLAYER_FIELD_COMBAT_RATING_1 >= 0)
@@ -3960,7 +3974,7 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[PLAYER_FIELD_COMBAT_RATING_1 + i])
                     {
-                        updateData.ActivePlayerData.CombatRatings[i] = updates[PLAYER_FIELD_COMBAT_RATING_1 + i].Int32Value;
+                        updateData.EnsureActivePlayerData().CombatRatings[i] = updates[PLAYER_FIELD_COMBAT_RATING_1 + i].Int32Value;
                     }
                 }
             }
@@ -4004,39 +4018,39 @@ public partial class WorldClient
                     /*
                     if (updateMaskArray[startOffset + teamMemberOffset])
                     {
-                        if (updateData.ActivePlayerData.PvpInfo[i] == null)
-                            updateData.ActivePlayerData.PvpInfo[i] = new PVPInfo();
+                        if (updateData.EnsureActivePlayerData().PvpInfo[i] == null)
+                            updateData.EnsureActivePlayerData().PvpInfo[i] = new PVPInfo();
 
-                        updateData.ActivePlayerData.PvpInfo[i].Captain = updates[startOffset + teamMemberOffset].Int32Value;
+                        updateData.EnsureActivePlayerData().PvpInfo[i].Captain = updates[startOffset + teamMemberOffset].Int32Value;
                     }
                     */
                     if (updateMaskArray[startOffset + teamGamesWeekOffset])
                     {
-                        if (updateData.ActivePlayerData.PvpInfo[i] == null)
-                            updateData.ActivePlayerData.PvpInfo[i] = new PVPInfo();
+                        if (updateData.EnsureActivePlayerData().PvpInfo[i] == null)
+                            updateData.EnsureActivePlayerData().PvpInfo[i] = new PVPInfo();
 
-                        updateData.ActivePlayerData.PvpInfo[i].WeeklyPlayed = updates[startOffset + teamGamesWeekOffset].UInt32Value;
+                        updateData.EnsureActivePlayerData().PvpInfo[i].WeeklyPlayed = updates[startOffset + teamGamesWeekOffset].UInt32Value;
                     }
                     if (updateMaskArray[startOffset + teamGamesSeasonOffset])
                     {
-                        if (updateData.ActivePlayerData.PvpInfo[i] == null)
-                            updateData.ActivePlayerData.PvpInfo[i] = new PVPInfo();
+                        if (updateData.EnsureActivePlayerData().PvpInfo[i] == null)
+                            updateData.EnsureActivePlayerData().PvpInfo[i] = new PVPInfo();
 
-                        updateData.ActivePlayerData.PvpInfo[i].SeasonPlayed = updates[startOffset + teamGamesSeasonOffset].UInt32Value;
+                        updateData.EnsureActivePlayerData().PvpInfo[i].SeasonPlayed = updates[startOffset + teamGamesSeasonOffset].UInt32Value;
                     }
                     if (updateMaskArray[startOffset + teamWinsSeasonOffset])
                     {
-                        if (updateData.ActivePlayerData.PvpInfo[i] == null)
-                            updateData.ActivePlayerData.PvpInfo[i] = new PVPInfo();
+                        if (updateData.EnsureActivePlayerData().PvpInfo[i] == null)
+                            updateData.EnsureActivePlayerData().PvpInfo[i] = new PVPInfo();
 
-                        updateData.ActivePlayerData.PvpInfo[i].SeasonWon = updates[startOffset + teamWinsSeasonOffset].UInt32Value;
+                        updateData.EnsureActivePlayerData().PvpInfo[i].SeasonWon = updates[startOffset + teamWinsSeasonOffset].UInt32Value;
                     }
                     if (updateMaskArray[startOffset + teamPersonalRatingOffset])
                     {
-                        if (updateData.ActivePlayerData.PvpInfo[i] == null)
-                            updateData.ActivePlayerData.PvpInfo[i] = new PVPInfo();
+                        if (updateData.EnsureActivePlayerData().PvpInfo[i] == null)
+                            updateData.EnsureActivePlayerData().PvpInfo[i] = new PVPInfo();
 
-                        updateData.ActivePlayerData.PvpInfo[i].Rating = updates[startOffset + teamPersonalRatingOffset].UInt32Value;
+                        updateData.EnsureActivePlayerData().PvpInfo[i].Rating = updates[startOffset + teamPersonalRatingOffset].UInt32Value;
                     }
                 }
             }
@@ -4060,7 +4074,7 @@ public partial class WorldClient
             int PLAYER_FIELD_MAX_LEVEL = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_MAX_LEVEL);
             if (PLAYER_FIELD_MAX_LEVEL >= 0 && updateMaskArray[PLAYER_FIELD_MAX_LEVEL])
             {
-                updateData.ActivePlayerData.MaxLevel = updates[PLAYER_FIELD_MAX_LEVEL].Int32Value;
+                updateData.EnsureActivePlayerData().MaxLevel = updates[PLAYER_FIELD_MAX_LEVEL].Int32Value;
             }
             int PLAYER_FIELD_DAILY_QUESTS_1 = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_DAILY_QUESTS_1);
             if (PLAYER_FIELD_DAILY_QUESTS_1 >= 0 && guid == GetSession().GameState.CurrentPlayerGuid)
@@ -4070,7 +4084,7 @@ public partial class WorldClient
                     if (updateMaskArray[PLAYER_FIELD_DAILY_QUESTS_1 + i])
                     {
                         GetSession().GameState.SetDailyQuestSlot((uint)i, updates[PLAYER_FIELD_DAILY_QUESTS_1 + i].UInt32Value);
-                        updateData.ActivePlayerData.HasDailyQuestsUpdate = true;
+                        updateData.EnsureActivePlayerData().HasDailyQuestsUpdate = true;
                     }
                 }
             }

--- a/HermesProxy/World/Logging/UpdateHandlerLogMessages.cs
+++ b/HermesProxy/World/Logging/UpdateHandlerLogMessages.cs
@@ -1,0 +1,54 @@
+using HermesProxy.World.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace HermesProxy.World.Logging;
+
+/// <summary>
+/// Source-generated logging for the legacy SMSG_UPDATE_OBJECT read path. Split out of
+/// <see cref="ObjectLifecycleLogMessages"/> because these fire per Values block rather than
+/// per object batch: in a bot-populated battleground the Values trace alone ran on every one
+/// of ~600 packets a second, and as an interpolated <c>Log.Print</c> it built its string, and
+/// scanned six inventory arrays to fill it, whether or not Verbose was on.
+///
+/// Guids are logged as their two raw halves. WowGuid128's generated ToString allocates and
+/// these sites are per packet; grep a single object's history with the Low value.
+///
+/// EventId 1200-1219 is reserved for this file (900-909 object lifecycle, 1100-1114
+/// gameobject fields, 1000-1007 battleground).
+/// </summary>
+internal static partial class UpdateHandlerLogMessages
+{
+    [LoggerMessage(
+        EventId = 1200,
+        Level = LogLevel.Trace,
+        Message = "[UpdateValuesTrace][in] i={Index} guidLow={GuidLow} guidHigh={GuidHigh} " +
+                  "legacyHigh={LegacyHigh} legacyEntry={LegacyEntry} legacyCounter={LegacyCounter} " +
+                  "isPlayer={IsPlayer} hasObj={HasObjectField} hasUnit={HasUnit} " +
+                  "unitAnyField={UnitAnyField} hp={Health} maxHp={MaxHealth} flags=0x{Flags:X} " +
+                  "hasPlayer={HasPlayer} playerAnyField={PlayerAnyField} " +
+                  "hasActive={HasActive} activeAnyField={ActiveAnyField} " +
+                  "auras={AuraCount} powers={PowerCount}")]
+    public static partial void ValuesUpdateIn(
+        ILogger logger, int index, ulong guidLow, ulong guidHigh,
+        HighGuidTypeLegacy legacyHigh, uint legacyEntry, ulong legacyCounter,
+        bool isPlayer, bool hasObjectField, bool hasUnit, bool unitAnyField,
+        long? health, long? maxHealth, uint flags,
+        bool hasPlayer, bool playerAnyField,
+        bool hasActive, bool activeAnyField,
+        int auraCount, int powerCount);
+
+    [LoggerMessage(
+        EventId = 1201,
+        Level = LogLevel.Debug,
+        Message = "[V343Trace][InvSlot] player slot={Slot} guidLow={GuidLow} guidHigh={GuidHigh}")]
+    public static partial void OwnerInvSlot(
+        ILogger logger, int slot, ulong guidLow, ulong guidHigh);
+
+    [LoggerMessage(
+        EventId = 1202,
+        Level = LogLevel.Trace,
+        Message = "[ActionBarTrace] PLAYER_FIELD_BYTES extracted: MultiActionBars=0x{MultiActionBars:X2} " +
+                  "raw32=0x{Raw:X8} guidLow={GuidLow} guidHigh={GuidHigh}")]
+    public static partial void ActionBarBytes(
+        ILogger logger, byte multiActionBars, uint raw, ulong guidLow, ulong guidHigh);
+}

--- a/HermesProxy/World/Objects/Version/V1_14_0_40237/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V1_14_0_40237/ObjectUpdateBuilder.cs
@@ -1187,7 +1187,7 @@ public class ObjectUpdateBuilder
             }
         }
 
-        ActivePlayerData activeData = m_updateData.ActivePlayerData;
+        ActivePlayerData? activeData = m_updateData.ActivePlayerData;
         if (activeData != null && m_objectType == Enums.ObjectTypeBCC.ActivePlayer)
         {
             for (int i = 0; i < 23; i++)

--- a/HermesProxy/World/Objects/Version/V1_14_1_40688/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V1_14_1_40688/ObjectUpdateBuilder.cs
@@ -1187,7 +1187,7 @@ public class ObjectUpdateBuilder
             }
         }
 
-        ActivePlayerData activeData = m_updateData.ActivePlayerData;
+        ActivePlayerData? activeData = m_updateData.ActivePlayerData;
         if (activeData != null && m_objectType == Enums.ObjectTypeBCC.ActivePlayer)
         {
             for (int i = 0; i < 23; i++)

--- a/HermesProxy/World/Objects/Version/V2_5_2_39570/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V2_5_2_39570/ObjectUpdateBuilder.cs
@@ -1187,7 +1187,7 @@ public class ObjectUpdateBuilder
             }
         }
 
-        ActivePlayerData activeData = m_updateData.ActivePlayerData;
+        ActivePlayerData? activeData = m_updateData.ActivePlayerData;
         if (activeData != null && m_objectType == Enums.ObjectTypeBCC.ActivePlayer)
         {
             for (int i = 0; i < 23; i++)

--- a/HermesProxy/World/Objects/Version/V2_5_3_41750/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V2_5_3_41750/ObjectUpdateBuilder.cs
@@ -1187,7 +1187,7 @@ public class ObjectUpdateBuilder
             }
         }
 
-        ActivePlayerData activeData = m_updateData.ActivePlayerData;
+        ActivePlayerData? activeData = m_updateData.ActivePlayerData;
         if (activeData != null && m_objectType == Enums.ObjectTypeBCC.ActivePlayer)
         {
             for (int i = 0; i < 23; i++)

--- a/HermesProxy/World/Server/CollectionSync.cs
+++ b/HermesProxy/World/Server/CollectionSync.cs
@@ -14,7 +14,7 @@ public static class CollectionSync
     {
         if (!state.SummonedBattlePetGuid.IsEmpty())
         {
-            update.ActivePlayerData.SummonedBattlePetGUID = state.SummonedBattlePetGuid;
+            update.EnsureActivePlayerData().SummonedBattlePetGUID = state.SummonedBattlePetGuid;
             if (!state.SummonedCompanionCreatureGuid.IsEmpty())
                 update.UnitData.Critter = state.SummonedCompanionCreatureGuid;
         }
@@ -60,7 +60,7 @@ public static class CollectionSync
 
         var state = session.GameState;
         var updateData = new ObjectUpdate(state.CurrentPlayerGuid, UpdateTypeModern.Values, session);
-        updateData.ActivePlayerData.SummonedBattlePetGUID = state.SummonedBattlePetGuid;
+        updateData.EnsureActivePlayerData().SummonedBattlePetGUID = state.SummonedBattlePetGuid;
         updateData.UnitData.Critter = state.SummonedCompanionCreatureGuid;
         var updatePacket = new UpdateObject(state);
         updatePacket.ObjectUpdates.Add(updateData);
@@ -129,9 +129,10 @@ public static class CollectionSync
         var usable = state.GetUsableToysOrdered();
         state.LastSentUsableToys = usable;
         var updateData = new ObjectUpdate(state.CurrentPlayerGuid, UpdateTypeModern.Values, session);
-        updateData.ActivePlayerData.Toys = new List<int>(usable.Length);
+        var toys = new List<int>(usable.Length);
         for (int i = 0; i < usable.Length; i++)
-            updateData.ActivePlayerData.Toys.Add((int)usable[i]);
+            toys.Add((int)usable[i]);
+        updateData.EnsureActivePlayerData().Toys = toys;
         var updatePacket = new UpdateObject(state);
         updatePacket.ObjectUpdates.Add(updateData);
         session.WorldClient.SendPacketToClient(updatePacket);

--- a/HermesProxy/World/Server/CurrentPlayerStorage.cs
+++ b/HermesProxy/World/Server/CurrentPlayerStorage.cs
@@ -165,7 +165,7 @@ public class CompletedQuestTracker
             _cachedQuestCompleted[idx] &= ~(((ulong)1) << bitIdx);
         
         ObjectUpdate updateData = new ObjectUpdate(Session.GameState.CurrentPlayerGuid, UpdateTypeModern.Values, Session);
-        updateData.ActivePlayerData.QuestCompleted[idx] = _cachedQuestCompleted[idx];
+        updateData.EnsureActivePlayerData().QuestCompleted[idx] = _cachedQuestCompleted[idx];
 
         UpdateObject updatePacket = new UpdateObject(Session.GameState);
         updatePacket.ObjectUpdates.Add(updateData);

--- a/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/MovementHandler.cs
@@ -7,6 +7,8 @@ using HermesProxy.World.Logging;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
 
 namespace HermesProxy.World.Server;
 
@@ -14,6 +16,33 @@ public partial class WorldSocket
 {
     private static readonly Microsoft.Extensions.Logging.ILogger _melTransportRider =
         Log.CreateMelLogger(Log.CategoryServer);
+
+    // CMSG_MOVE_* (universal, as the modern client sends it) -> MSG_MOVE_* (universal, the name
+    // the 3.3.5a-era protocol uses for the same message). Built once from the enum names so it
+    // cannot drift from the enum, then resolved through LegacyVersion's array lookup.
+    //
+    // HandlePlayerMove used to derive this per packet: enum ToString, string Replace, then a
+    // reflection-backed Enum.TryParse against the version's opcode enum. That measured 128 B and
+    // 595 ns on every movement packet -- the highest-rate client opcode there is -- versus 0 B and
+    // 2.3 ns for the lookup below (MovementHandlerPrologueBenchmarks).
+    private static readonly FrozenDictionary<Opcode, Opcode> ClientMoveToLegacyMsg =
+        BuildClientMoveToLegacyMsg();
+
+    private static FrozenDictionary<Opcode, Opcode> BuildClientMoveToLegacyMsg()
+    {
+        const string clientPrefix = "CMSG_MOVE";
+        var map = new Dictionary<Opcode, Opcode>();
+        foreach (Opcode op in Enum.GetValues<Opcode>())
+        {
+            string name = op.ToString();
+            if (!name.StartsWith(clientPrefix, StringComparison.Ordinal))
+                continue;
+            // "CMSG_MOVE_JUMP" -> "MSG_MOVE_JUMP"; matches the old Replace("CMSG", "MSG").
+            if (Enum.TryParse(string.Concat("MSG_", name.AsSpan("CMSG_".Length)), out Opcode legacyMsg))
+                map[op] = legacyMsg;
+        }
+        return map.ToFrozenDictionary();
+    }
 
     // Handlers for CMSG opcodes coming from the modern client
     [PacketHandler(Opcode.CMSG_MOVE_CHANGE_TRANSPORT)]
@@ -48,11 +77,12 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_MOVE_DOUBLE_JUMP)]
     void HandlePlayerMove(ClientPlayerMovement movement)
     {
-        string opcodeName = movement.GetUniversalOpcode().ToString();
-        opcodeName = opcodeName.Replace("CMSG", "MSG");
-        uint opcode = Opcodes.GetOpcodeValueForVersion(opcodeName, LegacyVersion.Build);
+        Opcode universalOpcode = movement.GetUniversalOpcode();
+        uint opcode = ClientMoveToLegacyMsg.TryGetValue(universalOpcode, out Opcode legacyMsg)
+            ? LegacyVersion.GetCurrentOpcode(legacyMsg)
+            : 0u;
         if (opcode == 0)
-            opcode = Opcodes.GetOpcodeValueForVersion("MSG_MOVE_SET_FACING", LegacyVersion.Build);
+            opcode = LegacyVersion.GetCurrentOpcode(Opcode.MSG_MOVE_SET_FACING);
 
         // The client attaches itself to a transport WMO it stands on, the way a 3.3.5a
         // client does, and that is what the backend's Strand of the Ancients boarding relies
@@ -66,7 +96,7 @@ public partial class WorldSocket
             {
                 // Both halves: a HighGuid::Transport guid keeps its identity in High and
                 // has Low = 0, so Low alone reads as "0 -> 0" on AzerothCore.
-                TransportLogMessages.ClientTransportChanged(_melTransportRider, opcodeName,
+                TransportLogMessages.ClientTransportChanged(_melTransportRider, universalOpcode.ToString(),
                     gameState.LastReportedTransportGuid.Low, gameState.LastReportedTransportGuid.High,
                     moveInfo.TransportGuid.Low, moveInfo.TransportGuid.High,
                     moveInfo.StandingOnGameObjectGuid.Low,

--- a/HermesProxy/World/Server/Packets/MovementPackets.cs
+++ b/HermesProxy/World/Server/Packets/MovementPackets.cs
@@ -64,10 +64,17 @@ public class MoveUpdate : ServerPacket, ISpanWritable
 public class MonsterMove : ServerPacket, ISpanWritable
 {
     // Practical cap for spline points - covers real-world movement patterns
-    // Real usage: Points=0-2 (next destination), PackedDeltas=0-15 (obstacle smoothing)
-    // Reduced from 64 to 16 based on actual usage data (74-116 bytes observed)
-    // If exceeded, WriteToSpan returns -1 to trigger fallback to Write()
-    private const int MaxSplinePoints = 16;
+    // Corruption guard, not a sizing cap. SplineCount is read straight off the legacy wire
+    // (MovementHandler.cs:563) and is unbounded, so a garbage count must not turn into a
+    // huge ArrayPool rent; beyond this WriteToSpan bails to the ByteBuffer path. MaxSize
+    // below sizes the rent from the spline this packet actually carries, so a normal path
+    // of any length still takes the span path.
+    //
+    // A previous fixed cap of 16 (reduced from 64 "based on actual usage data") was measured
+    // against light traffic. Under a bot-populated battleground it missed 370 times in ten
+    // minutes, and every miss rented a pooled buffer it discarded, re-wrote the packet through
+    // ByteBuffer, and emitted a Warn-level log on a per-packet path.
+    private const int MaxSplinePoints = 4096;
 
     public MonsterMove(WowGuid128 guid, ServerSideMovement moveSpline) : base(Opcode.SMSG_ON_MONSTER_MOVE, ConnectionType.Instance)
     {
@@ -182,17 +189,20 @@ public class MonsterMove : ServerPacket, ISpanWritable
                 $"wire={_worldPacket.GetSize()}B");
     }
 
-    // MaxSize computed from MaxSplinePoints:
     // Fixed: GUID(18) + StartPos(12) + SplineId(4) + Dest(12) + flags/times(36) + bits(6) = 88
     // SplineType FacingTarget (worst case, V2_5+): float(4) + GUID(18) = 22
-    // Points: MaxSplinePoints * Vector3(12)
-    // PackedDeltas: MaxSplinePoints * PackedXYZ(4)
     private const int FixedSize = 88 + 22; // 110 bytes
-    public int MaxSize => FixedSize + MaxSplinePoints * 12 + MaxSplinePoints * 4;
+
+    // Sized from this packet's own spline: Points write as Vector3 (12 B), PackedDeltas as
+    // PackXYZ (4 B) -- see WriteToSpan. Both lists are filled in the constructor, so the count
+    // is known before WritePacketData rents. ArrayPool rounds the rent up to its bucket, so
+    // exact sizing costs nothing versus a constant and never under-provisions.
+    public int MaxSize => FixedSize + Points.Count * 12 + PackedDeltas.Count * 4;
 
     public int WriteToSpan(Span<byte> buffer)
     {
-        // Check if we exceed the cap - if so, return -1 to trigger fallback
+        // Only a corrupt or hostile SplineCount should land here; MaxSize already sized the
+        // buffer for this spline's real length.
         if (Points.Count > MaxSplinePoints || PackedDeltas.Count > MaxSplinePoints)
             return -1;
 

--- a/HermesProxy/World/Server/Packets/UpdatePackets.cs
+++ b/HermesProxy/World/Server/Packets/UpdatePackets.cs
@@ -73,7 +73,12 @@ public class ObjectUpdate
             case ObjectType.ActivePlayer:
                 UnitData = new UnitData();
                 PlayerData = new PlayerData();
-                ActivePlayerData = new ActivePlayerData();
+                // ActivePlayerData is deliberately not allocated here. It is owner-only data
+                // (~32 KB of nullable arrays, QuestCompleted[875] alone being 14 KB), and a
+                // 3.3.5a core never sends owner-only fields for a foreign player, so every
+                // other Player in view -- every bot in a battleground -- allocated and then
+                // discarded the whole block. EnsureActivePlayerData() materialises it on the
+                // first owner field written; every reader already treats null as "no fields".
                 break;
             case ObjectType.GameObject:
                 GameObjectData = new GameObjectData();
@@ -87,6 +92,13 @@ public class ObjectUpdate
         }
     }
 
+    /// <summary>
+    /// Materialises <see cref="ActivePlayerData"/> on demand. Call this from every write
+    /// site; read sites keep using the field so a foreign player stays at null.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ActivePlayerData EnsureActivePlayerData() => ActivePlayerData ??= new ActivePlayerData();
+
     public UpdateTypeModern Type;
     public WowGuid128 Guid;
     public GlobalSessionData GlobalSession;
@@ -96,7 +108,7 @@ public class ObjectUpdate
     public ContainerData ContainerData = null!;
     public UnitData UnitData = null!;
     public PlayerData PlayerData = null!;
-    public ActivePlayerData ActivePlayerData = null!;
+    public ActivePlayerData? ActivePlayerData;
     public GameObjectData GameObjectData = null!;
     /// <summary>
     /// Stop frame for a type 11 transport, emitted as the single PauseTimes entry. Taken


### PR DESCRIPTION
Three allocation and CPU fixes in the packet hot path, each measured with a micro-benchmark and verified in a live bot battleground against the dated `docs/perf.md` baseline.

Method: `test-loop2.ps1 -AcoreBots -EnterWorld -Metrics -QuietLogs` against AzerothCore + mod-playerbots on a separate machine, Arathi Basin with bots, Release, Information log levels, sniff on — the same conditions the baseline was captured under. Two runs: one with only the first commit, one with all three. The per-opcode metrics table is cumulative since process start, so every per-packet figure below is a **delta between consecutive 60 s summaries**, not a lifetime average.

## 1. ActivePlayerData allocated for every player in view

`ObjectUpdate`'s constructor gave every Player-typed update an `ActivePlayerData` — ~32 KB of nullable arrays, of which `QuestCompleted[875]` is 14 KB and `SkillInfo`'s seven `ushort?[256]` another 7 KB. It is owner-only data that the builder only ever emits for `ActivePlayer`, so every *other* player in view allocated and discarded the whole block. In a bot battleground every bot is a Player.

| `ObjectUpdateConstructionBenchmarks` (x64) | before | after |
|---|---:|---:|
| `CreatePlayer` | 34,208 B / 1,483 ns | **3,400 B / 350 ns** |
| `CreatePlayerWithCreateData` | 34,272 B / 1,526 ns | **3,464 B / 224 ns** |
| `CreateUnit` (control) | 2,288 B / 169 ns | 2,288 B / 172 ns |

**−90.1% bytes, −76% time.**

No reader needed changing — the generated writers already did `?? new ActivePlayerData()`, `HasAnyActivePlayerFieldSet` already returned false on null, the V1_14/V2_5 builders already tested `activeData != null`, and `IsEmptyValuesDelta` already guarded its probe.

**One generator bug fixed along the way.** `HasAny{Section}FieldSet` emitted its mask-mutator predicates *after* `if (src == null) return false`, but one of them — `ActiveGlyphsDirty` — sources from the session, not the section object. With eager allocation `src` was never null so the line was always reached; with lazy allocation an owner update that set no `ActivePlayerData` field returned early and **dropped the glyph section**. Predicates that never read `src` now come before the null guard. The snapshot diff is exactly that one line moving.

## 2. Movement opcode translation did a string round trip per packet

`HandlePlayerMove` built a string and parsed it back on every movement packet — the highest-rate client opcode there is:

```csharp
string opcodeName = movement.GetUniversalOpcode().ToString();
opcodeName = opcodeName.Replace("CMSG", "MSG");
uint opcode = Opcodes.GetOpcodeValueForVersion(opcodeName, LegacyVersion.Build);
```

`GetOpcodeValueForVersion` uses the reflection overload of `Enum.TryParse` against a 1,311-entry version enum. An allocation-free array lookup for the same translation already existed and is used everywhere else in the proxy.

| `MovementHandlerPrologueBenchmarks` (256 iters) | before | after |
|---|---:|---:|
| Allocated | 32,854 B | **0 B** |
| Time | 151.7 µs | **1.58 µs** |
| Per movement packet | 128 B / 593 ns | **0 B / 6.2 ns** |

**96× faster, zero allocation.**

This also **answers the open question in `docs/perf.md`** about a recurring ~394 KB allocation on movement packets. It was this: a rare large cost that a per-call average hides, which is why it showed as `P99 == Max` at near-identical values across unrelated movement opcodes.

| `CMSG_MOVE_SET_FACING_HEARTBEAT` | run 1 (without this fix) | run 2 (with) |
|---|---:|---:|
| Average | 19,113 B | **1,401 B** |
| Max | 394,136 B | **3,104 B** |
| Share of C→S allocation | 32.2% | **~16%** |

Run 1 reached 394,136 B by 379 movement packets. Run 2 finished with 1,529 packets and a max of 3,104 B.

## 3. MonsterMove fell back off the span path constantly

`MaxSize` was a constant from `MaxSplinePoints`, lowered from 64 to 16 "based on actual usage data (74-116 bytes observed)". That data came from light traffic. Under a bot battleground the fallback fired **370 times in ten minutes**, each miss renting a pooled buffer it discarded, re-writing through `ByteBuffer`, and emitting a Warn-level log — Warn routes to Information, so per-packet logging enabled in production, against a baseline that already attributed ~22% of proxy CPU to Serilog with this message named as a source.

A larger constant only moves the cliff: `SplineCount` is read straight off the legacy wire and is unbounded. `MaxSize` is now computed from the spline the packet actually carries. `ArrayPool` rounds the rent to its bucket, so exact sizing costs nothing and never under-provisions. `MaxSplinePoints` survives at 4096 as a corruption guard only.

| | run 1 | run 2 |
|---|---:|---:|
| `MonsterMove` fallbacks | 370 / 10 min | **0** |
| `SMSG_ON_MONSTER_MOVE` packets | — | 22,249 |

To be precise about the win: this is a CPU and logging fix, not an allocation one. `SMSG_ON_MONSTER_MOVE` still averages ~1,444 B per packet, essentially unchanged. What goes away is 370 wasted rents, 370 double-writes and 370 Warn-level log calls on a per-packet path.

## Live result

Run 2, all three commits, 17-minute Arathi Basin. Twelve match windows spanning 236–605 pkt/s against the baseline's 390–620:

| Metric | baseline | run 2 |
|---|---:|---:|
| `SMSG_COMPRESSED_UPDATE_OBJECT` | 94 KB/pkt | **28.0–38.9 KB/pkt** |
| …share of S→C allocation | 79% | **61.4%** |
| Allocation rate | 1.5–2.3 MB/s | **0.41–1.17 MB/s** |
| Gen0 | 22–35 /min | **7–18 /min** |
| Gen2 | 1 per 15 min | 1 per 17 min |
| CPU | 1.8% of a core | **1.67%** |
| Lock contention | ~0 | 1 per 100 s |
| Heap | 92 MB flat | 105 MB flat |

Best single window, at 605.2 pkt/s — inside the baseline's rate band:

```
GC over 60s: gen0 +7 gen1 +7 gen2 +0 | allocated 24.7 MB (0.41 MB/s) | heap 104.3 MB | pause 0.03%
SMSG_COMPRESSED_UPDATE_OBJECT  Δ380 pkts  Δ11,021 KB  ->  29.0 KB/pkt
```

**3.7–5.6× lower allocation rate at a matched packet rate.**

## What this does not claim

- Update-object bytes/packet varies 28–39 KB across windows with bot density. The spread is real; the gap to the baseline's 94 KB is much larger than the spread.
- Run 2's figures run slightly above run 1's at comparable rates. That is bot density, not regression — run 2 pushed more packets.
- CPU moved 1.8% -> 1.67%, which is within run-to-run noise on this workload. The allocation and GC numbers are the solid ones.
- `SetSpellModifier` still falls back (6 times per session, both runs). Same class of fix, deliberately left out so it gets its own measurement.

## Verification

- `dotnet build` zero warnings; `dotnet test` **1020 passing**.
- `MovementOpcodeMappingTests` walks every `CMSG_MOVE_*` opcode and asserts the array lookup and the old reflection lookup return the same value. The risk in that swap was never the string cost, it was the two tables disagreeing and silently sending the backend a wrong opcode — which surfaces as rubber-banding, not an error. They agree.
- The `MonsterMove` test that pinned the old fallback contract is replaced by one asserting the span output is byte-identical to `Write()` for a 20-point spline (now a live path), plus one asserting the guard still trips at 5000.
- Glyph path exercised live and confirmed in the log after the generator fix.

## Unrelated issue seen during testing

`CMSG_OBJECT_UPDATE_FAILED` with a null guid appeared in both runs — once in run 1, twice in run 2, six minutes apart, no disconnect either time. Different code between the runs, identical signature, so it is independent of this branch. The trigger is now identified: **clicking a player corpse to take the PvP insignia**. Worth noting for whoever picks it up that the guid decodes to `Low=0 High=1 highType=Null entry=0` *identically every time*, which is as consistent with the proxy misparsing the V3_4_3 packet as with the client reporting an unresolvable object; `ObjectUpdateFailed.Read()` reads a single packed GUID and nothing else. Verify that layout before treating the null guid as data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019p1wW7nkNtVwYdvxmo7PVq
