### PR TITLE
fix(bnet): stop a throwing frame handler from silently killing the read loop

### DIFF
--- a/Framework/Networking/SSLSocket.cs
+++ b/Framework/Networking/SSLSocket.cs
@@ -22,12 +22,17 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Framework.Networking;
 
 public abstract class SSLSocket : ISocket, IDisposable
 {
+    private static readonly Microsoft.Extensions.Logging.ILogger _melNet = Log.CreateMelLogger(Log.CategoryNetwork);
+    private static readonly string _sourceFile = nameof(SSLSocket).PadRight(15);
+    private const string _netDirNone = "";
+
     Socket _socket;
     internal SslStream _stream;
     IPEndPoint? _remoteEndPoint;
@@ -75,12 +80,33 @@ public abstract class SSLSocket : ISocket, IDisposable
                 return;
             }
 
-            _ = ReadHandler(receiveBuffer, result);
+            // ReadHandler re-arms the loop itself by awaiting AsyncRead again, so awaiting it here
+            // would chain every read into the previous one and never unwind. It has to stay fire
+            // and forget — but the task must still be observed: a fault that goes unwatched also
+            // skips ReadHandler's own AsyncRead, leaving the connection open and never reading.
+            var handlerTask = ReadHandler(receiveBuffer, result);
+            if (!handlerTask.IsCompletedSuccessfully)
+                ObserveFault(handlerTask, GetRemoteIpEndPoint());
         }
         catch (Exception ex)
         {
             Log.outException(ex);
         }
+    }
+
+    private static void ObserveFault(Task handlerTask, IPEndPoint? endPoint)
+    {
+        handlerTask.ContinueWith(
+            static (task, state) =>
+            {
+                var ex = task.Exception!.GetBaseException();
+                SslSocketLogMessages.ReadHandlerFaulted(_melNet, ex, _sourceFile, _netDirNone,
+                    state?.ToString() ?? "<unknown>", ex.Message);
+            },
+            endPoint,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     public async Task AsyncHandshake(X509Certificate2 certificate)

--- a/Framework/Networking/SslSocketLogMessages.cs
+++ b/Framework/Networking/SslSocketLogMessages.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Logging;
+
+namespace Framework.Networking;
+
+#pragma warning disable SYSLIB1015
+internal static partial class SslSocketLogMessages
+{
+    // EventId 910-919 range is reserved for SSLSocket.
+
+    [LoggerMessage(EventId = 910, Level = LogLevel.Error, Message = "Read handler faulted for {Endpoint}: {Message}")]
+    public static partial void ReadHandlerFaulted(
+        ILogger logger, System.Exception ex, string SourceFile, string NetDir, string Endpoint, string Message);
+}

--- a/HermesProxy.Tests/BnetServer/BnetEmptyResponseTests.cs
+++ b/HermesProxy.Tests/BnetServer/BnetEmptyResponseTests.cs
@@ -1,16 +1,9 @@
-using System;
-using System.Buffers.Binary;
-using System.Collections.Generic;
-using System.Net;
-using System.Net.Sockets;
 using System.Threading.Tasks;
 using Bgs.Protocol;
 using Bgs.Protocol.Connection.V1;
-using BNetServer.Networking;
-using BNetServer.Services;
 using Framework.Constants;
-using Google.Protobuf;
 using Xunit;
+using static HermesProxy.Tests.BnetServer.BnetSessionHarness;
 
 namespace HermesProxy.Tests.BnetServer;
 
@@ -83,48 +76,5 @@ public class BnetEmptyResponseTests
             Assert.Equal(0, session._pooledBuffer.Length);
             Assert.Empty(session.Replies);
         });
-    }
-
-    private static void AppendFrame(BnetTcpSession session, Header header, IMessage? message = null)
-    {
-        var payload = message?.ToByteArray() ?? Array.Empty<byte>();
-        header.Size = (uint)payload.Length;
-        var headerBytes = header.ToByteArray();
-        var frame = new byte[2 + headerBytes.Length + payload.Length];
-        BinaryPrimitives.WriteUInt16BigEndian(frame, (ushort)headerBytes.Length);
-        headerBytes.CopyTo(frame, 2);
-        payload.CopyTo(frame, 2 + headerBytes.Length);
-        session._pooledBuffer.Append(frame, frame.Length);
-    }
-
-    private static async Task WithSession(Func<RecordingSession, Task> test)
-    {
-        using var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        using var client = new TcpClient();
-        await client.ConnectAsync((IPEndPoint)listener.LocalEndpoint, TestContext.Current.CancellationToken);
-        using var socket = await listener.AcceptSocketAsync(TestContext.Current.CancellationToken);
-        using var session = new RecordingSession(socket);
-        await test(session);
-    }
-
-    private sealed record Reply(uint ServiceId, OriginalHash Service, uint MethodId,
-        uint Token, BattlenetRpcErrorCode Status, IMessage? Message);
-
-    private sealed class RecordingSession(Socket socket) : BnetTcpSession(socket), BnetServices.INetwork
-    {
-        public List<Reply> Replies { get; } = new();
-
-        void BnetServices.INetwork.SendRpcMessage(uint serviceId, OriginalHash service,
-            uint methodId, uint token, BattlenetRpcErrorCode status, IMessage? message)
-        {
-            Replies.Add(new Reply(serviceId, service, methodId, token, status, message));
-        }
-
-        public override void Dispose()
-        {
-            _pooledBuffer.Dispose();
-            base.Dispose();
-        }
     }
 }

--- a/HermesProxy.Tests/BnetServer/BnetFrameFaultIsolationTests.cs
+++ b/HermesProxy.Tests/BnetServer/BnetFrameFaultIsolationTests.cs
@@ -1,0 +1,122 @@
+using System.Threading.Tasks;
+using Bgs.Protocol;
+using Bgs.Protocol.Connection.V1;
+using Framework.Constants;
+using Xunit;
+using static HermesProxy.Tests.BnetServer.BnetSessionHarness;
+
+namespace HermesProxy.Tests.BnetServer;
+
+/// <summary>
+/// Issue #266. A frame that makes the service dispatcher throw used to escape ProcessCurrentBuffer,
+/// which meant BnetTcpSession.ReadHandler never reached its AsyncRead() and SSLSocket discarded the
+/// faulted task — the session stayed open but stopped reading, with nothing in the log.
+/// </summary>
+public class BnetFrameFaultIsolationTests
+{
+    // Field 1 with wire type 7. No valid protobuf encoding uses it, so MergeFrom throws while the
+    // dispatcher is decoding the request — the same catch that covers a throwing service handler.
+    private static readonly byte[] UndecodablePayload = [0x0F, 0x0F];
+
+    private static Header ConnectHeader(uint token) => new()
+    {
+        ServiceId = 0,
+        ServiceHash = (uint)OriginalHash.ConnectionService,
+        MethodId = 1,
+        Token = token
+    };
+
+    [Fact]
+    public async Task UndecodablePayload_SkipsOnlyThatFrame_AndKeepsDispatching()
+    {
+        await WithSession(async session =>
+        {
+            AppendRawFrame(session, ConnectHeader(1), UndecodablePayload);
+            AppendFrame(session, ConnectHeader(2), new ConnectRequest { UseBindlessRpc = true });
+
+            await session.ProcessCurrentBuffer();
+
+            Assert.Equal(0, session._pooledBuffer.Length);
+            Assert.True(session.IsOpen());
+
+            // Only the good frame answered: the bad one throws before the dispatcher can reply.
+            var reply = Assert.Single(session.Replies);
+            Assert.Equal(2u, reply.Token);
+            Assert.Equal(BattlenetRpcErrorCode.Ok, reply.Status);
+            Assert.IsType<ConnectResponse>(reply.Message);
+        });
+    }
+
+    [Fact]
+    public async Task ConsecutiveUndecodablePayloads_AllSkipped_SessionStaysOpen()
+    {
+        await WithSession(async session =>
+        {
+            AppendRawFrame(session, ConnectHeader(1), UndecodablePayload);
+            AppendRawFrame(session, ConnectHeader(2), UndecodablePayload);
+            AppendRawFrame(session, ConnectHeader(3), UndecodablePayload);
+
+            await session.ProcessCurrentBuffer();
+
+            Assert.Equal(0, session._pooledBuffer.Length);
+            Assert.True(session.IsOpen());
+            Assert.Empty(session.Replies);
+        });
+    }
+
+    [Fact]
+    public async Task ReadHandler_SurvivesADispatchFault_AndDrainsTheBuffer()
+    {
+        await WithSession(async session =>
+        {
+            AppendRawFrame(session, ConnectHeader(1), UndecodablePayload);
+
+            // The guard lives in ReadHandler too: before #266 this path let the exception escape
+            // into a task nobody awaited, so the read loop was never re-armed.
+            await session.ProcessCurrentBuffer();
+
+            Assert.Equal(0, session._pooledBuffer.Length);
+            Assert.True(session.IsOpen());
+
+            // The session is still usable afterwards — a later frame dispatches normally.
+            AppendFrame(session, ConnectHeader(2), new ConnectRequest());
+            await session.ProcessCurrentBuffer();
+
+            Assert.Equal(0, session._pooledBuffer.Length);
+            Assert.Equal(2u, Assert.Single(session.Replies).Token);
+        });
+    }
+
+    [Fact]
+    public async Task UndecodableHeader_ClosesConnection_AndDrainsTheBuffer()
+    {
+        await WithSession(async session =>
+        {
+            AppendUndecodableHeader(session);
+            AppendFrame(session, ConnectHeader(9), new ConnectRequest());
+
+            await session.ProcessCurrentBuffer();
+
+            // A header that will not decode leaves no way to find the next frame boundary, so the
+            // rest of the buffer is unusable and the connection has to go.
+            Assert.Equal(0, session._pooledBuffer.Length);
+            Assert.False(session.IsOpen());
+            Assert.Empty(session.Replies);
+        });
+    }
+
+    [Fact]
+    public async Task ReadHandler_OversizedRead_ClosesConnectionInsteadOfFaulting()
+    {
+        await WithSession(async session =>
+        {
+            // PooledByteBuffer caps at 65536 bytes, so a larger single read cannot be buffered and
+            // EnsureCapacity throws. That used to kill the read loop silently.
+            var oversized = new byte[70000];
+
+            await session.ReadHandler(oversized, oversized.Length);
+
+            Assert.False(session.IsOpen());
+        });
+    }
+}

--- a/HermesProxy.Tests/BnetServer/BnetRestApiSessionFaultTests.cs
+++ b/HermesProxy.Tests/BnetServer/BnetRestApiSessionFaultTests.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using BNetServer.Networking;
+using HermesProxy.Configuration.Options;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace HermesProxy.Tests.BnetServer;
+
+/// <summary>
+/// Issue #266. BnetRestApiSession shares the SSLSocket read loop, so an exception escaping its
+/// ReadHandler skipped the AsyncRead() that re-arms the loop and vanished into a discarded task.
+/// </summary>
+public class BnetRestApiSessionFaultTests
+{
+    // HttpHelper.ParseRequest stores headers in a Dictionary via Add, so a repeated header name
+    // throws ArgumentException. Real clients do send duplicate headers.
+    private const string DuplicateHeaderRequest =
+        "GET /bnetserver/login/ HTTP/1.1\r\n" +
+        "Accept: application/json\r\n" +
+        "Accept: text/plain\r\n" +
+        "\r\n";
+
+    [Fact]
+    public async Task ReadHandler_RequestThatFailsToParse_ClosesConnectionInsteadOfFaulting()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        using var client = new TcpClient();
+        await client.ConnectAsync((IPEndPoint)listener.LocalEndpoint, TestContext.Current.CancellationToken);
+        using var socket = await listener.AcceptSocketAsync(TestContext.Current.CancellationToken);
+        using var session = new BnetRestApiSession(
+            socket,
+            Options.Create(new ClientOptions()),
+            Options.Create(new LegacyServerOptions()),
+            Options.Create(new ProxyNetworkOptions()),
+            Options.Create(new DiagnosticsOptions()),
+            Options.Create(new ThrottlingOptions()));
+
+        var data = Encoding.UTF8.GetBytes(DuplicateHeaderRequest);
+
+        await session.ReadHandler(data, data.Length);
+
+        Assert.False(session.IsOpen());
+    }
+}

--- a/HermesProxy.Tests/BnetServer/BnetSessionHarness.cs
+++ b/HermesProxy.Tests/BnetServer/BnetSessionHarness.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Bgs.Protocol;
+using BNetServer.Networking;
+using BNetServer.Services;
+using Framework.Constants;
+using Google.Protobuf;
+using Xunit;
+
+namespace HermesProxy.Tests.BnetServer;
+
+internal sealed record BnetReply(uint ServiceId, OriginalHash Service, uint MethodId,
+    uint Token, BattlenetRpcErrorCode Status, IMessage? Message);
+
+/// <summary>
+/// A real <see cref="BnetTcpSession"/> over a loopback socket pair that captures the RPC replies it
+/// would have written rather than serialising them onto the wire.
+/// </summary>
+internal sealed class RecordingSession(Socket socket) : BnetTcpSession(socket), BnetServices.INetwork
+{
+    public List<BnetReply> Replies { get; } = new();
+
+    void BnetServices.INetwork.SendRpcMessage(uint serviceId, OriginalHash service,
+        uint methodId, uint token, BattlenetRpcErrorCode status, IMessage? message)
+    {
+        Replies.Add(new BnetReply(serviceId, service, methodId, token, status, message));
+    }
+
+    public override void Dispose()
+    {
+        _pooledBuffer.Dispose();
+        base.Dispose();
+    }
+}
+
+internal static class BnetSessionHarness
+{
+    public static async Task WithSession(Func<RecordingSession, Task> test)
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        using var client = new TcpClient();
+        await client.ConnectAsync((IPEndPoint)listener.LocalEndpoint, TestContext.Current.CancellationToken);
+        using var socket = await listener.AcceptSocketAsync(TestContext.Current.CancellationToken);
+        using var session = new RecordingSession(socket);
+        await test(session);
+    }
+
+    public static void AppendFrame(BnetTcpSession session, Header header, IMessage? message = null)
+        => AppendRawFrame(session, header, message?.ToByteArray() ?? Array.Empty<byte>());
+
+    /// <summary>
+    /// Appends a frame carrying hand-built payload bytes, so a test can hand the dispatcher input no
+    /// protobuf message would ever produce.
+    /// </summary>
+    public static void AppendRawFrame(BnetTcpSession session, Header header, byte[] payload)
+    {
+        header.Size = (uint)payload.Length;
+        var headerBytes = header.ToByteArray();
+        var frame = new byte[2 + headerBytes.Length + payload.Length];
+        BinaryPrimitives.WriteUInt16BigEndian(frame, (ushort)headerBytes.Length);
+        headerBytes.CopyTo(frame, 2);
+        payload.CopyTo(frame, 2 + headerBytes.Length);
+        session._pooledBuffer.Append(frame, frame.Length);
+    }
+
+    /// <summary>
+    /// Appends a frame whose header bytes will not decode, which is what a desynchronised stream
+    /// looks like from the parser's side.
+    /// </summary>
+    public static void AppendUndecodableHeader(BnetTcpSession session)
+    {
+        // Wire type 7 does not exist in protobuf, so Header.MergeFrom rejects these bytes.
+        var headerBytes = new byte[] { 0x0F, 0x0F, 0x0F };
+        var frame = new byte[2 + headerBytes.Length];
+        BinaryPrimitives.WriteUInt16BigEndian(frame, (ushort)headerBytes.Length);
+        headerBytes.CopyTo(frame, 2);
+        session._pooledBuffer.Append(frame, frame.Length);
+    }
+}

--- a/HermesProxy/BnetServer/Networking/BnetRestApiSession.cs
+++ b/HermesProxy/BnetServer/Networking/BnetRestApiSession.cs
@@ -21,6 +21,10 @@ namespace BNetServer.Networking;
 
 public sealed class BnetRestApiSession : SSLSocket
 {
+    private static readonly Microsoft.Extensions.Logging.ILogger _melServer = Framework.Logging.Log.CreateMelLogger(Framework.Logging.Log.CategoryServer);
+    private static readonly string _sourceFile = nameof(BnetRestApiSession).PadRight(15);
+    private const string _netDirNone = "";
+
     private const string BNET_SERVER_BASE_PATH = "/bnetserver/";
     private const string TICKET_PREFIX = "HP-"; // Hermes Proxy
 
@@ -53,9 +57,21 @@ public sealed class BnetRestApiSession : SSLSocket
 
     public override async Task ReadHandler(byte[] data, int receivedLength)
     {
-        var httpRequest = HttpHelper.ParseRequest(data, receivedLength);
-        if (httpRequest == null || !RequestRouter(httpRequest))
+        try
         {
+            var httpRequest = HttpHelper.ParseRequest(data, receivedLength);
+            if (httpRequest == null || !RequestRouter(httpRequest))
+            {
+                CloseSocket();
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            // SSLSocket.AsyncRead cannot await this method, so an escaping exception would go
+            // unlogged and skip the AsyncRead below, leaving the session silently unreadable.
+            BnetRestApiSessionLogMessages.RequestHandlingFailed(_melServer, ex, _sourceFile, _netDirNone,
+                GetRemoteIpEndPoint()?.ToString() ?? "<unknown>", ex.Message);
             CloseSocket();
             return;
         }

--- a/HermesProxy/BnetServer/Networking/BnetRestApiSessionLogMessages.cs
+++ b/HermesProxy/BnetServer/Networking/BnetRestApiSessionLogMessages.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+
+namespace BNetServer.Networking;
+
+#pragma warning disable SYSLIB1015
+internal static partial class BnetRestApiSessionLogMessages
+{
+    // EventId 850-859 range is reserved for BnetRestApiSession (800-849 BnetTcpSession).
+
+    [LoggerMessage(EventId = 850, Level = LogLevel.Error,
+        Message = "Request handling failed for {Endpoint}, closing connection: {Message}")]
+    public static partial void RequestHandlingFailed(
+        ILogger logger, System.Exception ex, string SourceFile, string NetDir, string Endpoint, string Message);
+}

--- a/HermesProxy/BnetServer/Networking/BnetTcpSession.cs
+++ b/HermesProxy/BnetServer/Networking/BnetTcpSession.cs
@@ -385,9 +385,23 @@ public class BnetTcpSession : SSLSocket, BnetServices.INetwork
         if (!IsOpen())
             return;
 
-        _pooledBuffer.Append(data, receivedLength);
+        try
+        {
+            _pooledBuffer.Append(data, receivedLength);
 
-        await ProcessCurrentBuffer();
+            await ProcessCurrentBuffer();
+        }
+        catch (Exception ex)
+        {
+            // SSLSocket.AsyncRead cannot await this method, so anything escaping here would both
+            // go unlogged and skip the AsyncRead below, leaving the session open but permanently
+            // unreadable. Only buffer-level failures reach this far — the frame loop handles its
+            // own — so the stream state is unknown and the connection has to go.
+            BnetTcpSessionLogMessages.BufferProcessingFailed(_melServer, ex, _sourceFile, _netDirNone,
+                DescribeEndpoint(), ex.Message);
+            CloseSocket();
+            return;
+        }
 
         await AsyncRead();
     }
@@ -396,7 +410,21 @@ public class BnetTcpSession : SSLSocket, BnetServices.INetwork
     {
         while (_pooledBuffer.Length > 2)
         {
-            var result = BnetPacketParser.ParseFromSpan(_pooledBuffer.Span);
+            BnetPacketParseResultPooled result;
+            try
+            {
+                result = BnetPacketParser.ParseFromSpan(_pooledBuffer.Span);
+            }
+            catch (Exception ex)
+            {
+                // A header that will not decode leaves no way to find the next frame boundary, so
+                // every following byte is unusable. Drop the connection rather than spin.
+                BnetTcpSessionLogMessages.FrameParseFailed(_melServer, ex, _sourceFile, _netDirNone,
+                    DescribeEndpoint(), ex.Message);
+                _pooledBuffer.Clear();
+                CloseSocket();
+                return Task.CompletedTask;
+            }
 
             if (!result.Success)
             {
@@ -416,6 +444,14 @@ public class BnetTcpSession : SSLSocket, BnetServices.INetwork
                     _handlerManager.Invoke(result.Header.ServiceId, (OriginalHash)result.Header.ServiceHash, result.Header.MethodId, result.Header.Token, stream);
                 }
             }
+            catch (Exception ex)
+            {
+                // Framing was already advanced past this frame, so the stream stays in sync and the
+                // rest of the buffer is still readable. Skipping one bad frame beats killing the
+                // session — an unhandled handler fault used to stop all further reads silently.
+                BnetTcpSessionLogMessages.FrameDispatchFailed(_melServer, ex, _sourceFile, _netDirNone,
+                    result.Header!.ServiceHash, result.Header.MethodId, result.Header.Token, ex.Message);
+            }
             finally
             {
                 result.ReturnPayload();
@@ -424,6 +460,8 @@ public class BnetTcpSession : SSLSocket, BnetServices.INetwork
 
         return Task.CompletedTask;
     }
+
+    private string DescribeEndpoint() => GetRemoteIpEndPoint()?.ToString() ?? "<unknown>";
 
     public void SendRpcMessage(uint serviceId, OriginalHash service, uint methodId, uint token, BattlenetRpcErrorCode status, IMessage? message)
     {

--- a/HermesProxy/BnetServer/Networking/BnetTcpSessionLogMessages.cs
+++ b/HermesProxy/BnetServer/Networking/BnetTcpSessionLogMessages.cs
@@ -5,9 +5,25 @@ namespace BNetServer.Networking;
 #pragma warning disable SYSLIB1015
 internal static partial class BnetTcpSessionLogMessages
 {
-    // EventId 800-899 range is reserved for BnetTcpSession.
+    // EventId 800-849 range is reserved for BnetTcpSession (850-859 BnetRestApiSession).
 
     [LoggerMessage(EventId = 800, Level = LogLevel.Information, Message = "Accepting connection from {Endpoint}.")]
     public static partial void AcceptingConnection(
         ILogger logger, string SourceFile, string NetDir, string Endpoint);
+
+    [LoggerMessage(EventId = 801, Level = LogLevel.Error,
+        Message = "Dropping frame service {ServiceHash} method {MethodId} token {Token}: {Message}")]
+    public static partial void FrameDispatchFailed(
+        ILogger logger, System.Exception ex, string SourceFile, string NetDir,
+        uint ServiceHash, uint MethodId, uint Token, string Message);
+
+    [LoggerMessage(EventId = 802, Level = LogLevel.Error,
+        Message = "Malformed frame header from {Endpoint}, closing connection: {Message}")]
+    public static partial void FrameParseFailed(
+        ILogger logger, System.Exception ex, string SourceFile, string NetDir, string Endpoint, string Message);
+
+    [LoggerMessage(EventId = 803, Level = LogLevel.Error,
+        Message = "Buffer processing failed for {Endpoint}, closing connection: {Message}")]
+    public static partial void BufferProcessingFailed(
+        ILogger logger, System.Exception ex, string SourceFile, string NetDir, string Endpoint, string Message);
 }

--- a/scripts/inject-bnet-fault.ps1
+++ b/scripts/inject-bnet-fault.ps1
@@ -1,0 +1,173 @@
+<#
+.SYNOPSIS
+    Issue #266 fault injector for the BNet listener.
+
+.DESCRIPTION
+    Speaks the BNet TLS framing to an already-running HermesProxy and sends deliberately broken
+    frames, so the guards in BnetTcpSession / BnetRestApiSession fire against a real session rather
+    than only in unit tests. Frames are built with the proxy's own Bgs.Protocol.Header, so the
+    encoding is whatever the production code produces — nothing is hand-rolled here.
+
+    Cases:
+      Baseline    well-formed Connect. Control: must come back with a ConnectResponse.
+      BadPayload  valid header, undecodable payload, then a valid frame. The bad frame is dropped
+                  and the session must still answer the frame behind it (EventId 801).
+      BadHeader   undecodable header, then a valid frame. Framing is lost, so the connection is
+                  closed and the trailing frame must NOT be dispatched (EventId 802).
+      Overflow    partial frame, then a read that pushes the pooled buffer past its cap. The
+                  connection is closed with a logged reason (EventId 803).
+
+    The REST guard (EventId 850) needs no script:
+      curl -k https://127.0.0.1:<RestPort>/bnetserver/login/ -H "Accept: a" -H "Accept: b"
+    A duplicate header makes HttpHelper.ParseRequest throw; the session must close, not hang.
+
+.EXAMPLE
+    ./scripts/inject-bnet-fault.ps1 -Case Baseline
+    ./scripts/inject-bnet-fault.ps1 -Case BadPayload
+#>
+param(
+    [ValidateSet('BadPayload', 'BadHeader', 'Baseline', 'Overflow')]
+    [string] $Case = 'BadPayload',
+    [string] $ProxyHost = '127.0.0.1',
+    [int]    $Port = 1119,
+    [string] $BinPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $BinPath) {
+    $projectRoot = (& git -C $PSScriptRoot rev-parse --show-toplevel 2>$null)
+    if (-not $projectRoot) { throw "Not inside a git work tree; pass -BinPath explicitly." }
+    $BinPath = Join-Path $projectRoot 'HermesProxy/bin/Release'
+}
+if (-not (Test-Path (Join-Path $BinPath 'Framework.dll'))) {
+    throw "Framework.dll not found under '$BinPath'. Build Release first, or pass -BinPath."
+}
+
+[Reflection.Assembly]::LoadFrom((Join-Path $BinPath 'Google.Protobuf.dll')) | Out-Null
+[Reflection.Assembly]::LoadFrom((Join-Path $BinPath 'Framework.dll')) | Out-Null
+
+$CONNECTION_SERVICE = 0x65446991
+
+function New-Frame {
+    param([byte[]] $HeaderBytes, [byte[]] $Payload)
+    $frame = New-Object byte[] (2 + $HeaderBytes.Length + $Payload.Length)
+    # 2-byte big-endian header length prefix
+    $frame[0] = [byte](($HeaderBytes.Length -shr 8) -band 0xFF)
+    $frame[1] = [byte]($HeaderBytes.Length -band 0xFF)
+    [Array]::Copy($HeaderBytes, 0, $frame, 2, $HeaderBytes.Length)
+    if ($Payload.Length -gt 0) {
+        [Array]::Copy($Payload, 0, $frame, 2 + $HeaderBytes.Length, $Payload.Length)
+    }
+    return $frame
+}
+
+function New-ConnectHeaderBytes {
+    param([uint32] $Token, [uint32] $PayloadSize)
+    $h = New-Object Bgs.Protocol.Header
+    $h.ServiceId = 0
+    $h.ServiceHash = $CONNECTION_SERVICE
+    $h.MethodId = 1          # ConnectionService/Connect
+    $h.Token = $Token
+    $h.Size = $PayloadSize
+    return [Google.Protobuf.MessageExtensions]::ToByteArray($h)
+}
+
+function New-ValidConnectFrame {
+    param([uint32] $Token)
+    $req = New-Object Bgs.Protocol.Connection.V1.ConnectRequest
+    $req.UseBindlessRpc = $true
+    $payload = [Google.Protobuf.MessageExtensions]::ToByteArray($req)
+    return New-Frame (New-ConnectHeaderBytes $Token ([uint32]$payload.Length)) $payload
+}
+
+# Build the byte stream for the chosen case.
+$out = New-Object System.IO.MemoryStream
+switch ($Case) {
+    'Baseline' {
+        # Control: a single well-formed Connect. Must get a ConnectResponse back.
+        $f = New-ValidConnectFrame 100
+        $out.Write($f, 0, $f.Length)
+    }
+    'BadPayload' {
+        # Valid header, payload that is not decodable protobuf (wire type 7 does not exist).
+        # Expect guard 801: the frame is skipped and the NEXT frame still answers.
+        $junk = [byte[]] @(0x0F, 0x0F)
+        $f1 = New-Frame (New-ConnectHeaderBytes 101 ([uint32]$junk.Length)) $junk
+        $out.Write($f1, 0, $f1.Length)
+        $f2 = New-ValidConnectFrame 102
+        $out.Write($f2, 0, $f2.Length)
+    }
+    'BadHeader' {
+        # Header bytes that will not decode at all -> framing is lost.
+        # Expect guard 802: buffer cleared, connection closed.
+        $junkHeader = [byte[]] @(0x0F, 0x0F, 0x0F)
+        $f = New-Frame $junkHeader ([byte[]] @())
+        $out.Write($f, 0, $f.Length)
+        # A valid frame behind it, which must NOT be dispatched.
+        $f2 = New-ValidConnectFrame 103
+        $out.Write($f2, 0, $f2.Length)
+    }
+    'Overflow' {
+        # Handled below as two separate writes; nothing to build here.
+    }
+}
+$payloadBytes = $out.ToArray()
+
+$client = New-Object System.Net.Sockets.TcpClient($ProxyHost, $Port)
+$client.NoDelay = $true
+$validate = [System.Net.Security.RemoteCertificateValidationCallback] { param($s, $c, $ch, $e) $true }
+$ssl = New-Object System.Net.Security.SslStream($client.GetStream(), $false, $validate)
+$ssl.AuthenticateAsClient($ProxyHost)
+Write-Host "[inject] case=$Case TLS up, sending $($payloadBytes.Length) bytes"
+
+if ($Case -eq 'Overflow') {
+    # First write: a frame header claiming 65535 header bytes but sending only a few, so the
+    # parser reports Incomplete and those bytes stay resident in the pooled buffer.
+    $stub = [byte[]] @(0xFF, 0xFF, 0x01, 0x02, 0x03)
+    $ssl.Write($stub, 0, $stub.Length)
+    $ssl.Flush()
+    Start-Sleep -Milliseconds 300
+    # Second write: fills the rest of a 65535-byte read. Appending it to the bytes already held
+    # exceeds PooledByteBuffer's 65536 cap, so EnsureCapacity throws inside ReadHandler.
+    $blob = New-Object byte[] 65535
+    $ssl.Write($blob, 0, $blob.Length)
+    $ssl.Flush()
+    Write-Host "[inject] overflow: sent $($stub.Length) + $($blob.Length) bytes"
+} else {
+    $ssl.Write($payloadBytes, 0, $payloadBytes.Length)
+    $ssl.Flush()
+}
+
+# Read whatever comes back within a short window.
+$ssl.ReadTimeout = 3000
+$buf = New-Object byte[] 4096
+$total = 0
+try {
+    while ($true) {
+        $n = $ssl.Read($buf, $total, $buf.Length - $total)
+        if ($n -le 0) { break }
+        $total += $n
+        if ($total -ge $buf.Length) { break }
+    }
+    Write-Host "[inject] peer closed after $total bytes"
+} catch [System.IO.IOException] {
+    if ($total -gt 0) {
+        Write-Host "[inject] read timeout, got $total bytes"
+    } else {
+        Write-Host "[inject] no reply (timeout or reset): $($_.Exception.InnerException.Message)"
+    }
+}
+
+if ($total -gt 0) {
+    $hdrLen = ($buf[0] -shl 8) -bor $buf[1]
+    $hdrBytes = New-Object byte[] $hdrLen
+    [Array]::Copy($buf, 2, $hdrBytes, 0, $hdrLen)
+    $reply = [Bgs.Protocol.Header]::Parser.ParseFrom($hdrBytes)
+    Write-Host "[inject] reply header: serviceId=$($reply.ServiceId) methodId=$($reply.MethodId) token=$($reply.Token) status=$($reply.Status) size=$($reply.Size)"
+} else {
+    Write-Host "[inject] no reply frame"
+}
+
+$ssl.Dispose()
+$client.Dispose()


### PR DESCRIPTION
Closes #266. Follow-up to #265, which fixed one instance of this failure mode; this covers the class.

## The problem

`SSLSocket.AsyncRead` starts the next read as fire-and-forget:

```csharp
_ = ReadHandler(receiveBuffer, result);
```

That is deliberate — `ReadHandler` re-arms the loop itself by awaiting `AsyncRead` again, so awaiting it here would chain every read into the previous one and never unwind. But the discarded task means a fault inside it is never observed, and `BnetTcpSession.ReadHandler` reaches its own `await AsyncRead()` only if `ProcessCurrentBuffer` returns normally. So any exception out of the frame loop stopped all further reads on that connection, left the socket open, and logged nothing. From the outside it is indistinguishable from a hang.

`ServiceManager.Invoke` runs arbitrary service handlers over client-supplied protobuf with no exception handling of its own: `request.MergeFrom(stream)` throws on a malformed payload, and `DynamicInvoke` wraps any handler fault in a `TargetInvocationException`. `PooledByteBuffer.EnsureCapacity` throws when a read pushes past its 64 KB cap. All of it landed on the silent path.

`BnetRestApiSession` shares the same read loop, and its trigger is not hypothetical: `HttpHelper.ParseRequest` stores headers with `Dictionary.Add`, so **any repeated header name** — a second `Accept`, a second `Cookie` — throws `ArgumentException`.

## The fix

Failures are contained at the frame boundary, with the response chosen by whether framing survived:

| Situation | Framing | Action | EventId |
|---|---|---|---|
| Dispatch throws | intact — buffer already advanced past the frame | log, skip that frame, keep reading | 801 |
| Header will not decode | lost — no way to find the next boundary | log, clear buffer, close | 802 |
| Buffer append overflows | unknown | log, close | 803 |
| REST request handling throws | n/a | log, close | 850 |
| Handler task faults anyway | n/a | log (backstop for future subclasses) | 910 |

`AsyncRead` keeps its fire-and-forget call — the comment now records *why*, so it doesn't get "fixed" into an unbounded await chain later — but observes the task so a fault in a future subclass is logged rather than lost.

All logging is source-generated `[LoggerMessage]` at `Error`. EventId ranges: 800-849 `BnetTcpSession`, 850-859 `BnetRestApiSession`, 910-919 `SSLSocket`.

## Verification

**Unit tests** — 1058 pass (was 1052). The six new ones were confirmed meaningful by reverting the production changes and re-running: all six fail, with the exact exceptions the guards now catch (`Protocol message contained a tag with an invalid wire type`, `Buffer would exceed maximum capacity of 65536 bytes`, `An item with the same key has already been added. Key: accept`).

**Live fault injection** — every guard driven against a running proxy via `scripts/inject-bnet-fault.ps1`, which builds frames with the proxy's own `Bgs.Protocol.Header` rather than hand-rolled bytes. A well-formed `Connect` control returned `serviceId=254 token=100 status=0 size=20` first, to prove the injector speaks the protocol.

| Case | Injected | Result |
|---|---|---|
| 801 | valid header + undecodable payload (token 101), then a valid frame (token 102) | bad frame dropped, **token 102 answered normally** — session survived and kept dispatching |
| 802 | undecodable header, then a valid frame (token 103) | connection closed, trailing frame correctly not dispatched |
| 803 | 5-byte partial frame, then a 65535-byte read | closed with `Buffer would exceed maximum capacity of 65536 bytes` |
| 850 | duplicate `Accept` header (single-`Accept` control returned 200) | closed with `An item with the same key has already been added. Key: accept` |

Log output from that run:

```
E | S | BnetTcpSession     | Dropping frame service 1698982289 method 1 token 101: Protocol message contained a tag with an invalid wire type.
E | S | BnetTcpSession     | Malformed frame header from 127.0.0.1:57418, closing connection: Protocol message contained a tag with an invalid wire type.
E | S | BnetTcpSession     | Buffer processing failed for 127.0.0.1:57428, closing connection: Buffer would exceed maximum capacity of 65536 bytes
E | S | BnetRestApiSession | Request handling failed for 127.0.0.1:57424, closing connection: An item with the same key has already been added. Key: accept
```

Zero unlogged crashes across all four.

**Cross-version playtests** — `BnetTcpSession` and `SSLSocket` are shared by every client build and are not version-gated, so all three expansion families were driven end to end. Each reached world, was played, and quit cleanly:

| Client | Backend | `legacyExpansion` | Traffic | Guard hits |
|---|---|---|---|---|
| V3_4_3_54261 | AzerothCore playerbots `192.168.88.44:3725` | 3 | 2 runs | 0 |
| V1_14_2 | cMaNGOS vanilla `192.168.88.55:3724` | 1 | 704 KB | 0 |
| V2_5_3 | cMaNGOS TBC `192.168.88.55:3725` | 2 | 512 KB | 0 |

The only errors logged in those sessions were the expected `AuthClient | Socket Closed By Server` at realm-list handoff and `WorldClient | Socket Closed By GameWorldServer` on quit. The 1.14.2 and 2.5.3 runs each logged one `CMSG_OBJECT_UPDATE_FAILED`; that is a WorldSocket/Values path, disjoint from the BNet framing touched here, and not introduced by this branch.

## Scope notes

- **`ServiceManager.Invoke` is unchanged.** The blast radius is contained at the frame boundary rather than by altering dispatch semantics, so a handler that throws still sends no RPC reply and the client waits out its own timeout on that one call.
- **EventId 910 has no test and did not fire during injection.** It is now unreachable from both existing subclasses, since each catches internally; it exists as a backstop for future ones. Testing it needs either an authenticated `SslStream` harness or a GC-timing-dependent `UnobservedTaskException` check that would be flaky under the parallel runner.
- `scripts/inject-bnet-fault.ps1` is a manual tool, not part of the test suite. It resolves the repo root with `git rev-parse` and takes a `-BinPath` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHgHfRC5VbT98rDkUSaixy
