### PR TITLE
perf: cut allocations on the object-update receive and build paths

### DIFF
--- a/Framework/IO/ByteBuffer.cs
+++ b/Framework/IO/ByteBuffer.cs
@@ -603,7 +603,14 @@ public class ByteBuffer : IDisposable
         AdvanceWrite(data.Length);
     }
 
-    public void WriteBytes(Span<byte> data)
+    public void WriteBytes(Span<byte> data) => WriteBytes((ReadOnlySpan<byte>)data);
+
+    /// <summary>
+    /// Appends the bytes without requiring the caller to own an array. Pairs with
+    /// <see cref="GetDataSpan"/> so one buffer can be spliced into another with a single copy
+    /// instead of the two <see cref="GetData"/> would cost.
+    /// </summary>
+    public void WriteBytes(ReadOnlySpan<byte> data)
     {
         FlushBits();
         EnsureCapacity(data.Length);
@@ -892,6 +899,14 @@ public class ByteBuffer : IDisposable
         var remaining = (uint)(_length - _position);
         return ReadBytes(remaining);
     }
+
+    /// <summary>
+    /// Inflates the unread bytes into <paramref name="destination"/>, treating them as a zlib
+    /// blob. Unlike <see cref="ReadToEnd"/> + <c>ZLib.Decompress</c> this copies the compressed
+    /// payload nowhere first. Leaves the read position untouched.
+    /// </summary>
+    public void InflateRemainingInto(Span<byte> destination)
+        => ZLib.Decompress(_buffer, _position, _length - _position, destination);
 
     /// <summary>
     /// Bytes written so far, flushing any pending bit pack first — the same side effect

--- a/Framework/IO/Zlib/compress.cs
+++ b/Framework/IO/Zlib/compress.cs
@@ -51,16 +51,34 @@ public static partial class ZLib
     public static byte[] Decompress(byte[] data, uint unpackedSize)
     {
         byte[] decompressData = new byte[unpackedSize];
-        using (var deflateStream = new DeflateStream(new MemoryStream(data, 2, data.Length - 6), CompressionMode.Decompress))
-        {
-            var decompressed = new MemoryStream();
-            deflateStream.CopyTo(decompressed);
-
-            decompressed.Seek(0, SeekOrigin.Begin);
-            for (int i = 0; i < unpackedSize; i++)
-                decompressData[i] = (byte)decompressed.ReadByte();
-        }
-
+        Decompress(data, 0, data.Length, decompressData.AsSpan(0, (int)unpackedSize));
         return decompressData;
+    }
+
+    /// <summary>
+    /// Inflates a zlib blob straight into <paramref name="destination"/>.
+    /// </summary>
+    /// <remarks>
+    /// The previous shape decompressed into a growing <see cref="MemoryStream"/> and then copied
+    /// it out one <c>ReadByte()</c> at a time, so a 1.3 MB update object cost ~5.4 MB of garbage
+    /// and a virtual call per byte. Reading into the caller's buffer removes both, and lets the
+    /// caller rent that buffer.
+    ///
+    /// The offset/count pair lets the caller point at the compressed bytes already sitting in a
+    /// received packet instead of copying them out first.
+    /// </remarks>
+    public static void Decompress(byte[] data, int offset, int count, Span<byte> destination)
+    {
+        // 2-byte zlib header up front, 4-byte adler32 checksum on the end; DeflateStream wants
+        // neither.
+        using var deflateStream = new DeflateStream(
+            new MemoryStream(data, offset + 2, count - 6), CompressionMode.Decompress);
+
+        // A stream shorter than unpackedSize used to leave the tail at whatever the freshly
+        // allocated array held, i.e. zeroes. A pooled destination holds the previous packet
+        // instead, so clear the remainder rather than let stale bytes be parsed as payload.
+        int read = deflateStream.ReadAtLeast(destination, destination.Length, throwOnEndOfStream: false);
+        if (read < destination.Length)
+            destination[read..].Clear();
     }
 }

--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -424,7 +424,9 @@ public partial class WorldClient
     {
         var uncompressedSize = packet.ReadInt32();
 
-        WorldPacket pkt = packet.Inflate(uncompressedSize);
+        // Inflate hands back a pooled buffer; without the dispose the rental only comes back
+        // via the finalizer.
+        using WorldPacket pkt = packet.Inflate(uncompressedSize);
 
         while (pkt.CanRead())
         {

--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -1061,7 +1061,7 @@ public partial class ObjectUpdateBuilder
     // written earlier by the resize prefixes, so payload length has to agree with them.
     internal void WriteCreateActivePlayerDynamicPayloads(WorldPacket data, ActivePlayerData src)
     {
-        ulong[] foldedTitles = new ulong[6];
+        Span<ulong> foldedTitles = stackalloc ulong[6];
         int knownTitlesCount = FoldKnownTitles(src.KnownTitles, foldedTitles);
         for (int i = 0; i < knownTitlesCount; i++)
             data.WriteUInt64(foldedTitles[i]);
@@ -1120,7 +1120,7 @@ public partial class ObjectUpdateBuilder
     // both writers self-contained instead of threading a local across the whole block.
     internal void WriteCreateActivePlayerKnownTitlesCount(WorldPacket data, ActivePlayerData src)
     {
-        ulong[] folded = new ulong[6];
+        Span<ulong> folded = stackalloc ulong[6];
         data.WriteUInt32((uint)FoldKnownTitles(src.KnownTitles, folded));
     }
 
@@ -1215,7 +1215,7 @@ public partial class ObjectUpdateBuilder
 
     // Folds KnownTitles uint?[12] → ulong[6] (lo + hi<<32 per pair). Used by both
     // preamble (count) and body (data).
-    internal static int FoldKnownTitles(uint?[] knownTitles, ulong[] dest)
+    internal static int FoldKnownTitles(uint?[] knownTitles, Span<ulong> dest)
     {
         if (knownTitles == null)
             return 0;
@@ -1249,7 +1249,7 @@ public partial class ObjectUpdateBuilder
     // Emits: WriteBits(count, 32) + count× WriteBit(true).
     internal void WriteUpdateActivePlayerKnownTitlesPreamble(WorldPacket data, ref Framework.Util.StackBitMask blocks, ActivePlayerData src)
     {
-        ulong[] folded = new ulong[6];
+        Span<ulong> folded = stackalloc ulong[6];
         int count = FoldKnownTitles(src.KnownTitles, folded);
         data.WriteBits((uint)count, 32);
         for (int i = 0; i < count; i++)
@@ -1259,7 +1259,7 @@ public partial class ObjectUpdateBuilder
     // KnownTitles body — count× WriteUInt64(folded[i]).
     internal void WriteUpdateActivePlayerKnownTitlesBody(WorldPacket data, ActivePlayerData src)
     {
-        ulong[] folded = new ulong[6];
+        Span<ulong> folded = stackalloc ulong[6];
         int count = FoldKnownTitles(src.KnownTitles, folded);
         for (int i = 0; i < count; i++)
             data.WriteUInt64(folded[i]);
@@ -1535,46 +1535,46 @@ public partial class ObjectUpdateBuilder
     private void WriteValuesCreate(WorldPacket data)
     {
         var effectiveMask = _objectTypeMask;
-        bool trace = _objectType == ObjectTypeBCC.ActivePlayer;
+        bool trace = _objectType == ObjectTypeBCC.ActivePlayer && Framework.Logging.Log.IsTraceEnabled;
 
         byte updateFieldFlags = (byte)FieldVisibilityFlags;
         data.WriteUInt8(updateFieldFlags);
 
-        int p0 = data.GetData().Length;
+        int p0 = data.GetWrittenLength();
         WriteCreateObjectData(data);
-        int p1 = data.GetData().Length;
+        int p1 = data.GetWrittenLength();
 
         if (effectiveMask.HasAnyFlag(ObjectTypeMask.Item))
             WriteCreateItemData(data);
-        int p2 = data.GetData().Length;
+        int p2 = data.GetWrittenLength();
 
         if (effectiveMask.HasAnyFlag(ObjectTypeMask.Container))
             WriteCreateContainerData(data);
-        int p3 = data.GetData().Length;
+        int p3 = data.GetWrittenLength();
 
         if (effectiveMask.HasAnyFlag(ObjectTypeMask.Unit))
             WriteCreateUnitData(data);
-        int p4 = data.GetData().Length;
+        int p4 = data.GetWrittenLength();
 
         if (effectiveMask.HasAnyFlag(ObjectTypeMask.Player))
             WriteCreatePlayerData(data);
-        int p5 = data.GetData().Length;
+        int p5 = data.GetWrittenLength();
 
         if (effectiveMask.HasAnyFlag(ObjectTypeMask.ActivePlayer))
             WriteCreateActivePlayerData(data);
-        int p6 = data.GetData().Length;
+        int p6 = data.GetWrittenLength();
 
         if (_objectTypeMask.HasAnyFlag(ObjectTypeMask.GameObject))
             WriteCreateGameObjectData(data);
-        int p7 = data.GetData().Length;
+        int p7 = data.GetWrittenLength();
 
         if (_objectTypeMask.HasAnyFlag(ObjectTypeMask.DynamicObject))
             WriteCreateDynamicObjectData(data);
-        int p8 = data.GetData().Length;
+        int p8 = data.GetWrittenLength();
 
         if (_objectTypeMask.HasAnyFlag(ObjectTypeMask.Corpse))
             WriteCreateCorpseData(data);
-        int p9 = data.GetData().Length;
+        int p9 = data.GetWrittenLength();
 
         // Phase 5a diagnostic — per-section byte sizes for the ActivePlayer create
         // packet. Used to bisect which descriptor section diverges from the V3_4_3
@@ -1583,7 +1583,7 @@ public partial class ObjectUpdateBuilder
         // ends with unflushed bits — acceptable for first-pass bisection.
         if (trace)
         {
-            byte[] buf = data.GetData();
+            ReadOnlySpan<byte> buf = data.GetDataSpan();
             Framework.Logging.Log.Print(Framework.Logging.LogType.Trace,
                 $"[Phase5aTrace] sections flags=1 obj={p1 - p0} item={p2 - p1} container={p3 - p2} " +
                 $"unit={p4 - p3} player={p5 - p4} active={p6 - p5} " +
@@ -1596,12 +1596,14 @@ public partial class ObjectUpdateBuilder
         }
     }
 
-    private static void DumpSectionHead(byte[] buf, int start, int end, string label)
+    private static void DumpSectionHead(ReadOnlySpan<byte> buf, int start, int end, string label)
     {
         int len = end - start;
         if (len <= 0) return;
         int dumpLen = Math.Min(64, len);
-        string hex = BitConverter.ToString(buf, start, dumpLen);
+        // Copy only the window being dumped -- BitConverter.ToString needs an array, but the
+        // whole packet does not have to become one to hex 64 bytes of it.
+        string hex = BitConverter.ToString(buf.Slice(start, dumpLen).ToArray());
         Framework.Logging.Log.Print(Framework.Logging.LogType.Trace,
             $"[Phase5aTrace]   {label} ({len} bytes) head={hex}");
     }
@@ -1665,13 +1667,15 @@ public partial class ObjectUpdateBuilder
 
     private void WriteValuesModern(WorldPacket packet)
     {
-        var valuesBuffer = new WorldPacket();
+        // ByteBuffer rents from ArrayPool and has a finalizer, so an undisposed scratch packet
+        // both leaks the rental and puts one finalizable object per update on the queue.
+        using var valuesBuffer = new WorldPacket();
         if (_updateData.Type == UpdateTypeModern.Values)
             WriteValuesUpdate(valuesBuffer);
         else
             WriteValuesCreate(valuesBuffer);
 
-        var valuesData = valuesBuffer.GetData();
+        ReadOnlySpan<byte> valuesData = valuesBuffer.GetDataSpan();
 
         // Debug: dump the bytes we produce for Values updates so we can compare against
         // TC's accepted format. CMSG_OBJECT_UPDATE_FAILED or `CMSG_LOG_DISCONNECT(reason=7)`
@@ -1687,7 +1691,7 @@ public partial class ObjectUpdateBuilder
             && Framework.Logging.Log.IsEnabled(Framework.Logging.LogType.Debug))
         {
             int dumpLen = System.Math.Min(96, valuesData.Length);
-            string hex = System.BitConverter.ToString(valuesData, 0, dumpLen);
+            string hex = System.BitConverter.ToString(valuesData[..dumpLen].ToArray());
             Framework.Logging.Log.Print(Framework.Logging.LogType.Debug,
                 $"[ValuesUpdateHex] guid={_updateData.Guid} type={_objectType} size={valuesData.Length} hasUnit={_updateData.UnitData != null} hasPlayer={_updateData.PlayerData != null} hasActive={_updateData.ActivePlayerData != null} hasGO={_updateData.GameObjectData != null} hex={hex}");
         }
@@ -1698,7 +1702,7 @@ public partial class ObjectUpdateBuilder
 
     public void WriteToPacket(WorldPacket packet)
     {
-        int startPos = packet.GetData().Length;
+        int startPos = packet.GetWrittenLength();
         bool traceOn = Framework.Logging.Log.IsTraceEnabled;
 
         // Phase 5a diagnostic — log the player's UnitData fields most likely to cause
@@ -1740,10 +1744,12 @@ public partial class ObjectUpdateBuilder
         // is enough to identify which object type was being written.
         if (traceOn && _objectType == ObjectTypeBCC.ActivePlayer)
         {
-            byte[] all = packet.GetData();
+            // Slice the dump window off a span over the live buffer; GetData would copy the
+            // entire packet just to hex its first 80 bytes.
+            ReadOnlySpan<byte> all = packet.GetDataSpan();
             int len = all.Length - startPos;
             int dumpLen = Math.Min(80, len);
-            string hex = BitConverter.ToString(all, startPos, dumpLen);
+            string hex = BitConverter.ToString(all.Slice(startPos, dumpLen).ToArray());
             Framework.Logging.Log.Print(Framework.Logging.LogType.Trace,
                 $"[Phase5aTrace] ActivePlayer packet bytes={len} first80={hex}");
         }
@@ -1755,10 +1761,12 @@ public partial class ObjectUpdateBuilder
             && _updateData.Type != UpdateTypeModern.Values
             && _objectType == ObjectTypeBCC.GameObject)
         {
-            byte[] all = packet.GetData();
+            // Slice the dump window off a span over the live buffer; GetData would copy the
+            // entire packet just to hex its first 200 bytes.
+            ReadOnlySpan<byte> all = packet.GetDataSpan();
             int len = all.Length - startPos;
             int dumpLen = Math.Min(200, len);
-            string hex = BitConverter.ToString(all, startPos, dumpLen);
+            string hex = BitConverter.ToString(all.Slice(startPos, dumpLen).ToArray());
             var moveInfo = _updateData.CreateData?.MoveInfo;
             var go = _updateData.GameObjectData;
             Framework.Logging.Log.Print(Framework.Logging.LogType.Trace,
@@ -1778,10 +1786,12 @@ public partial class ObjectUpdateBuilder
             && _updateData.Type != UpdateTypeModern.Values
             && _updateData.Guid.GetHighType() == HighGuidType.Creature)
         {
-            byte[] all = packet.GetData();
+            // Slice the dump window off a span over the live buffer; GetData would copy the
+            // entire packet just to hex its first 256 bytes.
+            ReadOnlySpan<byte> all = packet.GetDataSpan();
             int len = all.Length - startPos;
             int dumpLen = Math.Min(256, len);
-            string hex = BitConverter.ToString(all, startPos, dumpLen);
+            string hex = BitConverter.ToString(all.Slice(startPos, dumpLen).ToArray());
             Framework.Logging.Log.Print(Framework.Logging.LogType.Trace,
                 $"[CreateObjectHex] guid={_updateData.Guid} entry={_updateData.ObjectData?.EntryID?.ToString() ?? "null"} " +
                 $"type={_objectType} bytes={len} first256={hex}");

--- a/HermesProxy/World/Packet.cs
+++ b/HermesProxy/World/Packet.cs
@@ -221,6 +221,17 @@ public class WorldPacket : ByteBuffer
         opcode = ReadUInt16();
     }
 
+    /// Read-mode ctor for a pooled, possibly-oversized buffer whose opcode is already known
+    /// (Inflate carries it over from the parent packet rather than reading it from the payload).
+    /// Pass isPooled=true when `data` came from ArrayPool<byte>.Shared so Dispose returns it.
+    public WorldPacket(uint opcode, byte[] data, int length, bool isPooled) : base(data, length, isPooled)
+    {
+        this.opcode = opcode;
+
+        if (this.opcode == 0)
+            Log.Print(LogType.Warn, "Constructed a legacy packet with opcode 0 from received data; it will be dropped as unknown.");
+    }
+
     public KeyValuePair<int, bool> ReadEntry()
     {
         // Entries masked with 0x80000000 are invalid entries OR used to tell apart NPCs and GOs
@@ -273,13 +284,21 @@ public class WorldPacket : ByteBuffer
         return field;
     }
 
+    /// <summary>
+    /// Inflates the rest of this packet into a new one. The caller owns the result and must
+    /// dispose it — the payload buffer is pooled.
+    /// </summary>
+    /// <remarks>
+    /// SMSG_COMPRESSED_UPDATE_OBJECT is the single largest allocator on the receive path, so
+    /// neither copy this used to make is affordable: the compressed bytes are inflated straight
+    /// out of this packet's buffer, and the destination is rented rather than allocated.
+    /// </remarks>
     public WorldPacket Inflate(int inflatedSize)
     {
-        var arr = ReadToEnd();
-        var newarr = ZLib.Decompress(arr, (uint)inflatedSize);
+        byte[] rented = ArrayPool<byte>.Shared.Rent(inflatedSize);
+        InflateRemainingInto(rented.AsSpan(0, inflatedSize));
 
-        // Cannot use "using" here
-        var pkt = new WorldPacket(GetOpcode(), newarr);
+        var pkt = new WorldPacket(GetOpcode(), rented, inflatedSize, isPooled: true);
         pkt.SetReceiveTime(GetReceivedTime());
         return pkt;
     }


### PR DESCRIPTION
Removes allocation from the two hottest paths in the proxy: building a V3_4_3 object update, and inflating the compressed ones the legacy server sends. No wire-format change and no behaviour change.

Every number below comes from `--metrics` runs against an AzerothCore playerbots battleground, same character and same routine each time.

## V3_4_3 ObjectUpdateBuilder

`WriteValuesCreate` recorded its ten section boundaries with `data.GetData().Length`. In write mode `GetData` allocates a `byte[]` and copies the whole packet, so every CreateObject paid ten full copies of the packet-so-far — with no gate at all, to feed a Phase 5a diagnostic that only reads them under Trace. `GetWrittenLength` performs the same `FlushBits` (the section layout depends on that flush landing where it does) and returns the same length without copying, which makes the swap byte-identical on the wire. `WriteToPacket` had the same bug for `startPos`.

Four smaller ones alongside it:

- The Phase 5a dump was gated on object type but not on log level, so an ActivePlayer create built its interpolated string and copied the packet even with Trace off.
- The three Trace hex dumps copied the whole packet to render 80–256 bytes of it; they now slice a span.
- The scratch `WorldPacket` in `WriteValuesModern` was never disposed, so it leaked its `ArrayPool` rental and queued a finalizable object per update.
- The four `ulong[6]` KnownTitles fold buffers are now `stackalloc`.

| metric | before | after |
|---|---|---|
| avg allocation per `SMSG_UPDATE_OBJECT` | 8772–9506 B | 8198–9222 B (**−6% to −8%**) |
| worst-case packet | 45048 B | **27608 B (−39%)** |

The shape matches the mechanism: the removed copies were per-CreateObject, so the largest creates gain most while the battleground's steady stream of Values updates gains less.

## zlib decompression

`ZLib.Decompress` inflated into a growing `MemoryStream` and then copied it out one `ReadByte()` at a time — roughly 2× the payload in garbage plus a virtual call per byte, and ~4× for a 1.3 MB update object. It now reads straight into the caller's buffer, and `Inflate` rents that buffer rather than allocating it, and no longer copies the compressed bytes out of the source packet first.

Because the destination is now pooled it can arrive holding a previous packet, so a stream shorter than `unpackedSize` clears the remainder instead of leaving stale bytes to be parsed as payload. The old code got zeroes for free from a fresh array; this preserves that guarantee.

Isolated microbenchmark, allocation per decompress:

| payload | before | after (pooled) |
|---|---|---|
| 4 KB | 8640 B | **280 B** |
| 64 KB | 131520 B | **280 B** |
| 1.3 MB | 5375365 B | **280 B** |

Also 1.3–3.5× faster (4.72 ms → 2.78 ms at 1.3 MB).

End to end, marginal cost of `SMSG_COMPRESSED_UPDATE_OBJECT` with the login window excluded:

| | packets | KB/packet |
|---|---|---|
| before | 3705 | 28.10 |
| after | 8873 | **25.95 (−7.7%)** |

Worth setting expectations: decompression turned out to be roughly 8% of that opcode's cost, not the bulk of it. The remainder is object parsing and modern-packet construction inside `HandleUpdateObject`, which is a separate piece of work.

`HandleCompressedMoves` never disposed its inflated packet. That was harmless with a plain array; with a pooled buffer it matters, so it does now.

## Verification

- Build clean, 1086/1086 tests pass. `ZlibCompressTests` locks the wire bytes and is untouched, so the decompress rewrite is covered by an existing oracle.
- Three battleground sessions — baseline, builder fix, zlib fix — with zero `OBJECT_UPDATE_FAILED`, zero reason-7 disconnects, and no visible misbehaviour with 14 playerbots in view.

`Inflate` and `ZLib.Decompress` sit on the receive path for every backend, so V1_14 and V2_5 are affected too. Neither was playtested here; the zlib unit tests are the only coverage for those paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
