### PR TITLE
fix(v3_4_3): read the transport pivot from the backend, not the live rotation

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -4210,7 +4210,17 @@ public partial class WorldClient
             // pre-Identity default), which the V3_4_3 client treats as an invalid
             // quaternion and rejects with CMSG_OBJECT_UPDATE_FAILED for the whole
             // SMSG_UPDATE_OBJECT (collateral Player rejection from byte misalignment).
-            if (GAMEOBJECT_ROTATION < 0)
+            // Which of the two the backend actually sent decides what the four floats mean.
+            // V1_12 / V2_4_3 send GAMEOBJECT_ROTATION -- the object's own local quaternion.
+            // The Classic re-releases (V1_14, V2_5, V3_3_5a) send GAMEOBJECT_PARENTROTATION,
+            // which is the transport *path* rotation: the pivot the client rotates a
+            // transport's animation path by. cMaNGOS SetTransportPathRotation writes it from
+            // `gameobject.path_rotation` and TrinityCore / AzerothCore from
+            // `gameobject_addon.parentRotation`, both defaulting to identity, while the local
+            // quaternion rides packed in the movement block instead. The two are unrelated
+            // values and must not be mixed.
+            bool legacyRotationIsPathRotation = GAMEOBJECT_ROTATION < 0;
+            if (legacyRotationIsPathRotation)
                 GAMEOBJECT_ROTATION = LegacyVersion.GetUpdateField(GameObjectField.GAMEOBJECT_PARENTROTATION);
             // GameObjectData.TypeID is not populated until the GAMEOBJECT_BYTES_1 unpack
             // much further down, so anything above that point reads null off it and any
@@ -4274,10 +4284,15 @@ public partial class WorldClient
 
             if (GAMEOBJECT_ROTATION >= 0 && updateData.CreateData != null && updateData.CreateData.MoveInfo != null)
             {
+                var liveRotation = updateData.CreateData.MoveInfo.Rotation;
+                int rotationMask = 0;
                 for (int i = 0; i < 4; i++)
                 {
                     if (updateMaskArray[GAMEOBJECT_ROTATION + i])
+                    {
                         updateData.CreateData.MoveInfo.Rotation[i] = updates[GAMEOBJECT_ROTATION + i].FloatValue;
+                        rotationMask |= 1 << i;
+                    }
                 }
                 // Sanitize: if the server sent all-zero rotation, snap to identity
                 // so the client doesn't reject a non-unit quaternion.
@@ -4312,6 +4327,38 @@ public partial class WorldClient
                         SetDestructibleParentRotation(parentRotation,
                             (uint)(updateData.ObjectData.EntryID ?? 0), updateData.GameObjectData.DisplayID);
                     }
+                    else if (legacyRotationIsPathRotation)
+                    {
+                        // Read the path rotation straight out of the update fields rather than
+                        // off `rot`. A legacy create block only carries the components the
+                        // update mask marks as set, and a component the backend left at zero is
+                        // never marked -- so every zero in the path rotation would otherwise
+                        // keep whatever the live movement quaternion held in that slot. The
+                        // Deeprun Tram cars ship parentRotation (0,0,1,0): only z is masked, and
+                        // the unmasked w inherited the live 0.707106, which tilts the pivot and
+                        // sends the car through the wall (issue seen on AzerothCore, PR #261).
+                        // Same failure the Values path above already guards against for the
+                        // Strand of the Ancients gunships.
+                        var cached = GetSession().GameState.GetCachedObjectFieldsLegacy(guid);
+                        bool allZero = true;
+                        for (int i = 0; i < 4; i++)
+                        {
+                            int index = GAMEOBJECT_ROTATION + i;
+                            float value;
+                            if (updateMaskArray[index])
+                                value = updates[index].FloatValue;
+                            else if (cached != null && cached.TryGetValue(index, out var field))
+                                value = field.FloatValue;
+                            else
+                                value = 0f;
+                            parentRotation[i] = value;
+                            allZero &= value == 0f;
+                        }
+                        // An all-zero quaternion is not a rotation; both backends default the
+                        // path rotation to identity, so that is what an empty field means.
+                        if (allZero)
+                            parentRotation[3] = 1f;
+                    }
                     else
                     {
                         parentRotation[0] = rot.X;
@@ -4320,11 +4367,35 @@ public partial class WorldClient
                         parentRotation[3] = rot.W;
                     }
 
+                    if (_melGoFields.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
+                        TransportLogMessages.ParentRotationOnCreate(_melGoFields, guid.Low, guid.GetEntry(), rotationMask,
+                            (rotationMask & 1) != 0 ? updates[GAMEOBJECT_ROTATION].FloatValue : 0f,
+                            (rotationMask & 2) != 0 ? updates[GAMEOBJECT_ROTATION + 1].FloatValue : 0f,
+                            (rotationMask & 4) != 0 ? updates[GAMEOBJECT_ROTATION + 2].FloatValue : 0f,
+                            (rotationMask & 8) != 0 ? updates[GAMEOBJECT_ROTATION + 3].FloatValue : 0f,
+                            liveRotation.X, liveRotation.Y, liveRotation.Z, liveRotation.W,
+                            parentRotation[0] ?? 0f, parentRotation[1] ?? 0f,
+                            parentRotation[2] ?? 0f, parentRotation[3] ?? 0f);
+
                     float ori = updateData.CreateData.MoveInfo.Orientation;
                     updateData.CreateData.MoveInfo.Rotation = Quaternion.CreateFromAxisAngle(Vector3.UnitZ, ori);
                 }
 
                 // Fix for invalid movement of Deeprun Tram, some carts were going through the wall (in the opposite direction)
+                //
+                // Both switches below are hardcoded corrections reverse-engineered in 2022 from
+                // what a cMaNGOS backend sends to a V1_14 client, and they are keyed on entry id
+                // -- which makes them wrong wherever a backend's spawn data differs. It does:
+                // cMaNGOS spawns 176085 with the reversed orientation, TrinityCore / AzerothCore
+                // spawn 176084 that way instead, so the flip list corrects the wrong car there.
+                //
+                // V3_4_3 does not need either of them. It reads ParentRotation straight off the
+                // backend's own path rotation above, and all three 3.3.5a backends ship the same
+                // (0, 0, 1, ~0) pivot for all six cars -- the value a native 3.4.3 server sends
+                // from its own gameobject_addon, verified against Wrathion. Applying a 180 degree
+                // yaw on top of a correct pivot double-corrects, and overwriting the pivot with a
+                // literal throws away exactly the data that just arrived. Skip both and the wire
+                // matches native; V1_14 / V2_5 keep the behaviour that makes trams work for them.
                 // Entry IDs of Trams:
                 const int tramSouthEastmost = 176080;
                 const int tramNorthMiddle = 176081;
@@ -4334,35 +4405,38 @@ public partial class WorldClient
                 const int tramNorthEastmost = 176085;
                 const int zangarmarshElevator = 183177;
 
-                switch (updateData.ObjectData.EntryID)
+                if (ModernVersion.ExpansionVersion < 3)
                 {
-                    case tramSouthEastmost:
-                    case tramNorthWestmost:
-                    case tramNorthEastmost:
+                    switch (updateData.ObjectData.EntryID)
                     {
-                        var rot = updateData.CreateData.MoveInfo.Rotation.AsEulerAngles();
-                        rot.Yaw *= -1; // Rotate the cart content by 180°, so players who stand on the left side of the cart are actually on the left side
-                        updateData.CreateData.MoveInfo.Rotation = rot.AsQuaternion();
-                        break;
+                        case tramSouthEastmost:
+                        case tramNorthWestmost:
+                        case tramNorthEastmost:
+                        {
+                            var rot = updateData.CreateData.MoveInfo.Rotation.AsEulerAngles();
+                            rot.Yaw *= -1; // Rotate the cart content by 180°, so players who stand on the left side of the cart are actually on the left side
+                            updateData.CreateData.MoveInfo.Rotation = rot.AsQuaternion();
+                            break;
+                        }
                     }
-                }
 
-                switch (updateData.ObjectData.EntryID)
-                {
-                    case tramNorthMiddle:
-                    case tramSouthMiddle:
-                    case tramSouthWestmost:
-                    case tramNorthEastmost:
+                    switch (updateData.ObjectData.EntryID)
                     {
-                        // Quaternion to rotate the pivot point of the transport movement by 180°
-                        SetParentRotation(updateData.GameObjectData.ParentRotation, -4.371139E-08f, 0f, 1f, 0f);
-                        break;
-                    }
-                    case zangarmarshElevator:
-                    {
-                        // Super weird angle -88°
-                        SetParentRotation(updateData.GameObjectData.ParentRotation, 0f, 0f, -0.69465846f, 0.7193397f);
-                        break;
+                        case tramNorthMiddle:
+                        case tramSouthMiddle:
+                        case tramSouthWestmost:
+                        case tramNorthEastmost:
+                        {
+                            // Quaternion to rotate the pivot point of the transport movement by 180°
+                            SetParentRotation(updateData.GameObjectData.ParentRotation, -4.371139E-08f, 0f, 1f, 0f);
+                            break;
+                        }
+                        case zangarmarshElevator:
+                        {
+                            // Super weird angle -88°
+                            SetParentRotation(updateData.GameObjectData.ParentRotation, 0f, 0f, -0.69465846f, 0.7193397f);
+                            break;
+                        }
                     }
                 }
             }

--- a/HermesProxy/World/Logging/TransportLogMessages.cs
+++ b/HermesProxy/World/Logging/TransportLogMessages.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
 namespace HermesProxy.World.Logging;
 
@@ -73,4 +73,21 @@ internal static partial class TransportLogMessages
     public static partial void PassengerCreate(
         ILogger logger, ulong guidLow, ulong transportLow, ulong transportHigh,
         bool clientKnowsTransport, float x, float y, float z, sbyte seat);
+
+    // The create block only carries the rotation components the legacy update mask marks as
+    // set, so a component the backend left at zero is absent and whatever the live movement
+    // quaternion held in that slot survives into ParentRotation. Logging the mask next to both
+    // quaternions is what separates "the backend sent a bad pivot" from "we kept a live
+    // component". Mask is four bits, x=1 y=2 z=4 w=8.
+    [LoggerMessage(
+        EventId = 1116,
+        Level = LogLevel.Trace,
+        Message = "[TransportSail] guidLow={GuidLow} entry={Entry} create rotation mask={Mask} " +
+                  "legacy=({LegacyX},{LegacyY},{LegacyZ},{LegacyW}) live=({LiveX},{LiveY},{LiveZ},{LiveW}) " +
+                  "parentRotation=({X},{Y},{Z},{W})")]
+    public static partial void ParentRotationOnCreate(
+        ILogger logger, ulong guidLow, uint entry, int mask,
+        float legacyX, float legacyY, float legacyZ, float legacyW,
+        float liveX, float liveY, float liveZ, float liveW,
+        float x, float y, float z, float w);
 }


### PR DESCRIPTION
Fixes #262. Supersedes #261, which reported the same mechanism for entries `176080` and `176084`.

The GameObject create path was building `ParentRotation` out of the live movement quaternion with the masked rotation components laid over the top. A create block only carries the components the legacy update mask marks as set, so every zero in the quaternion is absent and kept whatever the live rotation held in that slot.

The two are different values that happen to share a wire offset. V1_12 and V2_4_3 send `GAMEOBJECT_ROTATION`, the object's own local quaternion. V1_14, V2_5 and V3_3_5a send `GAMEOBJECT_PARENTROTATION`, the transport **path** rotation the client rotates a transport's animation path by — cMaNGOS writes it from `gameobject_addon.path_rotation`, TrinityCore and AzerothCore from `gameobject_addon.parentRotation`, while the local quaternion rides packed in the movement block. The Deeprun Tram cars ship `(0, 0, 1, 0)`, so only `z` is masked and the unmasked `w` inherited the live `0.707106` — a non-unit quaternion that normalises to 109.5° instead of 180°, which is what sent the cars through the wall.

Where the four floats are a path rotation, this reads them straight out of the update fields: masked component to its value, unmasked from the field cache, else zero, all-zero to identity. It is the rule the Values path already applied for the Strand of the Ancients gunships.

That makes the entry-keyed workarounds from 9d2a8ea redundant on V3_4_3, and they were actively wrong there. They were reverse-engineered in 2022 from what a cMaNGOS backend sends a V1_14 client, and they key on entry id: cMaNGOS spawns `176085` with the reversed orientation where TrinityCore and AzerothCore spawn `176084` that way, so the yaw flip corrected the wrong car. All three 3.3.5a backends ship `(0, 0, 1, ~0)` for all six cars — the value a native 3.4.3 server sends from its own `gameobject_addon`, checked against Wrathion — and the Zangarmarsh elevator literal matches `gameobject_addon` exactly on all three. Both switches are now skipped when `ExpansionVersion >= 3`; V1_14 and V2_5 keep them unchanged.

`ParentRotationOnCreate` (EventId 1116, Trace) logs the mask next to both quaternions, which is what separates a bad pivot from the backend from a live component we kept.

## Testing

AzerothCore mod-playerbots 3.3.5a, V3_4_3 client, plus `dotnet build -c Release` and 1049 tests green.

- Deeprun Tram: all six cars sit where they belong and travel with their train; both trains ridden from Ironforge; boarding and riding on the cars themselves
- Zangarmarsh elevator `183177`: pivot read off the wire as `(0,0,-0.694658,0.71934)`, byte-identical to the removed literal; boarding and exiting work
- Strand of the Ancients: the boat sails as before, and its two-stage create is handled better than it was — TrinityCore adds the boat to the map before calling `SetParentRotation`, so the first create carries no rotation in the mask at all and now gets the native identity default rather than `(0,0,-0.247,0.969)` off the live quaternion; the real `(0,0,1,0.0002)` arrives on the next create, `GO_FLAG_TRANSPORT` intact
- Destructible gates: `SetDestructibleParentRotation` keeps precedence, the `DestructibleModelData` id still rides in the x slot as raw bits (#184)
- V1_14 and V2_5: unchanged by code inspection, not playtested — no statement reachable on those builds was modified

Before and after on the same six cars, same backend:

```
before:  mask=4  legacy=(0,0,1,0)  live=(0,0,±0.70710754,0.707106)  parentRotation=(0,0,1,0.707106)
after:   mask=4  legacy=(0,0,1,0)  live=(0,0,±0.70710754,0.707106)  parentRotation=(0,0,1,0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux9vdy9gFJ7eR7WmCVZRic
