### PR TITLE
fix(v3.4.3): stop truncating vehicle action bar spell ids to 16 bits

### DIFF
--- a/HermesProxy.Tests/World/PetActionButtonEncodingTests.cs
+++ b/HermesProxy.Tests/World/PetActionButtonEncodingTests.cs
@@ -1,0 +1,103 @@
+using HermesProxy.World.Client;
+using HermesProxy.World.Server;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// Issue #264: the legacy 3.3.5a action button packs (state:8 | spell:24) —
+// UNIT_ACTION_BUTTON_ACTION(X) is X & 0x00FFFFFF on AzerothCore, mangos-wotlk and
+// VMaNGOS alike. Masking the spell to 16 bits dropped the high byte of every id above
+// 65535, so the Trial of the Champion mount's Thrust (68505) reached the client as 2969.
+public class PetActionButtonEncodingTests
+{
+    // Argent Warhorse (35644) / Argent Battleworg (36558), verified against the native
+    // 3.4.3 capture wrathion_343_toc_vehicle_actionbar_20260908.pkt.
+    private const uint Thrust = 68505;        // 0x010B99 — needs 17 bits
+    private const uint ShieldBreaker = 62575; // 0x00F46F — fits in 16, survived the old mask
+    private const uint Charge = 68282;        // 0x010ABA
+    private const uint Defend = 66482;        // 0x0103B2
+
+    [Theory]
+    [InlineData(Thrust)]
+    [InlineData(ShieldBreaker)]
+    [InlineData(Charge)]
+    [InlineData(Defend)]
+    public void LegacyVehicleButton_KeepsFullSpellIdAndUiPosition(uint spellId)
+    {
+        // Legacy vehicle bars put the UI position (index + 8) in the high byte.
+        const byte uiPosition = 0x0A;
+        uint legacy = ((uint)uiPosition << 24) | spellId;
+
+        uint modern = WorldClient.TranslateLegacyPetActionButtonToV343(legacy);
+
+        Assert.Equal(spellId, modern & 0x7FFFFF);
+        Assert.Equal(uiPosition, (byte)(modern >> 23));
+    }
+
+    [Theory]
+    [InlineData(0xC1u, 0x181u)] // ACT_ENABLED  -> AutoCastSpell
+    [InlineData(0x81u, 0x101u)] // ACT_DISABLED -> ManualSpell
+    [InlineData(0xC0u, 0x101u)] // plain spell  -> ManualSpell
+    [InlineData(0x01u, 0x001u)] // ACT_PASSIVE  -> PassiveSpell
+    public void LegacyPetButton_KeepsFullSpellId(uint legacyState, uint expectedSlot)
+    {
+        uint legacy = (legacyState << 24) | Thrust;
+
+        uint modern = WorldClient.TranslateLegacyPetActionButtonToV343(legacy);
+
+        Assert.Equal(Thrust, modern & 0x7FFFFF);
+        Assert.Equal(expectedSlot, modern >> 23);
+    }
+
+    [Fact]
+    public void LegacyCommandButton_MapsToCommandSlot()
+    {
+        // ACT_COMMAND carries a COMMAND_* value, not a spell id.
+        uint modern = WorldClient.TranslateLegacyPetActionButtonToV343((0x07u << 24) | 2u);
+
+        Assert.Equal(7u, modern >> 23);
+        Assert.Equal(2u, modern & 0x7FFFFF);
+    }
+
+    [Fact]
+    public void ModernSlotVocabulary_PassesThrough()
+    {
+        // TrinityCore wotlk_classic already emits modern slots; don't re-translate.
+        uint modern = (0x181u << 23) | Thrust;
+
+        Assert.Equal(modern, WorldClient.TranslateLegacyPetActionButtonToV343(modern));
+    }
+
+    [Theory]
+    [InlineData(Thrust)]
+    [InlineData(Charge)]
+    [InlineData(Defend)]
+    public void ModernToLegacy_RoundTripsFullSpellId(uint spellId)
+    {
+        uint legacy = (0xC1u << 24) | spellId;
+
+        uint modern = WorldClient.TranslateLegacyPetActionButtonToV343(legacy);
+        uint roundTripped = WorldSocket.TranslateV343PetActionToLegacy(modern);
+
+        Assert.Equal(legacy, roundTripped);
+    }
+
+    [Fact]
+    public void ModernToLegacy_VehicleSlotShipsCastableState()
+    {
+        // The client casts vehicle abilities through CMSG_PET_CAST_SPELL, so this path is a
+        // fallback — but echoing the UI position back would hit the legacy handler's
+        // "unknown PET flag" default and be dropped.
+        uint legacy = WorldSocket.TranslateV343PetActionToLegacy((8u << 23) | Thrust);
+
+        Assert.Equal(0x81u, legacy >> 24);
+        Assert.Equal(Thrust, legacy & 0x00FFFFFF);
+    }
+
+    [Fact]
+    public void EmptyButton_StaysEmpty()
+    {
+        Assert.Equal(0u, WorldClient.TranslateLegacyPetActionButtonToV343(0));
+        Assert.Equal(0u, WorldSocket.TranslateV343PetActionToLegacy(0));
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/PetHandler.cs
@@ -3,6 +3,7 @@ using HermesProxy.Enums;
 using HermesProxy.World.Enums;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
+using System;
 using System.Collections.Generic;
 
 namespace HermesProxy.World.Client;
@@ -52,10 +53,41 @@ public partial class WorldClient
 
         const int maxCreatureSpells = 10;
         bool translateActionEncoding = ModernVersion.Build == ClientVersionBuild.V3_4_3_54261;
+
+        Span<uint> rawButtons = stackalloc uint[maxCreatureSpells];
+        bool isVehicleBar = false;
         for (int i = 0; i < maxCreatureSpells; i++) // Read pet/vehicle spell ids
         {
             uint raw = packet.ReadUInt32();
-            // ActionButton encoding differs: 3.3.5a uses (state:8 | reserved:8 | spell:16),
+            rawButtons[i] = raw;
+            isVehicleBar |= IsLegacyVehicleBarSlot((byte)(raw >> 24));
+        }
+        isVehicleBar &= translateActionEncoding;
+
+        for (int i = 0; i < maxCreatureSpells; i++)
+        {
+            uint raw = rawButtons[i];
+
+            // A legacy vehicle bar carries the UI position (i + 8) in the high byte rather
+            // than a CharmInfo state. Native V3_4_3 keeps that position — every slot ships
+            // as MAKE_UNIT_ACTION_BUTTON_VEHICLE(spellId, i + 8), including the empty ones
+            // (Player.cpp:21560/21582), so the whole bar is rebuilt index-first here instead
+            // of per-button. See the reference capture wrathion_343_toc_vehicle_actionbar.
+            if (isVehicleBar)
+            {
+                uint vehicleSpellId = raw & LegacyActionButtonSpellMask;
+
+                // Passive control auras (e.g. Frostbrood Vanquisher Flight 53112) are cast on
+                // the vehicle server-side; the retail bar shows an empty slot for them. Keep
+                // the slot so the position still lines up with native.
+                if (vehicleSpellId != 0 && GameData.PassiveSpells.Contains(vehicleSpellId))
+                    vehicleSpellId = 0;
+
+                spells.ActionButtons[i] = ((uint)(i + VehicleActionBarFirstSlot) << 23) | vehicleSpellId;
+                continue;
+            }
+
+            // ActionButton encoding differs: 3.3.5a uses (state:8 | spell:24),
             // V3_4_3 modern uses (slot:9 | spell:23). Translate only for V3_4_3 — V1_14
             // and V2_5 modern clients haven't been verified to use the same modern format,
             // so preserve the verbatim forward there.
@@ -63,6 +95,11 @@ public partial class WorldClient
                 ? TranslateLegacyPetActionButtonToV343(raw)
                 : raw;
         }
+
+        // Native V3_4_3 ships Specialization = 0 for vehicles (Player::VehicleSpellInitialize)
+        // and -1 for hunter pets (see the emit comment below).
+        if (isVehicleBar)
+            spells.Specialization = 0;
 
         byte spellCount = packet.ReadUInt8();
         for (int i = 0; i < spellCount; i++)
@@ -339,7 +376,24 @@ public partial class WorldClient
     // hit the legacy switch's `_ => 0` fallback — the slot becomes 0 ("Passive"), which the
     // pet spellbook tab logic ignores. Spell IDs survive (low 16 bits) so the action bar
     // still displays icons, but the spellbook tab never renders.
-    private static uint TranslateLegacyPetActionButtonToV343(uint legacy)
+    // 3.3.5a packs the action button as (state:8 | spell:24) — AzerothCore, mangos-wotlk and
+    // VMaNGOS all define UNIT_ACTION_BUTTON_ACTION(X) as X & 0x00FFFFFF. Masking to 16 bits
+    // silently drops the high byte of every spell id above 65535, which is most of the 3.2+
+    // vehicle content (issue #264: Argent Warhorse 68505 arrived as 2969).
+    private const uint LegacyActionButtonSpellMask = 0x00FFFFFF;
+
+    // Modern V3_4_3 packs (slot:9 | spell:23).
+    private const uint V343ActionButtonSpellMask = 0x007FFFFF;
+
+    // TC/AC vehicle bars use the UI position (index + 8) as the high byte, which cannot
+    // collide with the CharmInfo ActiveStates values (0x00, 0x01, 0x06, 0x07, 0x81, 0xC0, 0xC1).
+    private const int VehicleActionBarFirstSlot = 8;
+    private const byte VehicleActionBarLastSlot = VehicleActionBarFirstSlot + 9;
+
+    private static bool IsLegacyVehicleBarSlot(byte legacyState)
+        => legacyState >= VehicleActionBarFirstSlot && legacyState <= VehicleActionBarLastSlot;
+
+    internal static uint TranslateLegacyPetActionButtonToV343(uint legacy)
     {
         if (legacy == 0)
             return 0;
@@ -357,7 +411,7 @@ public partial class WorldClient
             // get their abilities (52264 Charge, 52268 Buck) shown as clickable bar entries.
             // True passive auras live in the Actions list, not ActionButtons, so this won't
             // misclassify pet passives.
-            uint modernSpellId = legacy & 0x7FFFFF;
+            uint modernSpellId = legacy & V343ActionButtonSpellMask;
             if (maybeModernSlot == 0x000 && modernSpellId != 0)
                 return (0x101u << 23) | modernSpellId;
             return legacy;
@@ -365,14 +419,15 @@ public partial class WorldClient
 
         // Otherwise treat as CMaNGOS legacy state-byte format.
         byte legacyState = (byte)((legacy >> 24) & 0xFF);
-        ushort spellId = (ushort)(legacy & 0xFFFF);
+        uint spellId = legacy & LegacyActionButtonSpellMask;
 
-        // TC packs vehicle action buttons as (slot_index:8 | 0:8 | spellId:16) — the high
-        // byte is a UI position (0x08..0x11 for the vehicle bar), not a CharmInfo state.
-        // Anything outside the known CharmInfo state values that still carries a non-zero
-        // spell ID must be a vehicle/charm castable; map to ManualCast (0x101) so the V3_4_3
-        // client renders it as a clickable bar entry. Empty slots (high byte = index,
-        // spell = 0) stay 0.
+        // TC packs vehicle action buttons as (slot_index:8 | spellId:24) — the high byte is
+        // a UI position (0x08..0x11 for the vehicle bar), not a CharmInfo state. The
+        // ActionButtons array is rebuilt index-first by the caller; this path only sees such
+        // entries via the Actions list, where the position is preserved as the modern slot.
+        // Anything else outside the known CharmInfo state values that still carries a
+        // non-zero spell ID is treated as a charm castable and mapped to ManualCast (0x101)
+        // so the V3_4_3 client renders it as a clickable bar entry.
         // EXCEPTION: vehicle slots may also hold passive control auras (e.g. Frostbrood
         // Vanquisher Flight 53112 in DK quest 12779). TC's VehicleSpellInitialize ships
         // every m_spells[] entry — including IsPassive() ones — into the action bar with
@@ -395,9 +450,10 @@ public partial class WorldClient
             0xC1 => 0x181,  // AutoCastSpell (enabled with autocast)
             0xC0 => 0x101,  // ManualSpell (active, no autocast)
             0x81 => 0x101,  // Disabled — keep spell visible, autocast off
-            _    => spellId != 0 ? 0x101u : 0u,  // TC vehicle button (e.g. Havenshire Mare 28606 → 52264 Charge)
+            _ when IsLegacyVehicleBarSlot(legacyState) => legacyState, // vehicle bar: keep the UI position
+            _    => spellId != 0 ? 0x101u : 0u,  // unknown state carrying a spell — render as castable
         };
 
-        return (v343Slot << 23) | spellId;
+        return (v343Slot << 23) | (spellId & V343ActionButtonSpellMask);
     }
 }

--- a/HermesProxy/World/Server/PacketHandlers/PetHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/PetHandler.cs
@@ -80,14 +80,14 @@ public partial class WorldSocket
 
     // Inverse of WorldClient.PetHandler.TranslateLegacyPetActionButtonToV343 — repack
     // the V3_4_3 client's Action field (slot:9 in bits 23-31, spell:23 in bits 0-22)
-    // into the 3.3.5a legacy server's expected layout (state:8 in bits 24-31, spell:16
-    // in bits 0-15). Without this, an Attack click ships as Action=(7<<23)|2 = 0x03800002,
+    // into the 3.3.5a legacy server's expected layout (state:8 in bits 24-31, spell:24
+    // in bits 0-23). Without this, an Attack click ships as Action=(7<<23)|2 = 0x03800002,
     // which the legacy server reads as state_byte=0x03 (unknown) and ignores.
     //
     // Slot mapping mirrors the legacy ActiveStates enum (cmangos `ActiveStates`):
     //   0x07=ACT_COMMAND, 0x06=ACT_REACTION, 0x01=ACT_PASSIVE,
     //   0x81=ACT_DISABLED, 0xC1=ACT_ENABLED (autocast on)
-    private static uint TranslateV343PetActionToLegacy(uint v343Action)
+    internal static uint TranslateV343PetActionToLegacy(uint v343Action)
     {
         if (v343Action == 0)
             return 0;
@@ -103,11 +103,17 @@ public partial class WorldSocket
             0x181  => 0xC1, // AutoCastSpell (enabled with autocast)
             0x101  => 0x81, // ManualSpell (active, no autocast)
             0      => 0xC0, // plain SpellID — enabled active spell
+            // Vehicle bar positions (8..17). The V3_4_3 client casts these through
+            // CMSG_PET_CAST_SPELL rather than CMSG_PET_ACTION (confirmed in the native
+            // capture), so this is a fallback only — echoing the position back would land
+            // in the legacy handler's "unknown PET flag" default and be dropped, so ship a
+            // castable state instead.
+            >= 8 and <= 17 => 0x81,
             _      => 0x00,
         };
 
-        // Legacy stores spell_id in low 16 bits; clamp.
-        ushort legacySpell = (ushort)(spellId & 0xFFFF);
+        // Legacy stores spell_id in the low 24 bits (UNIT_ACTION_BUTTON_ACTION).
+        uint legacySpell = spellId & 0x00FFFFFF;
         return ((uint)legacyState << 24) | legacySpell;
     }
 


### PR DESCRIPTION
Vehicle action bars lost every spell id above 65535.

The legacy 3.3.5a action button packs `(state:8 | spell:24)` — `UNIT_ACTION_BUTTON_ACTION(X)` is `X & 0x00FFFFFF` on AzerothCore, mangos-wotlk and VMaNGOS alike. The translation masked the spell to 16 bits, so the high byte was silently dropped.

On the Trial of the Champion mount that produced:

| legacy | hex | forwarded | hex |
|---|---|---|---|
| 68505 Thrust | `0x010B99` | 2969 | `0x0B99` |
| 62575 Shield-Breaker | `0x00F46F` | 62575 | unchanged |
| 68282 Charge | `0x010ABA` | 2746 | `0x0ABA` |
| 66482 Defend | `0x0103B2` | 946 | `0x03B2` |

Shield-Breaker is the only one that fits in 16 bits, which is why the reported bar showed one correct ability plus one wrongly-named one and two that resolved to nothing.

## Also aligned with native 3.4.3

`Player::VehicleSpellInitialize` ships every slot as `MAKE_UNIT_ACTION_BUTTON_VEHICLE(spellId, i + 8)`, so:

- the UI position (`i + 8`) is preserved in bits 23+ instead of being rewritten to `ManualCast` (`0x101`)
- empty slots keep their position rather than collapsing to zero
- vehicle frames carry `Specialization = 0`; the `-1` default stays for hunter pets

The old `_ => 0x101` fallback rendered clickable buttons but is not what a real server sends.

The outbound inverse gets the same 24-bit widening. Vehicle abilities actually leave the client as `CMSG_PET_CAST_SPELL` (confirmed in the native capture), so the slot mapping added there is a guard, not the live path.

## Verification

A native capture from a 3.4.3 server (Argent Battleworg 36558) gives the reference frame. The emitted packet is now field-for-field identical — `Specialization`, `CreatureFamily`, `ReactState`, `CommandState`, `Flag`, and all ten `Action`/`SpellID` pairs.

Retested end to end on two backends:

- **TrinityCore** — frame matches native byte for byte; `CMSG_PET_CAST_SPELL` → `SMSG_SPELL_START` → `SMSG_SPELL_GO` → `SMSG_AURA_UPDATE`
- **AzerothCore + playerbots** (the reported environment, Argent Warhorse 35644) — all four ids correct on the bar and all four cast with no `CAST_FAILED`

15 unit tests cover both directions, including the round trip and the empty-slot case.

Fixes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHgHfRC5VbT98rDkUSaixy
