### PR TITLE
fix(v3_4_3): preserve tram parent rotations

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -4349,6 +4349,24 @@ public partial class WorldClient
 
                 switch (updateData.ObjectData.EntryID)
                 {
+                    case tramSouthEastmost:
+                    case tramNorthWestmost:
+                    {
+                        // Keep the legacy parent quaternion separate from the packed live
+                        // rotation. Missing create fields are zero, not components of the
+                        // live quaternion. Preserve the server's pivot so these cars keep
+                        // the same travel direction as the rest of their train.
+                        if (ModernVersion.Build == ClientVersionBuild.V3_4_3_54261)
+                        {
+                            var parent = updateData.GameObjectData.ParentRotation;
+                            for (int i = 0; i < 4; i++)
+                                parent[i] = updateMaskArray[GAMEOBJECT_ROTATION + i]
+                                    ? updates[GAMEOBJECT_ROTATION + i].FloatValue : 0f;
+                            if (parent[0] == 0f && parent[1] == 0f && parent[2] == 0f && parent[3] == 0f)
+                                parent[3] = 1f;
+                        }
+                        break;
+                    }
                     case tramNorthMiddle:
                     case tramSouthMiddle:
                     case tramSouthWestmost:


### PR DESCRIPTION
Fix Deeprun Tram cars moving at an angle through the wall on WotLK Classic 3.4.3.54261 with an AzerothCore 3.3.5a backend.

The create handler overlays sparse legacy parent-rotation fields onto the packed live rotation, then copies that mixed quaternion into `ParentRotation`. When the parent W is zero and omitted from the create mask, it retains the live W instead. In two paired packet captures, entries `176080` and `176084` arrive with parent `(0, 0, 1, 0)` but are sent to the modern client as `(0, 0, 1, 0.707106)`. The other four tram cars already have a complete pivot override.

For these two entries on build 54261, reconstruct the parent quaternion directly from the legacy parent fields, using zero for omitted create fields and identity only when all four components are zero. This preserves the server's movement pivot and avoids carrying over components of the live rotation. Other entries and client builds retain their existing behavior.

Validation:

- Built a self-contained Windows proxy from v4.4.11 with .NET 10.0.400.
- 45 existing transport and game-object packet tests passed, with no failures. The same 45 tests also passed after applying the change to current upstream master.
- Confirmed the fix works in-game on 3.4.3.54261 with AzerothCore. The original 3.3.5a client already moved the carts correctly.
- Verified the published source matches the tested local source after line-ending normalization.

To reproduce, enter the Deeprun Tram with the modern client and inspect all three carriages of each train as it departs. The affected carriage should follow the other two instead of moving through the wall. Boarding, passenger positioning, and full round trips are useful additional checks; those individual scenarios have not been separately confirmed.

AI assistance: Codex (GPT-6) produced the code change and this description. I performed the in-game validation.