### PR TITLE
fix(diagnostics): report the auth-failure code, drop pooled slack from sniffs

### DIFF
--- a/Framework/IO/ByteBuffer.cs
+++ b/Framework/IO/ByteBuffer.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (C) 2012-2020 CypherCore <http://github.com/CypherCore>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -910,6 +910,25 @@ public class ByteBuffer : IDisposable
         return _length;
     }
 
+    /// <summary>
+    /// The bytes actually written or received, with no pooled slack on the end. Prefer this over
+    /// <see cref="GetData"/> anywhere the length is meaningful — a capture, a hash, a hex dump —
+    /// because in read mode <c>GetData</c> hands back the whole rental, which is rounded up to an
+    /// <see cref="System.Buffers.ArrayPool{T}"/> bucket and so is routinely larger than the packet.
+    /// </summary>
+    public ReadOnlySpan<byte> GetDataSpan()
+    {
+        if (_isWriteMode)
+            FlushBits();
+
+        return _buffer.AsSpan(0, _length);
+    }
+
+    /// <remarks>
+    /// In read mode this returns the backing buffer itself, which for a pooled receive is longer
+    /// than the packet — <c>GetData().Length</c> is not the packet length. Use
+    /// <see cref="GetDataSpan"/> when the length matters.
+    /// </remarks>
     public byte[] GetData()
     {
         if (_isWriteMode)
@@ -922,7 +941,6 @@ public class ByteBuffer : IDisposable
         }
         else
         {
-            // For read mode, return the original buffer (which IS the right size)
             return _buffer;
         }
     }

--- a/HermesProxy.Tests/Framework/ByteBufferDataSpanTests.cs
+++ b/HermesProxy.Tests/Framework/ByteBufferDataSpanTests.cs
@@ -1,0 +1,86 @@
+using System.Buffers;
+using Framework.IO;
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.Framework;
+
+/// <summary>
+/// Cover for <see cref="ByteBuffer.GetDataSpan"/>, the length-honest counterpart to
+/// <see cref="ByteBuffer.GetData"/>.
+///
+/// A received packet is read into an <see cref="ArrayPool{T}"/> rental, which is rounded up to a
+/// bucket size, and the read-mode <c>GetData</c> returns that whole rental. Writing it to a sniff
+/// therefore recorded the bucket, not the payload: a 42-byte <c>SMSG_AUTH_CHALLENGE</c> landed in
+/// a 64-byte rental and every capture claimed a 62-byte body against a real 40. That artefact was
+/// misread as evidence of a customised server core while triaging
+/// <see href="https://github.com/Xian55/HermesProxy/issues/248">#248</see> — the same slack shows
+/// up against a stock TrinityCore.
+/// </summary>
+public class ByteBufferDataSpanTests
+{
+    // The real shape from WorldClient.ReceiveLoop: SMSG_AUTH_CHALLENGE is 2 opcode + 40 body.
+    private const int AuthChallengePacketSize = 42;
+
+    [Fact]
+    public void GetDataSpan_ReadModePooledBuffer_ReturnsPayloadLengthNotRentalLength()
+    {
+        byte[] rental = ArrayPool<byte>.Shared.Rent(AuthChallengePacketSize);
+        try
+        {
+            using var packet = new WorldPacket(rental, AuthChallengePacketSize, isPooled: false);
+
+            Assert.Equal(AuthChallengePacketSize, packet.GetDataSpan().Length);
+            Assert.Equal((uint)AuthChallengePacketSize, packet.GetSize());
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rental);
+        }
+    }
+
+    /// <summary>
+    /// Guards the premise rather than the fix: if the pool ever handed back an exactly-sized array
+    /// the bug would be invisible and the test above would pass for the wrong reason.
+    /// </summary>
+    [Fact]
+    public void GetData_ReadModePooledBuffer_IsLongerThanThePayload()
+    {
+        byte[] rental = ArrayPool<byte>.Shared.Rent(AuthChallengePacketSize);
+        try
+        {
+            Assert.True(
+                rental.Length > AuthChallengePacketSize,
+                $"ArrayPool returned an exact-size {rental.Length}-byte array; this test no longer proves anything.");
+
+            using var packet = new WorldPacket(rental, AuthChallengePacketSize, isPooled: false);
+
+            Assert.Equal(rental.Length, packet.GetData().Length);
+            Assert.True(packet.GetData().Length > packet.GetDataSpan().Length);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rental);
+        }
+    }
+
+    [Fact]
+    public void GetDataSpan_WriteMode_MatchesGetData()
+    {
+        var buffer = new ByteBuffer();
+        buffer.WriteUInt32(1);
+        buffer.WriteUInt32(0xC94B8C0D);
+
+        Assert.Equal(buffer.GetData(), buffer.GetDataSpan().ToArray());
+        Assert.Equal(8, buffer.GetDataSpan().Length);
+    }
+
+    [Fact]
+    public void GetDataSpan_ReadModeExactBuffer_MatchesGetData()
+    {
+        var data = new byte[] { 0xEC, 0x01, 0x01, 0x00, 0x00, 0x00 };
+        var buffer = new ByteBuffer(data);
+
+        Assert.Equal(data, buffer.GetDataSpan().ToArray());
+    }
+}

--- a/HermesProxy.Tests/World/AuthFailureLoggingTests.cs
+++ b/HermesProxy.Tests/World/AuthFailureLoggingTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+/// <summary>
+/// Cover for the world-auth failure log lines.
+///
+/// The legacy server's verdict used to be dropped on the floor — the line read only
+/// "Authentication failed!", so telling <c>AUTH_FAILED</c> (13, a digest or session-key mismatch)
+/// apart from <c>AUTH_REJECT</c> (14, credentials accepted and a policy check refused the session)
+/// meant decoding the <c>.pkt</c> by hand. That distinction is what identified the cause of
+/// <see href="https://github.com/Xian55/HermesProxy/issues/248">#248</see>.
+///
+/// These assert the rendered text because the code is only useful to a human reading a log, and
+/// because the failure path needs a backend that refuses the session, which no test backend does.
+/// </summary>
+public class AuthFailureLoggingTests
+{
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
+    }
+
+    [Theory]
+    [InlineData(AuthResult.AUTH_REJECT, 14)]
+    [InlineData(AuthResult.AUTH_FAILED, 13)]
+    [InlineData(AuthResult.AUTH_BANNED, 28)]
+    public void AuthenticationFailed_NamesTheCodeAndItsRawValue(AuthResult result, byte expectedId)
+    {
+        var logger = new CapturingLogger();
+
+        WorldClientLogMessages.AuthenticationFailed(logger, "WorldClient", "", result, (byte)result);
+
+        string message = Assert.Single(logger.Messages);
+        Assert.Contains(result.ToString(), message);
+        Assert.Contains($"({expectedId})", message);
+        Assert.Equal(expectedId, (byte)result);
+    }
+
+    /// <summary>
+    /// The client-facing half. <c>WorldSocket</c> tells the modern client <c>BadServer</c> and
+    /// drops the session, so this is the only place the backend's verdict reaches the log on that
+    /// side — including when no response arrived at all, which is what a local TrinityCore does:
+    /// it sends <c>AUTH_REJECT</c> and closes so promptly that the read hits EOF first.
+    /// </summary>
+    [Fact]
+    public void WorldClientConnectFailed_CarriesTheLegacyVerdict()
+    {
+        var logger = new CapturingLogger();
+
+        WorldSocketLogMessages.WorldClientConnectFailed(logger, "WorldSocket", "", "AUTH_REJECT (14)");
+
+        Assert.Contains("AUTH_REJECT (14)", Assert.Single(logger.Messages));
+    }
+
+    [Fact]
+    public void WorldClientConnectFailed_NoResponse_SaysSo()
+    {
+        var logger = new CapturingLogger();
+
+        WorldSocketLogMessages.WorldClientConnectFailed(logger, "WorldSocket", "", "none received");
+
+        Assert.Contains("none received", Assert.Single(logger.Messages));
+    }
+}

--- a/HermesProxy.Tests/World/SniffFileLengthTests.cs
+++ b/HermesProxy.Tests/World/SniffFileLengthTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.IO;
+using HermesProxy.World;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+/// <summary>
+/// The record length <see cref="SniffFile"/> writes for a server packet must be the payload, not
+/// the <see cref="ArrayPool{T}"/> rental it was received into.
+///
+/// This is the test that was missing while triaging
+/// <see href="https://github.com/Xian55/HermesProxy/issues/248">#248</see>: a 42-byte
+/// <c>SMSG_AUTH_CHALLENGE</c> arrives in a 64-byte rental, the capture recorded all 64, and the
+/// resulting apparent 62-byte body (against a real 40) was misread as proof of a customised
+/// server core. A stock TrinityCore produces the identical inflated capture.
+/// </summary>
+public class SniffFileLengthTests
+{
+    private const ushort LegacyBuild = 12340;
+    private const ushort SmsgAuthChallenge = 0x1EC;
+
+    // 2-byte opcode + 40-byte body, the real 3.3.5a SMSG_AUTH_CHALLENGE frame.
+    private const int PacketSize = 42;
+
+    /// <summary>PKT header: "PKT" + uint16 version + uint16 build + 40 session-key bytes.</summary>
+    private const int PktHeaderSize = 3 + 2 + 2 + 40;
+
+    /// <summary>Per-record prologue: direction byte + unixtime + tickcount + size.</summary>
+    private const int RecordPrologueSize = 1 + 4 + 4 + 4;
+
+    [Fact]
+    public void WritePacket_ServerPacketFromPooledBuffer_RecordsPayloadLengthNotRentalLength()
+    {
+        byte[] rental = ArrayPool<byte>.Shared.Rent(PacketSize);
+        SniffFile? sniff = null;
+        try
+        {
+            Assert.True(
+                rental.Length > PacketSize,
+                $"ArrayPool returned an exact-size {rental.Length}-byte array; this test no longer proves anything.");
+
+            // Poison the slack so a regression shows up as recorded bytes, not just a length.
+            rental.AsSpan().Fill(0xAA);
+            BinaryPrimitives.WriteUInt16LittleEndian(rental, SmsgAuthChallenge);
+            rental.AsSpan(2, PacketSize - 2).Clear();
+
+            using var packet = new WorldPacket(rental, PacketSize, isPooled: false);
+
+            // EnsureOpen rather than the ctor: it is what production uses, and it writes the
+            // PKT header before publishing the reference.
+            SniffFile slot = null!;
+            sniff = SniffFile.EnsureOpen(ref slot, "test-authchallenge", LegacyBuild);
+            sniff.WritePacket(packet.GetOpcode(), isFromClient: false, packet.GetDataSpan());
+            sniff.CloseFile();
+
+            byte[] written = File.ReadAllBytes(sniff.FilePath);
+
+            uint recordedSize = BinaryPrimitives.ReadUInt32LittleEndian(
+                written.AsSpan(PktHeaderSize + RecordPrologueSize - 4, 4));
+
+            // SniffFile prefixes the server record with its own uint16 opcode.
+            Assert.Equal((uint)(PacketSize + sizeof(ushort)), recordedSize);
+            Assert.Equal(PktHeaderSize + RecordPrologueSize + PacketSize + sizeof(ushort), written.Length);
+
+            // None of the 0xAA slack may have reached the file.
+            Assert.DoesNotContain((byte)0xAA, written);
+        }
+        finally
+        {
+            sniff?.CloseFile();
+            if (sniff is not null && File.Exists(sniff.FilePath))
+                File.Delete(sniff.FilePath);
+            ArrayPool<byte>.Shared.Return(rental);
+        }
+    }
+}

--- a/HermesProxy/World/Client/WorldClient.cs
+++ b/HermesProxy/World/Client/WorldClient.cs
@@ -68,6 +68,14 @@ public partial class WorldClient
     Dictionary<Opcode, List<WorldPacket>> _delayedPacketsToServer = null!;
     Dictionary<Opcode, List<ServerPacket>> _delayedPacketsToClient = null!;
 
+    /// <summary>
+    /// Last <c>SMSG_AUTH_RESPONSE</c> code the legacy world server sent, or <c>null</c> if the
+    /// handshake died before one arrived (socket refused, unknown opcode during the handshake).
+    /// Read by <see cref="Server.WorldSocket"/> so the client-facing failure line can name the
+    /// backend's verdict instead of only reporting that the connect failed.
+    /// </summary>
+    public AuthResult? LastAuthResult { get; private set; }
+
     public WorldClient()
     {
         InitializePacketHandlers();
@@ -93,7 +101,10 @@ public partial class WorldClient
 
         var sniff = SniffFile.EnsureOpen(ref session.LegacySniff, "legacy", (ushort)LegacyVersion.Build);
 
-        ReadOnlySpan<byte> body = packet.GetData();
+        // GetDataSpan, not GetData: received packets sit in an ArrayPool rental rounded up to a
+        // bucket, so GetData would staple that slack onto every captured server packet and make
+        // the .pkt claim payloads longer than the wire ever carried (issue #248).
+        ReadOnlySpan<byte> body = packet.GetDataSpan();
         uint opcode = packet.GetOpcode();
 
         if (isFromClient)
@@ -115,6 +126,7 @@ public partial class WorldClient
         _globalSession = globalSession;
         _username = globalSession.Username;
         _isSuccessful = null;
+        LastAuthResult = null;
         _delayedPacketsToServer = new Dictionary<Opcode, List<WorldPacket>>();
         _delayedPacketsToClient = new Dictionary<Opcode, List<ServerPacket>>();
 
@@ -771,6 +783,7 @@ public partial class WorldClient
     private void HandleAuthResponse(WorldPacket packet)
     {
         AuthResult result = (AuthResult)packet.ReadUInt8();
+        LastAuthResult = result;
 
         if (_isSuccessful == null)
         {
@@ -798,14 +811,14 @@ public partial class WorldClient
         else if (result == AuthResult.AUTH_WAIT_QUEUE)
         {
             _queuePosition = packet.ReadUInt32();
-            Log.Print(LogType.Network, $"Position in queue is {_queuePosition}.");
+            WorldClientLogMessages.QueuePosition(_melNet, _sourceFile, _netDirNone, _queuePosition);
             if (_isSuccessful != null && GetSession().RealmSocket != null)
                 GetSession().RealmSocket.SendAuthWaitQue(_queuePosition);
             _isSuccessful = true;
         }
         else
         {
-            Log.Print(LogType.Network, "Authentication failed!");
+            WorldClientLogMessages.AuthenticationFailed(_melNet, _sourceFile, _netDirNone, result, (byte)result);
             _isSuccessful = false;
         }
     }

--- a/HermesProxy/World/Logging/WorldClientLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldClientLogMessages.cs
@@ -227,4 +227,34 @@ internal static partial class WorldClientLogMessages
         string SourceFile,
         string NetDir,
         int Records);
+
+    /// <summary>
+    /// The legacy world server refused the session. <paramref name="ResultId"/> carries the raw
+    /// byte alongside the enum name because a customised core can send a code this build's
+    /// <see cref="AuthResult"/> has no name for, and the number is what the core's source is
+    /// grepped for. The distinction matters for triage: AUTH_FAILED (13) is a digest or
+    /// session-key mismatch, while AUTH_REJECT (14) means the credentials were accepted and a
+    /// policy check refused us anyway -- an OS whitelist, an IP ban, or a closed realm
+    /// (issue #248).
+    /// </summary>
+    [LoggerMessage(
+        EventId = 220,
+        Level = LogLevel.Warning,
+        Message = "Authentication failed! Server answered SMSG_AUTH_RESPONSE {Result} ({ResultId}).")]
+    public static partial void AuthenticationFailed(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        AuthResult Result,
+        byte ResultId);
+
+    [LoggerMessage(
+        EventId = 221,
+        Level = LogLevel.Information,
+        Message = "Position in queue is {Position}.")]
+    public static partial void QueuePosition(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        uint Position);
 }

--- a/HermesProxy/World/Logging/WorldSocketLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldSocketLogMessages.cs
@@ -145,4 +145,20 @@ internal static partial class WorldSocketLogMessages
         string NetDir,
         byte TeamSize,
         bool AsGroup);
+
+    /// <summary>
+    /// The modern client is told BadServer and dropped here, so this line is the only place the
+    /// legacy world server's own verdict reaches the log on the client-facing side. Carrying
+    /// <paramref name="LegacyAuthResult"/> across saves a .pkt decode to answer "why" -- see
+    /// <see cref="WorldClientLogMessages.AuthenticationFailed"/> for what the codes mean.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 116,
+        Level = LogLevel.Error,
+        Message = "The WorldClient failed to connect to the selected world server! (legacy SMSG_AUTH_RESPONSE: {LegacyAuthResult})")]
+    public static partial void WorldClientConnectFailed(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        string LegacyAuthResult);
 }

--- a/HermesProxy/World/Packet.cs
+++ b/HermesProxy/World/Packet.cs
@@ -66,7 +66,9 @@ public abstract class ClientPacket : IDisposable
             return;
 
         var sniff = SniffFile.EnsureOpen(ref sniffFile, "modern", (ushort)context.ClientBuild);
-        sniff.WritePacket(GetOpcode(), true, _worldPacket.GetData());
+        // GetDataSpan: this packet was received into a pooled rental, and GetData would hand back
+        // the whole bucket-rounded buffer rather than the payload (issue #248).
+        sniff.WritePacket(GetOpcode(), true, _worldPacket.GetDataSpan());
     }
 
     protected WorldPacket _worldPacket;

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -55,6 +55,7 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
     private static readonly string _sourceFile = nameof(WorldSocket).PadRight(15);
     private static readonly string _netDirRecv = Log.FormatDir(LogNetDir.C2P);
     private static readonly string _netDirSend = Log.FormatDir(LogNetDir.P2C);
+    private const string _netDirNone = "";
 
     static readonly string ClientConnectionInitialize = "WORLD OF WARCRAFT CONNECTION - CLIENT TO SERVER - V2";
     static readonly string ServerConnectionInitialize = "WORLD OF WARCRAFT CONNECTION - SERVER TO CLIENT - V2";
@@ -797,7 +798,13 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
         if (!GetSession().WorldClient!.ConnectToWorldServer(GetSession().RealmManager.GetRealm(_realmId)!, GetSession()))
         {
             SendAuthResponseError(BattlenetRpcErrorCode.BadServer);
-            Log.Print(LogType.Error, "The WorldClient failed to connect to the selected world server!");
+            // Only reached once, on a dead session, so the interpolation here is not on any path
+            // that runs twice. Without the code this line said nothing about *why* the backend
+            // refused us and the answer could only be recovered by decoding the .pkt (issue #248).
+            var legacyResult = GetSession().WorldClient!.LastAuthResult;
+            WorldSocketLogMessages.WorldClientConnectFailed(
+                _melLog, _sourceFile, _netDirNone,
+                legacyResult is { } r ? $"{r} ({(byte)r})" : "none received");
             Session.AccountMetaDataMgr.InvalidateLastSelectedCharacter();
             CloseSocket();
             GetSession().OnDisconnect();

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -19,6 +19,18 @@ This is not a gap waiting to be filled. A modern Classic client runs a Warden mo
 
 **Consequence:** the remote server must have Warden disabled. Every backend used to develop and test HermesProxy runs with it off — that is the default for `vmangos-deploy`, and TrinityCore, AzerothCore and CMaNGOS all ship it disabled or trivially disableable in config.
 
+### Rejected at login: check `ReportedOS` first
+
+Some Warden-enabled cores gate the session on the OS string the account logged in with, *before* any Warden check runs. TrinityCore refuses anything but `Win`/`OSX` with `AUTH_REJECT` (`WorldSocket.cpp`, `wardenActive && !ClientBuild::Platform::IsValid(account.OS)`). HermesProxy sends that string from `ClientOptions.ReportedOS`, which **defaults to `OSX`**.
+
+The symptom is specific: logon succeeds, the realm list arrives, and the world server closes at realm join. `AUTH_REJECT` (14) means the session key was accepted and a policy check refused it — unlike `AUTH_FAILED` (13), which is a digest or key mismatch. Try:
+
+```
+HermesProxy.exe --set ReportedOS=Win
+```
+
+Confirmed on WoW Circle ([#248](https://github.com/Xian55/HermesProxy/issues/248)). This is a config default, not a structural limit — but it does not make a Warden server playable, it only moves the failure to "logged in, then kicked".
+
 ### Warmane
 
 **Warmane does not work and is not supported.** It is the most common server people ask about, so it is called out by name.
@@ -29,5 +41,11 @@ Two independent blockers:
 2. **Warmane runs a heavily customised core.** Its protocol has diverged from stock 3.3.5a in ways the translation layer does not model, so even with Warden off the session would not be trustworthy.
 
 > **Do not attempt this with an account you care about.** Connecting through a proxy is indistinguishable from client tampering as far as Warden is concerned, and public servers ban for it. If you experiment anyway, use a throwaway account and accept that losing it is the expected outcome.
+
+### WoW Circle
+
+**Not supported.** Fails in two stages ([#248](https://github.com/Xian55/HermesProxy/issues/248)): with the default `ReportedOS=OSX` every realm answers `AUTH_REJECT` at realm join (see above, `ReportedOS=Win` clears it); with that fixed, Warden takes over — one measured session reached the world, played 116 s with the proxy translating cleanly, then was closed by the server. Throwaway account only.
+
+> In captures taken before the `GetDataSpan` fix, `SMSG_AUTH_CHALLENGE` looks like a 62-byte body against stock 3.3.5a's 40. It is not evidence of anything: received packets were sniffed with `ByteBuffer.GetData()`, which returns the whole pooled receive buffer, so every server packet carried slack — a stock TrinityCore capture shows the identical 62. It was briefly read here as proof of a customised core; it was not.
 
 The same reasoning applies to any other public server that runs Warden or a custom core. Public servers known to work are listed in [wotlk.md](../wotlk.md); they work because they are close to stock AzerothCore and do not enforce Warden.

--- a/wotlk.md
+++ b/wotlk.md
@@ -22,6 +22,7 @@ Note that `test-loop2.ps1` invoked bare still selects cMangos — the parameter 
 | ChromieCraft (public, AC-derived, read-only) | `logon.chromiecraft.com:3724` | `-ChromieCraft` | — |
 | tavernwlk.top (public, AC-derived, read-only) | `login.tavernwlk.top:3724` | `-Tavern` | `wotlk-tavernwlk` |
 | Warmane (public, custom core + Warden) | `logon.warmane.com:3724` | — | `wotlk-warmane` |
+| WoW Circle (public, Warden — needs `ReportedOS=Win`, [#248](https://github.com/Xian55/HermesProxy/issues/248)) | `logon.wowcircle.com:3724` | `-WowCircle` | `wotlk-wowcircle` |
 | Wrathion native V3_4_3.23121 — **not a backend** | `127.0.0.1` | `-LocalTc343` | `wotlk-tc-local-343` |
 
 **Which one to reach for.** TrinityCore is local, fast to restart, and has a GM account, so it is the default for anything needing repeated iteration or `.additem` / `.gm` setup. AzerothCore is the tie-breaker: its playerbots are real `Player` objects, so unlike TC's NPCBots they appear as scoreboard rows, fill a Dungeon Finder queue, and can be partied, duelled and traded with — most of the group, battleground, arena and loot work landed there for exactly that reason. A behaviour present on one core and absent on the other is server policy far more often than it is a translation bug, so check both before opening an issue.


### PR DESCRIPTION
Triaging #248 turned on two facts the proxy was throwing away. One was missing; the other was wrong, which cost more.

## The auth failure code never reached the log

The world-auth failure line read only `Authentication failed!`. The legacy server's verdict — the single byte that identifies *why* — was parsed and dropped, so recovering it meant hand-decoding the `.pkt`.

That byte is the whole diagnosis:

| Code | Meaning |
|---|---|
| `AUTH_FAILED` (13) | digest or session-key mismatch — credentials/crypto |
| `AUTH_REJECT` (14) | credentials accepted, a policy check refused the session |

`WorldClient` now keeps the code and both failure lines name it, including the client-facing one in `WorldSocket`, which previously reported only that the connect had failed. That one says `none received` when no response arrived, which is not a defensive placeholder: a local TrinityCore sends `AUTH_REJECT` and closes so promptly that our read hits EOF first.

## Captures were recording pool buckets, not payloads

Received packets are read into an `ArrayPool` rental rounded up to a bucket size, and read-mode `GetData()` returns that whole rental. `SniffFile` wrote it verbatim, so every captured server packet carried slack.

A 42-byte `SMSG_AUTH_CHALLENGE` lands in a 64-byte rental, and every capture claimed a 62-byte body against a real 40. While triaging #248 I read that as evidence of a customised server core and published it. It is not — a stock TrinityCore produces the identical inflated capture. That claim has been retracted from the docs and the issue.

`GetDataSpan()` returns the written region, and the two sniff sites that write *received* packets use it. `GetData()` itself is unchanged: trimming in read mode would allocate a copy on a path that is deliberately zero-allocation. `ServerPacket.LogPacket` was already correct — its buffer is exact-sized — so it is untouched.

Confirmed against AzerothCore after the fix: `SMSG_AUTH_CHALLENGE` records 44 bytes instead of 66, and across 4,273 legacy records only 29 land exactly on a pool bucket, with the common payloads (11, 55, 59, 63, 54) being natural packet sizes rather than powers of two.

## Docs

`ReportedOS` defaults to `OSX`, and a core gating on `wardenActive && !ClientBuild::Platform::IsValid(account.OS)` refuses every HermesProxy session with `AUTH_REJECT` *before* any Warden check runs. That is a config default with a specific signature, not a structural limit, so `known-limitations.md` now separates it from Warden proper and points at `--set ReportedOS=Win` first. A WoW Circle entry records both stages of its failure.

## Verification

- **A/B run against WoW Circle**, one field changed: `OSX` → `AUTH_REJECT` at realm join (the reporter's exact failure); `Win` → auth, character select, world enter.
- **Reproduced offline** on a stock TrinityCore with `Warden.Enabled=1` and a non-whitelisted OS, which logs `attempted to log in using invalid client OS`. This also showed that no WoW Circle observation requires a customised core — the reject, the Warden pushes and the in-world kick are all stock behaviour with Warden on.
- **AzerothCore + mod-playerbots**, 3m10s of real play: 13,807 log lines, zero errors, zero exceptions, zero over-reads. No regression from either change.
- `SniffFileLengthTests` was **confirmed to fail without the fix** (`Expected: 44, Actual: 66`) rather than passing for the wrong reason.
- Build clean, 1043 tests pass (1033 before; 10 new across 3 files).

## Not included

The global `ReportedOS` default stays `OSX` — it suits the backends HermesProxy actually targets, and a server that needs `Win` is the exception, set per-server.

The new `AUTH_REJECT` log line has never printed in a live session: every TrinityCore reject path closes the socket before the response can be read, and the one server known to deliver it is a public Warden-enforcing one not worth further sessions. It is covered by tests against a capturing `ILogger`, and it sits in the same branch as the line it replaces, which did fire in the WoW Circle run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GauqhYLB1DchePeKgFt4uv
