### PR TITLE
docs(issue-template): require clearing the client cache before reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,6 +9,8 @@ body:
 
       **Log files are required.** Issues without both an application log and a packet capture will be closed unactioned, because they cannot be triaged. See the README section "Reporting bugs" if you need help locating these files.
 
+      **Clear the client cache first.** Delete the whole `Cache` folder in your WoW directory, then restart the client and try again. The client caches item tooltips and DB2 data in `Cache\WDB\<locale>\`; once it has stored a broken entry it keeps using it and never asks again, so a bug that was already fixed can look like it is still there. Your settings live in `WTF`, not `Cache`, so nothing is lost.
+
       **Reproduce with verbose logging.** For the highest-quality triage, please reproduce the issue with verbose logs enabled:
 
       ```
@@ -106,8 +108,10 @@ body:
 - type: checkboxes
   attributes:
     label: Confirmation
-    description: Both attachments are required for the issue to be triaged.
+    description: All three are required for the issue to be triaged.
     options:
+      - label: I have deleted the `Cache` folder in my WoW directory and the problem still happens.
+        required: true
       - label: I have attached the application log from `Logs/`.
         required: true
       - label: I have attached the packet capture from `PacketsLog/` (zipped, or renamed to `.pkt.txt`).


### PR DESCRIPTION
Closes #251.

The WoW client caches item tooltips and DB2 data under `Cache\WDB\<locale>\`. Once it stores a broken entry it keeps serving it and never re-asks, so a proxy-side bug that has already been fixed still looks broken to the reporter.

That has now cost three round trips on the same underlying non-bug:

- #167 closed as no-repro
- #251 reopened against the same backend, this time with logs and captures attached
- both reproduced clean on ChromieCraft with two characters
- reporter resolved it themselves: *"I delete the cache, it work now"*

The wire data in their capture was correct throughout — `SMSG_BIND_POINT_UPDATE` with the right coordinates and zone, the `ItemEffect` hotfix at the client's own baked RecordID, the hearthstone item created. Nothing to fix in the proxy; the client simply refused to re-read what it had already cached.

Adds the step to the template intro and as a third required confirmation checkbox, next to the existing log and packet-capture ones. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GauqhYLB1DchePeKgFt4uv