### PR TITLE
perf: cut allocations in the update path and item hotfix lookups

### DIFF
--- a/HermesProxy.Tests/SourceGen/ContainerSectionEquivalenceTests.cs
+++ b/HermesProxy.Tests/SourceGen/ContainerSectionEquivalenceTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using HermesProxy;
 using HermesProxy.Enums;
 using HermesProxy.World;
@@ -70,13 +70,13 @@ public class ContainerSectionEquivalenceTests
         var session = CreateGameSession();
         var guid = WowGuid128.Create(HighGuidType703.Item, 1);
         var builder = MakeBuilder(guid, session, out var update);
-        populate(update.ContainerData!);
+        populate(update.EnsureContainerData());
 
         var actual = new WorldPacket();
         builder.WriteCreateContainerData(actual);
 
         var expected = new WorldPacket();
-        WriteCreateContainerData_HandPort(expected, update.ContainerData!);
+        WriteCreateContainerData_HandPort(expected, update.EnsureContainerData());
 
         Assert.Equal(expected.GetData(), actual.GetData());
     }
@@ -110,13 +110,13 @@ public class ContainerSectionEquivalenceTests
         var session = CreateGameSession();
         var guid = WowGuid128.Create(HighGuidType703.Item, 1);
         var builder = MakeBuilder(guid, session, out var update);
-        populate(update.ContainerData!);
+        populate(update.EnsureContainerData());
 
         var actual = new WorldPacket();
         builder.WriteUpdateContainerData(actual);
 
         var expected = new WorldPacket();
-        WriteUpdateContainerData_HandPort(expected, update.ContainerData!);
+        WriteUpdateContainerData_HandPort(expected, update.EnsureContainerData());
 
         Assert.Equal(expected.GetData(), actual.GetData());
     }
@@ -132,9 +132,9 @@ public class ContainerSectionEquivalenceTests
         var session = CreateGameSession();
         var guid = WowGuid128.Create(HighGuidType703.Item, 1);
         var builder = MakeBuilder(guid, session, out var update);
-        populate(update.ContainerData!);
+        populate(update.EnsureContainerData());
 
-        Assert.Equal(HasAnyContainerFieldSet_HandPort(update.ContainerData!), builder.HasAnyContainerFieldSet());
+        Assert.Equal(HasAnyContainerFieldSet_HandPort(update.EnsureContainerData()), builder.HasAnyContainerFieldSet());
     }
 
     // ---------------------------------------------------------------------

--- a/HermesProxy.Tests/SourceGen/PlayerSectionEquivalenceTests.cs
+++ b/HermesProxy.Tests/SourceGen/PlayerSectionEquivalenceTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using HermesProxy;
 using HermesProxy.Enums;
 using HermesProxy.World;
@@ -81,20 +81,20 @@ public class PlayerSectionEquivalenceTests
         }) };
         yield return new object[] { "visible-items-partial", (System.Action<PlayerData>)(p =>
         {
-            p.VisibleItems[0] = new VisibleItem { ItemID = 12345, ItemAppearanceModID = 1, ItemVisual = 0 };
-            p.VisibleItems[5] = new VisibleItem { ItemID = 67890, ItemAppearanceModID = 2, ItemVisual = 100 };
-            p.VisibleItems[18] = new VisibleItem { ItemID = 99999, ItemAppearanceModID = 0, ItemVisual = 0 };
+            p.EnsureVisibleItems()[0] = new VisibleItem { ItemID = 12345, ItemAppearanceModID = 1, ItemVisual = 0 };
+            p.EnsureVisibleItems()[5] = new VisibleItem { ItemID = 67890, ItemAppearanceModID = 2, ItemVisual = 100 };
+            p.EnsureVisibleItems()[18] = new VisibleItem { ItemID = 99999, ItemAppearanceModID = 0, ItemVisual = 0 };
         }) };
         yield return new object[] { "customizations-some", (System.Action<PlayerData>)(p =>
         {
-            p.Customizations[0] = new ChrCustomizationChoice(1u, 11u);
-            p.Customizations[3] = new ChrCustomizationChoice(4u, 44u);
-            p.Customizations[35] = new ChrCustomizationChoice(36u, 360u);
+            p.EnsureCustomizations()[0] = new ChrCustomizationChoice(1u, 11u);
+            p.EnsureCustomizations()[3] = new ChrCustomizationChoice(4u, 44u);
+            p.EnsureCustomizations()[35] = new ChrCustomizationChoice(36u, 360u);
         }) };
         yield return new object[] { "customizations-all", (System.Action<PlayerData>)(p =>
         {
             for (int i = 0; i < 36; i++)
-                p.Customizations[i] = new ChrCustomizationChoice((uint)(i + 1), (uint)((i + 1) * 10));
+                p.EnsureCustomizations()[i] = new ChrCustomizationChoice((uint)(i + 1), (uint)((i + 1) * 10));
         }) };
     }
 
@@ -143,22 +143,22 @@ public class PlayerSectionEquivalenceTests
         }) };
         yield return new object[] { "questlog-single", (System.Action<PlayerData>)(p =>
         {
-            p.QuestLog[0] = new QuestLog { QuestID = 1234, EndTime = 1700000000u, StateFlags = 0u };
+            p.EnsureQuestLog()[0] = new QuestLog { QuestID = 1234, EndTime = 1700000000u, StateFlags = 0u };
             p.QuestLog[0].ObjectiveProgress[0] = 5;
         }) };
         yield return new object[] { "questlog-multi", (System.Action<PlayerData>)(p =>
         {
             for (int i = 0; i < 5; i++)
             {
-                p.QuestLog[i] = new QuestLog { QuestID = 1000 + i, EndTime = (uint)i, StateFlags = 1u };
+                p.EnsureQuestLog()[i] = new QuestLog { QuestID = 1000 + i, EndTime = (uint)i, StateFlags = 1u };
                 for (int o = 0; o < 24; o++) p.QuestLog[i].ObjectiveProgress[o] = (short)(o + i);
             }
         }) };
         yield return new object[] { "visible-items-update", (System.Action<PlayerData>)(p =>
         {
-            p.VisibleItems[0] = new VisibleItem { ItemID = 100, ItemAppearanceModID = 1, ItemVisual = 0 };
-            p.VisibleItems[16] = new VisibleItem { ItemID = 200, ItemAppearanceModID = 2, ItemVisual = 50 };
-            p.VisibleItems[18] = new VisibleItem { ItemID = 300, ItemAppearanceModID = 0, ItemVisual = 0 };
+            p.EnsureVisibleItems()[0] = new VisibleItem { ItemID = 100, ItemAppearanceModID = 1, ItemVisual = 0 };
+            p.EnsureVisibleItems()[16] = new VisibleItem { ItemID = 200, ItemAppearanceModID = 2, ItemVisual = 50 };
+            p.EnsureVisibleItems()[18] = new VisibleItem { ItemID = 300, ItemAppearanceModID = 0, ItemVisual = 0 };
         }) };
         yield return new object[] { "all-block0-plus-quest-plus-items", (System.Action<PlayerData>)(p =>
         {
@@ -176,8 +176,8 @@ public class PlayerSectionEquivalenceTests
             p.CurrentSpecID = 10u;
             p.GuildTimeStamp = 11;
             p.DuelTeam = 12u;
-            p.QuestLog[2] = new QuestLog { QuestID = 200, EndTime = 0u, StateFlags = 0u };
-            p.VisibleItems[7] = new VisibleItem { ItemID = 77, ItemAppearanceModID = 0, ItemVisual = 0 };
+            p.EnsureQuestLog()[2] = new QuestLog { QuestID = 200, EndTime = 0u, StateFlags = 0u };
+            p.EnsureVisibleItems()[7] = new VisibleItem { ItemID = 77, ItemAppearanceModID = 0, ItemVisual = 0 };
         }) };
     }
 

--- a/HermesProxy.Tests/SourceGen/UnitSectionEquivalenceTests.cs
+++ b/HermesProxy.Tests/SourceGen/UnitSectionEquivalenceTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using HermesProxy;
 using HermesProxy.Enums;
 using HermesProxy.World;
@@ -83,8 +83,8 @@ public class UnitSectionEquivalenceTests
         unit.Health = 1000L;
         unit.MaxHealth = 1500L;
         unit.DisplayID = 49;
-        unit.NpcFlags[0] = 1u;
-        unit.NpcFlags[1] = 0u;
+        unit.EnsureNpcFlags()[0] = 1u;
+        unit.EnsureNpcFlags()[1] = 0u;
         unit.ChannelData = new UnitChannel(51769, 0);
         unit.ChannelObject = WowGuid128.Create(HighGuidType703.Creature, 0, 7777, 42);
         unit.RaceId = 7;
@@ -94,16 +94,16 @@ public class UnitSectionEquivalenceTests
         unit.DisplayPower = 1u; // Rage — the bug-history regression vector for DisplayPower UInt8 width.
         unit.Level = 60;
         unit.EffectiveLevel = 70;
-        unit.Power[0] = 100;
-        unit.MaxPower[0] = 100;
-        unit.Power[1] = 50;   // Rage
-        unit.MaxPower[1] = 100;
+        unit.EnsurePower()[0] = 100;
+        unit.EnsureMaxPower()[0] = 100;
+        unit.EnsurePower()[1] = 50;   // Rage
+        unit.EnsureMaxPower()[1] = 100;
         unit.FactionTemplate = 35;
         unit.Flags = 0x40u;
         unit.Flags2 = 0u;
         unit.AuraState = 0x100u;
-        unit.AttackRoundBaseTime[0] = 2000u;
-        unit.AttackRoundBaseTime[1] = 2000u;
+        unit.EnsureAttackRoundBaseTime()[0] = 2000u;
+        unit.EnsureAttackRoundBaseTime()[1] = 2000u;
         unit.BoundingRadius = 0.5f;
         unit.CombatReach = 2f;
         unit.NativeDisplayID = 49;
@@ -127,9 +127,8 @@ public class UnitSectionEquivalenceTests
         unit.GuildGUID = WowGuid128.Create(HighGuidType703.Guild, 99);
 
         // Populate PlayerData VisibleItems for VirtualItems fallback (mainhand at slot 15).
-        update.PlayerData!.VisibleItems = new VisibleItem?[19];
-        update.PlayerData.VisibleItems[15] = new VisibleItem(12345, 0, 0); // mainhand
-        update.PlayerData.VisibleItems[17] = new VisibleItem(2508, 0, 0);  // ranged → triggers 2300ms fallback for RangedAttackRoundBaseTime
+        update.PlayerData.EnsureVisibleItems()[15] = new VisibleItem(12345, 0, 0); // mainhand
+        update.PlayerData.EnsureVisibleItems()[17] = new VisibleItem(2508, 0, 0);  // ranged → triggers 2300ms fallback for RangedAttackRoundBaseTime
 
         var actual = new WorldPacket();
         builder.WriteCreateUnitData(actual);
@@ -189,7 +188,7 @@ public class UnitSectionEquivalenceTests
         data.WriteInt64(unit.MaxHealth.GetValueOrDefault());
         data.WriteInt32(unit.DisplayID.GetValueOrDefault());
         for (int i = 0; i < 2; i++)
-            data.WriteUInt32(unit.NpcFlags?[i].GetValueOrDefault() ?? 0);
+            data.WriteUInt32(unit.NpcFlags[i].GetValueOrDefault());
         data.WriteUInt32(0u);
         data.WriteUInt32(0u);
         data.WriteUInt32(0u);
@@ -238,7 +237,7 @@ public class UnitSectionEquivalenceTests
         for (int l = 0; l < 3; l++)
         {
             int vItemId = unit.VirtualItems != null && unit.VirtualItems[l] is VisibleItem vi ? vi.ItemID : 0;
-            if (vItemId == 0 && isOwner && playerData?.VisibleItems != null)
+            if (vItemId == 0 && isOwner && playerData != null)
             {
                 int playerSlot = 15 + l;
                 if (playerSlot < playerData.VisibleItems.Length
@@ -259,11 +258,11 @@ public class UnitSectionEquivalenceTests
         data.WriteUInt32(0u);
         data.WriteUInt32(unit.AuraState.GetValueOrDefault());
         for (int m = 0; m < 2; m++)
-            data.WriteUInt32(unit.AttackRoundBaseTime?[m].GetValueOrDefault() ?? 0);
+            data.WriteUInt32(unit.AttackRoundBaseTime[m].GetValueOrDefault());
         if (isOwner)
         {
             uint rangedTime = unit.RangedAttackRoundBaseTime.GetValueOrDefault();
-            if (rangedTime == 0 && playerData?.VisibleItems != null
+            if (rangedTime == 0 && playerData != null
                 && playerData.VisibleItems.Length > 17
                 && playerData.VisibleItems[17] is VisibleItem ranged && ranged.ItemID != 0)
             {
@@ -306,28 +305,28 @@ public class UnitSectionEquivalenceTests
         {
             for (int n = 0; n < 5; n++)
             {
-                data.WriteInt32(unit.Stats?[n].GetValueOrDefault() ?? 0);
-                data.WriteInt32(unit.StatPosBuff?[n].GetValueOrDefault() ?? 0);
-                data.WriteInt32(unit.StatNegBuff?[n].GetValueOrDefault() ?? 0);
+                data.WriteInt32(unit.Stats[n].GetValueOrDefault());
+                data.WriteInt32(unit.StatPosBuff[n].GetValueOrDefault());
+                data.WriteInt32(unit.StatNegBuff[n].GetValueOrDefault());
             }
         }
         if (isOwner)
         {
             for (int r = 0; r < 7; r++)
-                data.WriteInt32(unit.Resistances?[r].GetValueOrDefault() ?? 0);
+                data.WriteInt32(unit.Resistances[r].GetValueOrDefault());
         }
         if (isOwner)
         {
             for (int p = 0; p < 7; p++)
             {
-                data.WriteInt32(unit.PowerCostModifier?[p].GetValueOrDefault() ?? 0);
-                data.WriteFloat(unit.PowerCostMultiplier?[p].GetValueOrDefault() ?? 0f);
+                data.WriteInt32(unit.PowerCostModifier[p].GetValueOrDefault());
+                data.WriteFloat(unit.PowerCostMultiplier[p].GetValueOrDefault());
             }
         }
         for (int b = 0; b < 7; b++)
         {
-            data.WriteInt32(unit.ResistanceBuffModsPositive?[b].GetValueOrDefault() ?? 0);
-            data.WriteInt32(unit.ResistanceBuffModsNegative?[b].GetValueOrDefault() ?? 0);
+            data.WriteInt32(unit.ResistanceBuffModsPositive[b].GetValueOrDefault());
+            data.WriteInt32(unit.ResistanceBuffModsNegative[b].GetValueOrDefault());
         }
         data.WriteInt32(unit.BaseMana.GetValueOrDefault());
         if (isOwner)
@@ -547,7 +546,7 @@ public class UnitSectionEquivalenceTests
         var guid = WowGuid128.Create(HighGuidType703.Creature, 0, 1234, 1);
         var builder = MakeBuilder(guid, session, out var update);
 
-        update.UnitData!.NpcFlags[0] = 0u;   // HasValue = true, value = 0
+        update.UnitData!.EnsureNpcFlags()[0] = 0u;   // HasValue = true, value = 0
 
         Assert.False(builder.HasAnyUnitFieldSet());
     }

--- a/HermesProxy.Tests/World/ObjectUpdateTests.cs
+++ b/HermesProxy.Tests/World/ObjectUpdateTests.cs
@@ -149,7 +149,7 @@ public class ObjectUpdateConstructorTests
     }
 
     [Fact]
-    public void Constructor_ItemGuid_InitializesItemAndContainerData()
+    public void Constructor_ItemGuid_InitializesItemData_ContainerDataOnDemand()
     {
         var guid = WowGuid128.Create(HighGuidType703.Item, 1);
         var session = CreateGlobalSession();
@@ -157,8 +157,14 @@ public class ObjectUpdateConstructorTests
         var update = new ObjectUpdate(guid, UpdateTypeModern.Values, session);
 
         Assert.NotNull(update.ItemData);
-        Assert.NotNull(update.ContainerData);
         Assert.NotNull(update.ObjectData);
+        // A bag and a plain item share a guid type, so the 36-slot container block is only
+        // materialised once a container field is written.
+        Assert.Null(update.ContainerData);
+
+        var container = update.EnsureContainerData();
+        Assert.Same(container, update.ContainerData);
+        Assert.Same(container, update.EnsureContainerData());
     }
 
     [Fact]

--- a/HermesProxy.Tests/World/UpdateMaskTests.cs
+++ b/HermesProxy.Tests/World/UpdateMaskTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections;
+using HermesProxy.World.Client;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// ReadValuesUpdateBlock used to build its update mask as new BitArray(int[]) and then widen it
+// through mask.Length. BuildUpdateMask replaces both steps with one allocation; these pin it to
+// the exact bits and length the old construction produced, since every field the proxy reads
+// from a legacy update is selected by this mask.
+public class UpdateMaskTests
+{
+    private static BitArray Reference(int[] words, int length)
+    {
+        var mask = new BitArray(words);
+        if (mask.Length < length)
+            mask.Length = length;
+        return mask;
+    }
+
+    private static void AssertSame(BitArray expected, BitArray actual)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        for (int i = 0; i < expected.Length; i++)
+            Assert.True(expected[i] == actual[i], $"bit {i}: expected {expected[i]}, got {actual[i]}");
+    }
+
+    [Fact]
+    public void NoWords_NoLength_IsEmpty()
+        => AssertSame(Reference([], 0), WorldClient.BuildUpdateMask([], 0));
+
+    [Fact]
+    public void NoWords_WidensToLength()
+        => AssertSame(Reference([], 148), WorldClient.BuildUpdateMask([], 148));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    [InlineData(0x55555555)]
+    [InlineData(unchecked((int)0xAAAAAAAA))]
+    public void SingleWord_KeepsEveryBit(int word)
+        => AssertSame(Reference([word], 32), WorldClient.BuildUpdateMask([word], 32));
+
+    [Fact]
+    public void LengthShorterThanWords_KeepsTheWordsLength()
+    {
+        // BitArray(int[]) is only ever widened, never truncated, so neither is the builder.
+        int[] words = [0, 1 << 31, 7];
+        AssertSame(Reference(words, 40), WorldClient.BuildUpdateMask(words, 40));
+    }
+
+    [Fact]
+    public void RandomMasks_MatchReference()
+    {
+        var rnd = new Random(12345);
+        for (int iter = 0; iter < 2000; iter++)
+        {
+            int n = rnd.Next(0, 48);
+            var words = new int[n];
+            // Real deltas are sparse: most words are zero, a few carry a handful of bits.
+            for (int i = 0; i < n; i++)
+                words[i] = rnd.Next(4) == 0 ? rnd.Next(int.MinValue, int.MaxValue) : 0;
+
+            int length = rnd.Next(3) switch
+            {
+                0 => n * 32,
+                1 => n * 32 + rnd.Next(1, 1400), // widened to an object's *_END
+                _ => rnd.Next(0, n * 32 + 1),    // shorter than the words
+            };
+
+            AssertSame(Reference(words, length), WorldClient.BuildUpdateMask(words, length));
+        }
+    }
+}

--- a/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/CharacterHandler.cs
@@ -629,12 +629,16 @@ public partial class WorldClient
     {
         ObjectUpdate updateData = new ObjectUpdate(GetSession().GameState.CurrentPlayerGuid, UpdateTypeModern.Values, GetSession());
         var comboTarget = packet.ReadPackedGuid().To128(GetSession().GameState);
-        updateData.EnsureActivePlayerData().ComboTarget = comboTarget;
+        // Only the V1_14/V2_5 builders read ComboTarget from ActivePlayerData; V3_4_3 writes it
+        // from UnitData. Materialising ActivePlayerData for this one field was nearly all of the
+        // ~35 KB each combo-point update allocated on V3_4_3.
+        if (ModernVersion.Build != ClientVersionBuild.V3_4_3_54261)
+            updateData.EnsureActivePlayerData().ComboTarget = comboTarget;
         updateData.UnitData.ComboTarget = comboTarget;
         byte comboPoints = packet.ReadUInt8();
         sbyte powerSlot = ClassPowerTypes.GetPowerSlotForClass(GetSession().GameState.GetUnitClass(GetSession().GameState.CurrentPlayerGuid), PowerType.ComboPoints);
         if (powerSlot >= 0)
-            updateData.UnitData.Power[powerSlot] = comboPoints;
+            updateData.UnitData.EnsurePower()[powerSlot] = comboPoints;
 
         UpdateObject updatePacket = new UpdateObject(GetSession().GameState);
         updatePacket.ObjectUpdates.Add(updateData);

--- a/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/QueryHandler.cs
@@ -739,7 +739,7 @@ public partial class WorldClient
                         for (int i = 0; i < 5; i++)
                             if (srcUnit.Stats[i].HasValue)
                             {
-                                dstUnit.Stats[i] = srcUnit.Stats[i];
+                                dstUnit.EnsureStats()[i] = srcUnit.Stats[i];
                                 any = true;
                             }
                     }
@@ -755,7 +755,7 @@ public partial class WorldClient
                         for (int i = 0; i < 7; i++)
                             if (srcUnit.Resistances[i].HasValue)
                             {
-                                dstUnit.Resistances[i] = srcUnit.Resistances[i];
+                                dstUnit.EnsureResistances()[i] = srcUnit.Resistances[i];
                                 any = true;
                             }
                     }
@@ -764,7 +764,7 @@ public partial class WorldClient
                         statsUpdateObject.ObjectUpdates.Add(petValuesOu);
                         if (Log.IsTraceEnabled)
                             Log.Print(LogType.Trace,
-                            $"[PetStatsValuesSynth] sending follow-up Values for pet {mergedPetGuid} with Stats={(srcUnit.Stats != null ? "[" + string.Join(",", new[] { srcUnit.Stats[0], srcUnit.Stats[1], srcUnit.Stats[2], srcUnit.Stats[3], srcUnit.Stats[4] }) + "]" : "n")} AP={srcUnit.AttackPower} minDmg={srcUnit.MinDamage} maxDmg={srcUnit.MaxDamage} armor={srcUnit.Resistances?[0]} baseHP={srcUnit.BaseHealth}");
+                            $"[PetStatsValuesSynth] sending follow-up Values for pet {mergedPetGuid} with Stats={(srcUnit.Stats != null ? "[" + string.Join(",", new[] { srcUnit.Stats[0], srcUnit.Stats[1], srcUnit.Stats[2], srcUnit.Stats[3], srcUnit.Stats[4] }) + "]" : "n")} AP={srcUnit.AttackPower} minDmg={srcUnit.MinDamage} maxDmg={srcUnit.MaxDamage} armor={srcUnit.Resistances[0]} baseHP={srcUnit.BaseHealth}");
                         SendPacketToClient(statsUpdateObject);
                     }
                 }

--- a/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/UpdateHandler.cs
@@ -9,6 +9,7 @@ using HermesProxy.World.Objects;
 using HermesProxy.World.Server;
 using HermesProxy.World.Server.Packets;
 using System;
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -1174,6 +1175,31 @@ public partial class WorldClient
 #endif
     }
 
+    /// Renders a packed uint as its four bytes, low byte first, for DEBUG_UPDATES output.
+    /// Called only from a [Conditional] PrintValue argument, so it disappears with the call.
+    private static string FormatByteQuad(uint packed)
+        => $"{packed & 0xFF}/{(packed >> 8) & 0xFF}/{(packed >> 16) & 0xFF}/{packed >> 24}";
+
+    /// <summary>
+    /// Builds a legacy update mask of <paramref name="length"/> bits from its 32-bit words, bit 0
+    /// of word 0 first (the layout BitArray(int[]) uses), without an intermediate array. Never
+    /// shorter than the words themselves, matching BitArray(int[]) widened through Length.
+    /// </summary>
+    internal static BitArray BuildUpdateMask(ReadOnlySpan<int> words, int length)
+    {
+        var mask = new BitArray(Math.Max(length, words.Length * 32));
+        for (int w = 0; w < words.Length; w++)
+        {
+            uint word = (uint)words[w];
+            while (word != 0)
+            {
+                mask[(w << 5) + BitOperations.TrailingZeroCount(word)] = true;
+                word &= word - 1;
+            }
+        }
+        return mask;
+    }
+
     [System.Diagnostics.Conditional("DEBUG_UPDATES")]
     private void PrintValue<T>(string name, T obj, params object[] indexes)
     {
@@ -1187,14 +1213,16 @@ public partial class WorldClient
         bool missingCreateObject = !isCreating && oldValues == null;
         var maskSize = packet.ReadUInt8();
 
-        var updateMask = new int[maskSize];
+        // Staged on the stack (maskSize is a byte, so at most 1 KB), counting set bits on the way;
+        // the count sizes the field cache below.
+        Span<int> maskWords = stackalloc int[maskSize];
+        int setBits = 0;
         for (var i = 0; i < maskSize; i++)
-            updateMask[i] = packet.ReadInt32();
-
-        var mask = new BitArray(updateMask);
-        outUpdateMaskArray = mask;
-        outActuallyChangedValuesMaskArray = new BitArray(new int[maskSize]);
-        var dict = oldValues ?? new Dictionary<int, UpdateField>();
+        {
+            maskWords[i] = packet.ReadInt32();
+            setBits += BitOperations.PopCount((uint)maskWords[i]);
+        }
+        int maskBits = maskSize * 32;
 
         if (missingCreateObject)
         {
@@ -1202,7 +1230,7 @@ public partial class WorldClient
             {
                 case ObjectType.Item:
                 {
-                    if (mask.Count >= LegacyVersion.GetUpdateField(ItemField.ITEM_END))
+                    if (maskBits >= LegacyVersion.GetUpdateField(ItemField.ITEM_END))
                     {
                         // Container MaskSize = 8 (6.1.0 - 8.0.1) 5 (2.4.3 - 6.0.3)
                         if (maskSize == Convert.ToInt32((LegacyVersion.GetUpdateField(ContainerField.CONTAINER_END) + 32) / 32))
@@ -1212,7 +1240,7 @@ public partial class WorldClient
                 }
                 case ObjectType.Player:
                 {
-                    if (mask.Count >= LegacyVersion.GetUpdateField(PlayerField.PLAYER_END))
+                    if (maskBits >= LegacyVersion.GetUpdateField(PlayerField.PLAYER_END))
                     {
                         // ActivePlayer MaskSize = 184 (8.0.1)
                         if (maskSize == Convert.ToInt32((LegacyVersion.GetUpdateField(ActivePlayerField.ACTIVE_PLAYER_END) + 32) / 32))
@@ -1224,63 +1252,41 @@ public partial class WorldClient
                     break;
             }
         }
-        else
+        // A delta's mask stops at the highest word that changed. For a known object, widen it to
+        // the object's whole field range so every index the loop below reads is in bounds; a
+        // missing-create block keeps its own length, as before.
+        int maskLength = maskBits;
+        if (!missingCreateObject)
         {
-            switch (type)
+            int objectFieldEnd = type switch
             {
-                case ObjectType.Item:
-                {
-                    int ITEM_END = LegacyVersion.GetUpdateField(ItemField.ITEM_END);
-                    if (mask.Length < ITEM_END)
-                        mask.Length = ITEM_END;
-                    break;
-                }
-                case ObjectType.Container:
-                {
-                    int CONTAINER_END = LegacyVersion.GetUpdateField(ContainerField.CONTAINER_END);
-                    if (mask.Length < CONTAINER_END)
-                        mask.Length = CONTAINER_END;
-                    break;
-                }
-                case ObjectType.Unit:
-                {
-                    int UNIT_END = LegacyVersion.GetUpdateField(UnitField.UNIT_END);
-                    if (mask.Length < UNIT_END)
-                        mask.Length = UNIT_END;
-                    break;
-                }
-                case ObjectType.Player:
-                {
-                    int PLAYER_END = LegacyVersion.GetUpdateField(PlayerField.PLAYER_END);
-                    if (mask.Length < PLAYER_END)
-                        mask.Length = PLAYER_END;
-                    break;
-                }
-                case ObjectType.GameObject:
-                {
-                    int GAMEOBJECT_END = LegacyVersion.GetUpdateField(GameObjectField.GAMEOBJECT_END);
-                    if (mask.Length < GAMEOBJECT_END)
-                        mask.Length = GAMEOBJECT_END;
-                    break;
-                }
-                case ObjectType.DynamicObject:
-                {
-                    int DYNAMICOBJECT_END = LegacyVersion.GetUpdateField(DynamicObjectField.DYNAMICOBJECT_END);
-                    if (mask.Length < DYNAMICOBJECT_END)
-                        mask.Length = DYNAMICOBJECT_END;
-                    break;
-                }
-                case ObjectType.Corpse:
-                {
-                    int CORPSE_END = LegacyVersion.GetUpdateField(CorpseField.CORPSE_END);
-                    if (mask.Length < CORPSE_END)
-                        mask.Length = CORPSE_END;
-                    break;
-                }
-            }
+                ObjectType.Item => LegacyVersion.GetUpdateField(ItemField.ITEM_END),
+                ObjectType.Container => LegacyVersion.GetUpdateField(ContainerField.CONTAINER_END),
+                ObjectType.Unit => LegacyVersion.GetUpdateField(UnitField.UNIT_END),
+                ObjectType.Player => LegacyVersion.GetUpdateField(PlayerField.PLAYER_END),
+                ObjectType.GameObject => LegacyVersion.GetUpdateField(GameObjectField.GAMEOBJECT_END),
+                ObjectType.DynamicObject => LegacyVersion.GetUpdateField(DynamicObjectField.DYNAMICOBJECT_END),
+                ObjectType.Corpse => LegacyVersion.GetUpdateField(CorpseField.CORPSE_END),
+                _ => 0,
+            };
+            maskLength = Math.Max(maskBits, objectFieldEnd);
         }
 
+        // Built once at its final length. BitArray(int[]) copied a throwaway int[], and widening it
+        // afterwards through mask.Length reallocated it a second time.
+        var mask = BuildUpdateMask(maskWords, maskLength);
+        outUpdateMaskArray = mask;
+        // All-false at maskSize * 32 bits, which is what BitArray(new int[maskSize]) produced. The
+        // in-range check in the write-back relies on that length, so it is deliberately not widened.
+        outActuallyChangedValuesMaskArray = new BitArray(maskBits);
+        // A create starts this object's field cache from empty; sizing it for the fields the mask
+        // carries avoids growing it through every intermediate capacity on the way there.
+        var dict = oldValues ?? new Dictionary<int, UpdateField>(setBits);
+
         int objectEnd = LegacyVersion.GetUpdateField(ObjectField.OBJECT_END);
+        // Every field group's values go through this one buffer instead of a List each. If parsing
+        // throws, the rental is simply not returned, which ArrayPool tolerates.
+        UpdateField[] fieldScratch = ArrayPool<UpdateField>.Shared.Rent(16);
         for (var i = 0; i < mask.Count; ++i)
         {
             if (!mask[i])
@@ -1288,8 +1294,6 @@ public partial class WorldClient
 
             UpdateField blockVal = packet.ReadUpdateField();
 
-            string key = "Block Value " + i;
-            string value = blockVal.UInt32Value + "/" + blockVal.FloatValue;
             UpdateFieldInfo? fieldInfo = null;
 
             if (i < objectEnd)
@@ -1384,6 +1388,7 @@ public partial class WorldClient
             }
             int start = i;
             int size = 1;
+            string key;
             UpdateFieldType updateFieldType = UpdateFieldType.Default;
             if (fieldInfo != null)
             {
@@ -1392,17 +1397,31 @@ public partial class WorldClient
                 start = fieldInfo.Value;
                 updateFieldType = fieldInfo.Format;
             }
+            else
+            {
+                key = "Block Value " + i;
+            }
 
-            List<UpdateField> fieldData = new List<UpdateField>();
+            // Usually exactly `size` values: the slots before i, i itself, and the slots after it.
+            // But GetUpdateFieldInfo answers an index in a gap with the nearest preceding field,
+            // so i can sit past start + size, and then the group runs from start to i instead.
+            int groupLength = Math.Max(size, i - start + 1);
+            if (fieldScratch.Length < groupLength)
+            {
+                ArrayPool<UpdateField>.Shared.Return(fieldScratch);
+                fieldScratch = ArrayPool<UpdateField>.Shared.Rent(groupLength);
+            }
+            Span<UpdateField> fieldData = fieldScratch.AsSpan(0, groupLength);
+            int filled = 0;
             for (int k = start; k < i; ++k)
             {
                 UpdateField updateField;
                 if (oldValues == null || !oldValues.TryGetValue(k, out updateField))
                     updateField = new UpdateField(0);
 
-                fieldData.Add(updateField);
+                fieldData[filled++] = updateField;
             }
-            fieldData.Add(blockVal);
+            fieldData[filled++] = blockVal;
             for (int k = i - start + 1; k < size; ++k)
             {
                 int currentPosition = ++i;
@@ -1412,8 +1431,9 @@ public partial class WorldClient
                 else if (oldValues == null || !oldValues.TryGetValue(currentPosition, out updateField))
                     updateField = new UpdateField(0);
 
-                fieldData.Add(updateField);
+                fieldData[filled++] = updateField;
             }
+            fieldData = fieldData[..filled];
 
             switch (updateFieldType)
             {
@@ -1497,40 +1517,37 @@ public partial class WorldClient
                 }
                 case UpdateFieldType.Uint:
                 {
-                    for (int k = 0; k < fieldData.Count; ++k)
+                    for (int k = 0; k < fieldData.Length; ++k)
                         if (mask[start + k] && (!isCreating || fieldData[k].UInt32Value != 0))
                             PrintValue(k > 0 ? key + " + " + k : key, fieldData[k].UInt32Value, index);
                     break;
                 }
                 case UpdateFieldType.Int:
                 {
-                    for (int k = 0; k < fieldData.Count; ++k)
+                    for (int k = 0; k < fieldData.Length; ++k)
                         if (mask[start + k] && (!isCreating || fieldData[k].UInt32Value != 0))
                             PrintValue(k > 0 ? key + " + " + k : key, fieldData[k].Int32Value, index);
                     break;
                 }
                 case UpdateFieldType.Float:
                 {
-                    for (int k = 0; k < fieldData.Count; ++k)
+                    for (int k = 0; k < fieldData.Length; ++k)
                         if (mask[start + k] && (!isCreating || fieldData[k].UInt32Value != 0))
                             PrintValue(k > 0 ? key + " + " + k : key, fieldData[k].FloatValue, index);
                     break;
                 }
                 case UpdateFieldType.Bytes:
                 {
-                    for (int k = 0; k < fieldData.Count; ++k)
+                    for (int k = 0; k < fieldData.Length; ++k)
                     {
                         if (mask[start + k] && (!isCreating || fieldData[k].UInt32Value != 0))
-                        {
-                            byte[] intBytes = BitConverter.GetBytes(fieldData[k].UInt32Value);
-                            PrintValue(k > 0 ? key + " + " + k : key, intBytes[0] + "/" + intBytes[1] + "/" + intBytes[2] + "/" + intBytes[3], index);
-                        }
+                            PrintValue(k > 0 ? key + " + " + k : key, FormatByteQuad(fieldData[k].UInt32Value), index);
                     }
                     break;
                 }
                 case UpdateFieldType.Short:
                 {
-                    for (int k = 0; k < fieldData.Count; ++k)
+                    for (int k = 0; k < fieldData.Length; ++k)
                     {
                         if (mask[start + k] && (!isCreating || fieldData[k].UInt32Value != 0))
                             PrintValue(k > 0 ? key + " + " + k : key, ((short)(fieldData[k].UInt32Value & 0xffff)) + "/" + ((short)(fieldData[k].UInt32Value >> 16)), index);
@@ -1539,13 +1556,13 @@ public partial class WorldClient
                 }
                 case UpdateFieldType.Custom:
                 default:
-                    for (int k = 0; k < fieldData.Count; ++k)
+                    for (int k = 0; k < fieldData.Length; ++k)
                         if (mask[start + k] && (!isCreating || fieldData[k].UInt32Value != 0))
                             PrintValue(k > 0 ? key + " + " + k : key, fieldData[k].UInt32Value + "/" + fieldData[k].FloatValue, index);
                     break;
             }
 
-            for (int k = 0; k < fieldData.Count; ++k)
+            for (int k = 0; k < fieldData.Length; ++k)
             {
                 int absoluteIndex = start + k;
                 // V3_4_3 field-table iterates past the legacy mask's bit count when
@@ -1569,6 +1586,7 @@ public partial class WorldClient
             }
         }
 
+        ArrayPool<UpdateField>.Shared.Return(fieldScratch);
         return dict;
     }
 
@@ -2604,7 +2622,7 @@ public partial class WorldClient
             int CONTAINER_FIELD_NUM_SLOTS = LegacyVersion.GetUpdateField(ContainerField.CONTAINER_FIELD_NUM_SLOTS);
             if (CONTAINER_FIELD_NUM_SLOTS >= 0 && updateMaskArray[CONTAINER_FIELD_NUM_SLOTS])
             {
-                updateData.ContainerData.NumSlots = updates[CONTAINER_FIELD_NUM_SLOTS].UInt32Value;
+                updateData.EnsureContainerData().NumSlots = updates[CONTAINER_FIELD_NUM_SLOTS].UInt32Value;
             }
             int CONTAINER_FIELD_SLOT_1 = LegacyVersion.GetUpdateField(ContainerField.CONTAINER_FIELD_SLOT_1);
             if (CONTAINER_FIELD_SLOT_1 >= 0)
@@ -2613,7 +2631,7 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[CONTAINER_FIELD_SLOT_1 + i * 2])
                     {
-                        updateData.ContainerData.Slots[i] = GetGuidValue(updates, CONTAINER_FIELD_SLOT_1 + i * 2).To128(GetSession().GameState);
+                        updateData.EnsureContainerData().Slots[i] = GetGuidValue(updates, CONTAINER_FIELD_SLOT_1 + i * 2).To128(GetSession().GameState);
                     }
                 }
             }
@@ -2760,7 +2778,7 @@ public partial class WorldClient
                         }
                             
                         if (powerSlot >= 0)
-                            updateData.UnitData.Power[powerSlot] = updates[UNIT_FIELD_POWER1 + i].Int32Value;
+                            updateData.UnitData.EnsurePower()[powerSlot] = updates[UNIT_FIELD_POWER1 + i].Int32Value;
                     }
                 }
             }
@@ -2784,13 +2802,13 @@ public partial class WorldClient
                             powerSlot = ClassPowerTypes.GetPowerSlotForClass(classId, (PowerType)i);
 
                         if (powerSlot >= 0)
-                            updateData.UnitData.MaxPower[powerSlot] = updates[UNIT_FIELD_MAXPOWER1 + i].Int32Value;
+                            updateData.UnitData.EnsureMaxPower()[powerSlot] = updates[UNIT_FIELD_MAXPOWER1 + i].Int32Value;
 
                         if (i == (byte)PowerType.Energy)
                         {
                             powerSlot = ClassPowerTypes.GetPowerSlotForClass(classId, PowerType.ComboPoints);
                             if (powerSlot >= 0)
-                                updateData.UnitData.MaxPower[powerSlot] = 5;
+                                updateData.UnitData.EnsureMaxPower()[powerSlot] = 5;
                         }
                     }
                 }
@@ -2806,7 +2824,7 @@ public partial class WorldClient
                         uint itemId = GameData.GetItemIdWithDisplayId(itemDisplayId);
                         if (itemId != 0)
                         {
-                            updateData.UnitData.VirtualItems[i] = new VisibleItem((int)itemId, 0, 0);
+                            updateData.UnitData.EnsureVirtualItems()[i] = new VisibleItem((int)itemId, 0, 0);
                         }
                     }
                 }
@@ -2818,7 +2836,7 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[UNIT_VIRTUAL_ITEM_SLOT_ID + i])
                     {
-                        updateData.UnitData.VirtualItems[i] = new VisibleItem(updates[UNIT_VIRTUAL_ITEM_SLOT_ID + i].Int32Value, 0, 0);
+                        updateData.UnitData.EnsureVirtualItems()[i] = new VisibleItem(updates[UNIT_VIRTUAL_ITEM_SLOT_ID + i].Int32Value, 0, 0);
                     }
                 }
             }
@@ -2897,7 +2915,7 @@ public partial class WorldClient
                 for (int i = 0; i < 2; i++)
                 {
                     if (updateMaskArray[UNIT_FIELD_BASEATTACKTIME + i])
-                        updateData.UnitData.AttackRoundBaseTime[i] = updates[UNIT_FIELD_BASEATTACKTIME + i].UInt32Value;
+                        updateData.UnitData.EnsureAttackRoundBaseTime()[i] = updates[UNIT_FIELD_BASEATTACKTIME + i].UInt32Value;
                 }
             }
             int UNIT_FIELD_RANGEDATTACKTIME = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_RANGEDATTACKTIME);
@@ -3050,11 +3068,11 @@ public partial class WorldClient
                 if (LegacyVersion.RemovedInVersion(ClientVersionBuild.V2_0_1_6180))
                 {
                     NPCFlagsVanilla vanillaFlags = (NPCFlagsVanilla)updates[UNIT_NPC_FLAGS].UInt32Value;
-                    updateData.UnitData.NpcFlags[0] = (uint)(vanillaFlags.CastFlags<NPCFlags>());
+                    updateData.UnitData.EnsureNpcFlags()[0] = (uint)(vanillaFlags.CastFlags<NPCFlags>());
                 }
                 else
                 {
-                    updateData.UnitData.NpcFlags[0] = updates[UNIT_NPC_FLAGS].UInt32Value;
+                    updateData.UnitData.EnsureNpcFlags()[0] = updates[UNIT_NPC_FLAGS].UInt32Value;
                 }
             }
             int UNIT_NPC_EMOTESTATE = LegacyVersion.GetUpdateField(UnitField.UNIT_NPC_EMOTESTATE);
@@ -3074,7 +3092,7 @@ public partial class WorldClient
                 for (int i = 0; i < 5; i++)
                 {
                     if (updateMaskArray[UNIT_FIELD_STAT0 + i])
-                        updateData.UnitData.Stats[i] = updates[UNIT_FIELD_STAT0 + i].Int32Value;
+                        updateData.UnitData.EnsureStats()[i] = updates[UNIT_FIELD_STAT0 + i].Int32Value;
                 }
             }
             int UNIT_FIELD_POSSTAT0 = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_POSSTAT0);
@@ -3083,7 +3101,7 @@ public partial class WorldClient
                 for (int i = 0; i < 5; i++)
                 {
                     if (updateMaskArray[UNIT_FIELD_POSSTAT0 + i])
-                        updateData.UnitData.StatPosBuff[i] = updates[UNIT_FIELD_POSSTAT0 + i].Int32Value;
+                        updateData.UnitData.EnsureStatPosBuff()[i] = updates[UNIT_FIELD_POSSTAT0 + i].Int32Value;
                 }
             }
             int UNIT_FIELD_NEGSTAT0 = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_NEGSTAT0);
@@ -3092,7 +3110,7 @@ public partial class WorldClient
                 for (int i = 0; i < 5; i++)
                 {
                     if (updateMaskArray[UNIT_FIELD_NEGSTAT0 + i])
-                        updateData.UnitData.StatNegBuff[i] = updates[UNIT_FIELD_NEGSTAT0 + i].Int32Value;
+                        updateData.UnitData.EnsureStatNegBuff()[i] = updates[UNIT_FIELD_NEGSTAT0 + i].Int32Value;
                 }
             }
             // V3_3_5a (cMangos / TrinityCore wotlk_classic) emits the resistance arrays
@@ -3110,7 +3128,7 @@ public partial class WorldClient
                 for (int i = 0; i < 7; i++)
                 {
                     if (updateMaskArray[UNIT_FIELD_RESISTANCES + i])
-                        updateData.UnitData.Resistances[i] = updates[UNIT_FIELD_RESISTANCES + i].Int32Value;
+                        updateData.UnitData.EnsureResistances()[i] = updates[UNIT_FIELD_RESISTANCES + i].Int32Value;
                 }
             }
             int UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE);
@@ -3121,7 +3139,7 @@ public partial class WorldClient
                 for (int i = 0; i < 7; i++)
                 {
                     if (updateMaskArray[UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE + i])
-                        updateData.UnitData.ResistanceBuffModsPositive[i] = updates[UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE + i].Int32Value;
+                        updateData.UnitData.EnsureResistanceBuffModsPositive()[i] = updates[UNIT_FIELD_RESISTANCEBUFFMODSPOSITIVE + i].Int32Value;
                 }
             }
             int UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE);
@@ -3132,7 +3150,7 @@ public partial class WorldClient
                 for (int i = 0; i < 7; i++)
                 {
                     if (updateMaskArray[UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE + i])
-                        updateData.UnitData.ResistanceBuffModsNegative[i] = updates[UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE + i].Int32Value;
+                        updateData.UnitData.EnsureResistanceBuffModsNegative()[i] = updates[UNIT_FIELD_RESISTANCEBUFFMODSNEGATIVE + i].Int32Value;
                 }
             }
             int UNIT_FIELD_BASE_MANA = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_BASE_MANA);
@@ -3209,7 +3227,7 @@ public partial class WorldClient
                 for (int i = 0; i < 7; i++)
                 {
                     if (updateMaskArray[UNIT_FIELD_POWER_COST_MODIFIER + i])
-                        updateData.UnitData.PowerCostModifier[i] = updates[UNIT_FIELD_POWER_COST_MODIFIER + i].Int32Value;
+                        updateData.UnitData.EnsurePowerCostModifier()[i] = updates[UNIT_FIELD_POWER_COST_MODIFIER + i].Int32Value;
                 }
             }
             int UNIT_FIELD_POWER_COST_MULTIPLIER = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_POWER_COST_MULTIPLIER);
@@ -3218,7 +3236,7 @@ public partial class WorldClient
                 for (int i = 0; i < 7; i++)
                 {
                     if (updateMaskArray[UNIT_FIELD_POWER_COST_MULTIPLIER + i])
-                        updateData.UnitData.PowerCostMultiplier[i] = updates[UNIT_FIELD_POWER_COST_MULTIPLIER + i].FloatValue;
+                        updateData.UnitData.EnsurePowerCostMultiplier()[i] = updates[UNIT_FIELD_POWER_COST_MULTIPLIER + i].FloatValue;
                 }
             }
             int UNIT_FIELD_MAXHEALTHMODIFIER = LegacyVersion.GetUpdateField(UnitField.UNIT_FIELD_MAXHEALTHMODIFIER);
@@ -3335,7 +3353,7 @@ public partial class WorldClient
                 for (int i = 0; i < questsCount; i++)
                 {
                     QuestLog? entry = ReadQuestLogEntry(i, updateMaskArray, updates);
-                    updateData.PlayerData.QuestLog[i] = entry!;
+                    updateData.PlayerData.EnsureQuestLog()[i] = entry!;
                 }
             }
             int PLAYER_CHOSEN_TITLE = LegacyVersion.GetUpdateField(PlayerField.PLAYER_CHOSEN_TITLE);
@@ -3361,7 +3379,7 @@ public partial class WorldClient
                             itemVisual = (ushort)GameData.GetItemEnchantVisual(updates[tempEnchantIndex].UInt32Value);
                         if (itemVisual == 0 && updates.ContainsKey(permEnchantIndex))
                             itemVisual = (ushort)GameData.GetItemEnchantVisual(updates[permEnchantIndex].UInt32Value);
-                        updateData.PlayerData.VisibleItems[i] = new VisibleItem(itemId, 0, itemVisual);
+                        updateData.PlayerData.EnsureVisibleItems()[i] = new VisibleItem(itemId, 0, itemVisual);
                     }
                 }
             }
@@ -3382,7 +3400,7 @@ public partial class WorldClient
                         ushort itemVisual = updates.ContainsKey(enchantIndex)
                             ? (ushort)GameData.GetItemEnchantVisual(updates[enchantIndex].UInt32Value)
                             : (ushort)0;
-                        updateData.PlayerData.VisibleItems[i] = new VisibleItem(itemId, 0, itemVisual);
+                        updateData.PlayerData.EnsureVisibleItems()[i] = new VisibleItem(itemId, 0, itemVisual);
                     }
                 }
             }
@@ -3549,7 +3567,7 @@ public partial class WorldClient
                     var customizations = CharacterCustomizations.ConvertLegacyCustomizationsToModern(raceId, sexId, (byte)skin, (byte)face, (byte)hairStyle, (byte)hairColor, (byte)facialHair);
                     for (int i = 0; i < 5; i++)
                     {
-                        updateData.PlayerData.Customizations[i] = customizations[i];
+                        updateData.PlayerData.EnsureCustomizations()[i] = customizations[i];
                     }
 
                     // Create writes customizations unconditionally; a Values delta only carries
@@ -3603,7 +3621,10 @@ public partial class WorldClient
             if (PLAYER_FIELD_COMBO_TARGET >= 0 && updateMaskArray[PLAYER_FIELD_COMBO_TARGET])
             {
                 var comboTarget = GetGuidValue(updates, PlayerField.PLAYER_FIELD_COMBO_TARGET).To128(GetSession().GameState);
-                updateData.EnsureActivePlayerData().ComboTarget = comboTarget;
+                // Only the V1_14/V2_5 builders read ComboTarget from ActivePlayerData; V3_4_3
+                // writes it from UnitData, so don't materialise ActivePlayerData just for it.
+                if (ModernVersion.Build != ClientVersionBuild.V3_4_3_54261)
+                    updateData.EnsureActivePlayerData().ComboTarget = comboTarget;
                 updateData.UnitData.ComboTarget = comboTarget;
             }
             int PLAYER_FIELD_KNOWN_TITLES = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_KNOWN_TITLES);
@@ -3820,7 +3841,7 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[PLAYER_FIELD_POSSTAT0 + i])
                     {
-                        updateData.UnitData.StatPosBuff[i] = updates[PLAYER_FIELD_POSSTAT0 + i].Int32Value;
+                        updateData.UnitData.EnsureStatPosBuff()[i] = updates[PLAYER_FIELD_POSSTAT0 + i].Int32Value;
                     }
                 }
             }
@@ -3831,7 +3852,7 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[PLAYER_FIELD_NEGSTAT0 + i])
                     {
-                        updateData.UnitData.StatNegBuff[i] = updates[PLAYER_FIELD_NEGSTAT0 + i].Int32Value;
+                        updateData.UnitData.EnsureStatNegBuff()[i] = updates[PLAYER_FIELD_NEGSTAT0 + i].Int32Value;
                     }
                 }
             }
@@ -3842,7 +3863,7 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[PLAYER_FIELD_RESISTANCEBUFFMODSPOSITIVE + i])
                     {
-                        updateData.UnitData.ResistanceBuffModsPositive[i] = updates[PLAYER_FIELD_RESISTANCEBUFFMODSPOSITIVE + i].Int32Value;
+                        updateData.UnitData.EnsureResistanceBuffModsPositive()[i] = updates[PLAYER_FIELD_RESISTANCEBUFFMODSPOSITIVE + i].Int32Value;
                     }
                 }
             }
@@ -3853,7 +3874,7 @@ public partial class WorldClient
                 {
                     if (updateMaskArray[PLAYER_FIELD_RESISTANCEBUFFMODSNEGATIVE + i])
                     {
-                        updateData.UnitData.ResistanceBuffModsNegative[i] = updates[PLAYER_FIELD_RESISTANCEBUFFMODSNEGATIVE + i].Int32Value;
+                        updateData.UnitData.EnsureResistanceBuffModsNegative()[i] = updates[PLAYER_FIELD_RESISTANCEBUFFMODSNEGATIVE + i].Int32Value;
                     }
                 }
             }
@@ -3923,7 +3944,7 @@ public partial class WorldClient
                     {
                         if (powerUpdate != null && guid == GetSession().GameState.CurrentPlayerGuid)
                             powerUpdate.Powers.Add(new PowerUpdatePower(comboPoints, (byte)PowerType.ComboPoints));
-                        updateData.UnitData.Power[powerSlot] = comboPoints;
+                        updateData.UnitData.EnsurePower()[powerSlot] = comboPoints;
                     }
                 }
                 else
@@ -4146,7 +4167,7 @@ public partial class WorldClient
             int PLAYER_FIELD_MOD_MANA_REGEN = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_MOD_MANA_REGEN);
             if (PLAYER_FIELD_MOD_MANA_REGEN >= 0 && updateMaskArray[PLAYER_FIELD_MOD_MANA_REGEN])
             {
-                updateData.UnitData.ModPowerRegen[0] = updates[PLAYER_FIELD_MOD_MANA_REGEN].FloatValue;
+                updateData.UnitData.EnsureModPowerRegen()[0] = updates[PLAYER_FIELD_MOD_MANA_REGEN].FloatValue;
             }
             int PLAYER_FIELD_MAX_LEVEL = LegacyVersion.GetUpdateField(PlayerField.PLAYER_FIELD_MAX_LEVEL);
             if (PLAYER_FIELD_MAX_LEVEL >= 0 && updateMaskArray[PLAYER_FIELD_MAX_LEVEL])

--- a/HermesProxy/World/GameData.cs
+++ b/HermesProxy/World/GameData.cs
@@ -3893,7 +3893,18 @@ public static partial class GameData
 
     public static List<HotfixRecord> FindHotfixesByRecordIdAndTable(uint id, DB2Hash table, uint startId = 0)
     {
-        return Hotfixes.Values.Where(hotfix => hotfix.HotfixId >= startId && hotfix.TableHash == table && hotfix.RecordId == id).ToList();
+        // Enumerate the dictionary itself. ConcurrentDictionary.Values takes every lock and copies
+        // the whole store (tens of thousands of records) into a new list before anything is
+        // filtered, and the item-query path runs this twice per hotfix. The enumerator walks the
+        // same buckets in the same order without locking or copying; UpdateHotfix depends on that
+        // order, since it keeps the last match and invalidates the rest.
+        var found = new List<HotfixRecord>();
+        foreach (var (_, hotfix) in Hotfixes)
+        {
+            if (hotfix.HotfixId >= startId && hotfix.TableHash == table && hotfix.RecordId == id)
+                found.Add(hotfix);
+        }
+        return found;
     }
 
     public static void UpdateHotfix(object obj, bool remove = false)

--- a/HermesProxy/World/Objects/PlayerData.cs
+++ b/HermesProxy/World/Objects/PlayerData.cs
@@ -18,6 +18,14 @@ public class QuestLog
 }
 public class PlayerData
 {
+    // Same scheme as UnitData: an array nothing has written yet reads as a shared, never-written
+    // stand-in exposed only as ReadOnlySpan, and writers materialise the real one through
+    // Ensure*. A foreign player's Values delta rarely touches its quest log, gear or
+    // customizations, so it no longer allocates three arrays for them.
+    private static readonly QuestLog[] _emptyQuestLog = new QuestLog[QuestConst.MaxQuestLogSize];
+    private static readonly VisibleItem?[] _emptyVisibleItem19 = new VisibleItem?[19];
+    private static readonly ChrCustomizationChoice[] _emptyCustomizations36 = new ChrCustomizationChoice[36];
+
     public WowGuid128? DuelArbiter;
     public WowGuid128? WowAccount;
     public WowGuid128? LootTargetGUID;
@@ -35,8 +43,12 @@ public class PlayerData
     public byte? PvPRank;
     public uint? DuelTeam;
     public int? GuildTimeStamp;
-    public QuestLog[] QuestLog = new QuestLog[QuestConst.MaxQuestLogSize];
-    public VisibleItem?[] VisibleItems = new VisibleItem?[19];
+    private QuestLog[]? _questLog;
+    public ReadOnlySpan<QuestLog> QuestLog => _questLog ?? _emptyQuestLog;
+    public QuestLog[] EnsureQuestLog() => _questLog ??= new QuestLog[QuestConst.MaxQuestLogSize];
+    private VisibleItem?[]? _visibleItems;
+    public ReadOnlySpan<VisibleItem?> VisibleItems => _visibleItems ?? _emptyVisibleItem19;
+    public VisibleItem?[] EnsureVisibleItems() => _visibleItems ??= new VisibleItem?[19];
     public int? ChosenTitle;
     public int? FakeInebriation;
     public uint? VirtualPlayerRealm;
@@ -45,7 +57,9 @@ public class PlayerData
     public float?[] AvgItemLevel { get; } = new float?[6];
     public uint? CurrentBattlePetBreedQuality;
     public int? HonorLevel;
-    public ChrCustomizationChoice[] Customizations = new ChrCustomizationChoice[36];
+    private ChrCustomizationChoice[]? _customizations;
+    public ReadOnlySpan<ChrCustomizationChoice> Customizations => _customizations ?? _emptyCustomizations36;
+    public ChrCustomizationChoice[] EnsureCustomizations() => _customizations ??= new ChrCustomizationChoice[36];
 
     // Set when a legacy appearance change (barber shop) rewrote Customizations, so the
     // Values path emits the dynamic field. Create always writes them, Values only on change.

--- a/HermesProxy/World/Objects/UnitData.cs
+++ b/HermesProxy/World/Objects/UnitData.cs
@@ -1,4 +1,6 @@
-﻿namespace HermesProxy.World.Objects;
+﻿using System;
+
+namespace HermesProxy.World.Objects;
 
 public struct UnitChannel
 {
@@ -28,6 +30,16 @@ public struct VisibleItem
 
 public class UnitData
 {
+    // An array nothing has written yet reads as one of these shared, all-null stand-ins. They are
+    // only ever exposed as ReadOnlySpan, so nothing can write through them, and a creature's
+    // Values delta no longer allocates fourteen arrays it never touches (~900 B per object).
+    // Writers go through the Ensure* accessors, which materialise the real array on first use.
+    private static readonly int?[] _emptyInt7 = new int?[7];
+    private static readonly int?[] _emptyInt5 = new int?[5];
+    private static readonly float?[] _emptyFloat7 = new float?[7];
+    private static readonly uint?[] _emptyUInt2 = new uint?[2];
+    private static readonly VisibleItem?[] _emptyVisibleItem3 = new VisibleItem?[3];
+
     public WowGuid128? Charm;
     public WowGuid128? Summon;
     public WowGuid128? Critter;
@@ -48,10 +60,16 @@ public class UnitData
     public uint? DisplayPower;
     public uint? OverrideDisplayPowerID;
     public long? Health;
-    public int?[] Power = new int?[7];
+    private int?[]? _power;
+    public ReadOnlySpan<int?> Power => _power ?? _emptyInt7;
+    public int?[] EnsurePower() => _power ??= new int?[7];
     public long? MaxHealth;
-    public int?[] MaxPower = new int?[7];
-    public float?[] ModPowerRegen = new float?[7];
+    private int?[]? _maxPower;
+    public ReadOnlySpan<int?> MaxPower => _maxPower ?? _emptyInt7;
+    public int?[] EnsureMaxPower() => _maxPower ??= new int?[7];
+    private float?[]? _modPowerRegen;
+    public ReadOnlySpan<float?> ModPowerRegen => _modPowerRegen ?? _emptyFloat7;
+    public float?[] EnsureModPowerRegen() => _modPowerRegen ??= new float?[7];
     public int? Level;
     public int? EffectiveLevel;
     public int? ContentTuningID;
@@ -62,12 +80,16 @@ public class UnitData
     public int? ScalingHealthItemLevelCurveID;
     public int? ScalingDamageItemLevelCurveID;
     public int? FactionTemplate;
-    public VisibleItem?[] VirtualItems = new VisibleItem?[3];
+    private VisibleItem?[]? _virtualItems;
+    public ReadOnlySpan<VisibleItem?> VirtualItems => _virtualItems ?? _emptyVisibleItem3;
+    public VisibleItem?[] EnsureVirtualItems() => _virtualItems ??= new VisibleItem?[3];
     public uint? Flags;
     public uint? Flags2;
     public uint? Flags3;
     public uint? AuraState;
-    public uint?[] AttackRoundBaseTime = new uint?[2];
+    private uint?[]? _attackRoundBaseTime;
+    public ReadOnlySpan<uint?> AttackRoundBaseTime => _attackRoundBaseTime ?? _emptyUInt2;
+    public uint?[] EnsureAttackRoundBaseTime() => _attackRoundBaseTime ??= new uint?[2];
     public uint? RangedAttackRoundBaseTime;
     public float? BoundingRadius;
     public float? CombatReach;
@@ -95,16 +117,30 @@ public class UnitData
     public float? ModHasteRegen;
     public float? ModTimeRate;
     public int? CreatedBySpell;
-    public uint?[] NpcFlags = new uint?[2];
+    private uint?[]? _npcFlags;
+    public ReadOnlySpan<uint?> NpcFlags => _npcFlags ?? _emptyUInt2;
+    public uint?[] EnsureNpcFlags() => _npcFlags ??= new uint?[2];
     public int? EmoteState;
     public ushort? TrainingPointsUsed;
     public ushort? TrainingPointsTotal;
-    public int?[] Stats = new int?[5];
-    public int?[] StatPosBuff = new int?[5];
-    public int?[] StatNegBuff = new int?[5];
-    public int?[] Resistances { get; } = new int?[7];
-    public int?[] ResistanceBuffModsPositive { get; } = new int?[7];
-    public int?[] ResistanceBuffModsNegative { get; } = new int?[7];
+    private int?[]? _stats;
+    public ReadOnlySpan<int?> Stats => _stats ?? _emptyInt5;
+    public int?[] EnsureStats() => _stats ??= new int?[5];
+    private int?[]? _statPosBuff;
+    public ReadOnlySpan<int?> StatPosBuff => _statPosBuff ?? _emptyInt5;
+    public int?[] EnsureStatPosBuff() => _statPosBuff ??= new int?[5];
+    private int?[]? _statNegBuff;
+    public ReadOnlySpan<int?> StatNegBuff => _statNegBuff ?? _emptyInt5;
+    public int?[] EnsureStatNegBuff() => _statNegBuff ??= new int?[5];
+    private int?[]? _resistances;
+    public ReadOnlySpan<int?> Resistances => _resistances ?? _emptyInt7;
+    public int?[] EnsureResistances() => _resistances ??= new int?[7];
+    private int?[]? _resistanceBuffModsPositive;
+    public ReadOnlySpan<int?> ResistanceBuffModsPositive => _resistanceBuffModsPositive ?? _emptyInt7;
+    public int?[] EnsureResistanceBuffModsPositive() => _resistanceBuffModsPositive ??= new int?[7];
+    private int?[]? _resistanceBuffModsNegative;
+    public ReadOnlySpan<int?> ResistanceBuffModsNegative => _resistanceBuffModsNegative ?? _emptyInt7;
+    public int?[] EnsureResistanceBuffModsNegative() => _resistanceBuffModsNegative ??= new int?[7];
     public int? BaseMana;
     public int? BaseHealth;
     public byte? SheatheState;
@@ -123,8 +159,12 @@ public class UnitData
     public float? Lifesteal;
     public float? MinRangedDamage;
     public float? MaxRangedDamage;
-    public int?[] PowerCostModifier = new int?[7];
-    public float?[] PowerCostMultiplier = new float?[7];
+    private int?[]? _powerCostModifier;
+    public ReadOnlySpan<int?> PowerCostModifier => _powerCostModifier ?? _emptyInt7;
+    public int?[] EnsurePowerCostModifier() => _powerCostModifier ??= new int?[7];
+    private float?[]? _powerCostMultiplier;
+    public ReadOnlySpan<float?> PowerCostMultiplier => _powerCostMultiplier ?? _emptyFloat7;
+    public float?[] EnsurePowerCostMultiplier() => _powerCostMultiplier ??= new float?[7];
     public float? MaxHealthModifier;
     public float? HoverHeight;
     public int? MinItemLevelCutoff;

--- a/HermesProxy/World/Objects/Version/V1_14_0_40237/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V1_14_0_40237/ObjectUpdateBuilder.cs
@@ -752,7 +752,7 @@ public class ObjectUpdateBuilder
             }
         }
 
-        ContainerData containerData = m_updateData.ContainerData;
+        ContainerData? containerData = m_updateData.ContainerData;
         if (containerData != null)
         {
             for (int i = 0; i < 36; i++)

--- a/HermesProxy/World/Objects/Version/V1_14_1_40688/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V1_14_1_40688/ObjectUpdateBuilder.cs
@@ -752,7 +752,7 @@ public class ObjectUpdateBuilder
             }
         }
 
-        ContainerData containerData = m_updateData.ContainerData;
+        ContainerData? containerData = m_updateData.ContainerData;
         if (containerData != null)
         {
             for (int i = 0; i < 36; i++)

--- a/HermesProxy/World/Objects/Version/V2_5_2_39570/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V2_5_2_39570/ObjectUpdateBuilder.cs
@@ -752,7 +752,7 @@ public class ObjectUpdateBuilder
             }
         }
 
-        ContainerData containerData = m_updateData.ContainerData;
+        ContainerData? containerData = m_updateData.ContainerData;
         if (containerData != null)
         {
             for (int i = 0; i < 36; i++)

--- a/HermesProxy/World/Objects/Version/V2_5_3_41750/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V2_5_3_41750/ObjectUpdateBuilder.cs
@@ -752,7 +752,7 @@ public class ObjectUpdateBuilder
             }
         }
 
-        ContainerData containerData = m_updateData.ContainerData;
+        ContainerData? containerData = m_updateData.ContainerData;
         if (containerData != null)
         {
             for (int i = 0; i < 36; i++)

--- a/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
+++ b/HermesProxy/World/Objects/Version/V3_4_3_54261/ObjectUpdateBuilder.cs
@@ -598,7 +598,7 @@ public partial class ObjectUpdateBuilder
             // Players don't populate VirtualItems server-side (use PLAYER_VISIBLE_ITEM
             // descriptors instead). For the local player, fall back to PlayerData.VisibleItems:
             // slot 0=mainhand(15), 1=offhand(16), 2=ranged(17).
-            if (vItemId == 0 && IsOwner && _updateData.PlayerData?.VisibleItems != null)
+            if (vItemId == 0 && IsOwner && _updateData.PlayerData != null)
             {
                 int playerSlot = 15 + l;
                 if (playerSlot < _updateData.PlayerData.VisibleItems.Length
@@ -622,7 +622,7 @@ public partial class ObjectUpdateBuilder
     {
         // IF IsOwner: bow-default fallback. Generator wraps in if (IsOwner) already.
         uint rangedTime = src.RangedAttackRoundBaseTime.GetValueOrDefault();
-        if (rangedTime == 0 && _updateData.PlayerData?.VisibleItems != null
+        if (rangedTime == 0 && _updateData.PlayerData != null
             && _updateData.PlayerData.VisibleItems.Length > 17
             && _updateData.PlayerData.VisibleItems[17] is VisibleItem ranged && ranged.ItemID != 0)
         {
@@ -636,9 +636,9 @@ public partial class ObjectUpdateBuilder
         // IF IsOwner: 5 slots × (Stats[n], StatPosBuff[n], StatNegBuff[n]).
         for (int n = 0; n < 5; n++)
         {
-            data.WriteInt32(src.Stats?[n].GetValueOrDefault() ?? 0);
-            data.WriteInt32(src.StatPosBuff?[n].GetValueOrDefault() ?? 0);
-            data.WriteInt32(src.StatNegBuff?[n].GetValueOrDefault() ?? 0);
+            data.WriteInt32(src.Stats[n].GetValueOrDefault());
+            data.WriteInt32(src.StatPosBuff[n].GetValueOrDefault());
+            data.WriteInt32(src.StatNegBuff[n].GetValueOrDefault());
         }
     }
 
@@ -646,7 +646,7 @@ public partial class ObjectUpdateBuilder
     {
         // IF IsOwner: 7× Resistances Int32.
         for (int r = 0; r < 7; r++)
-            data.WriteInt32(src.Resistances?[r].GetValueOrDefault() ?? 0);
+            data.WriteInt32(src.Resistances[r].GetValueOrDefault());
     }
 
     internal void WriteCreateUnitPowerCostInterleaved(WorldPacket data, UnitData src)
@@ -654,8 +654,8 @@ public partial class ObjectUpdateBuilder
         // IF IsOwner: 7 slots × (PowerCostModifier[p] Int32, PowerCostMultiplier[p] Float).
         for (int p = 0; p < 7; p++)
         {
-            data.WriteInt32(src.PowerCostModifier?[p].GetValueOrDefault() ?? 0);
-            data.WriteFloat(src.PowerCostMultiplier?[p].GetValueOrDefault() ?? 0f);
+            data.WriteInt32(src.PowerCostModifier[p].GetValueOrDefault());
+            data.WriteFloat(src.PowerCostMultiplier[p].GetValueOrDefault());
         }
     }
 
@@ -664,8 +664,8 @@ public partial class ObjectUpdateBuilder
         // 7 slots × (ResistanceBuffModsPositive[b] Int32, ResistanceBuffModsNegative[b] Int32).
         for (int b = 0; b < 7; b++)
         {
-            data.WriteInt32(src.ResistanceBuffModsPositive?[b].GetValueOrDefault() ?? 0);
-            data.WriteInt32(src.ResistanceBuffModsNegative?[b].GetValueOrDefault() ?? 0);
+            data.WriteInt32(src.ResistanceBuffModsPositive[b].GetValueOrDefault());
+            data.WriteInt32(src.ResistanceBuffModsNegative[b].GetValueOrDefault());
         }
     }
 
@@ -719,7 +719,7 @@ public partial class ObjectUpdateBuilder
         data.WritePackedGuid128(src.ChannelObject.Value);
     }
 
-    internal void WriteUpdateUnitVirtualItem(WorldPacket data, System.Nullable<VisibleItem>[] arr, int i)
+    internal void WriteUpdateUnitVirtualItem(WorldPacket data, ReadOnlySpan<VisibleItem?> arr, int i)
     {
         // VirtualItem inner mask: 4-bit (bit 0 = group, 1 = ItemID present). Hand-port
         // (file:2308-2316 pre-delete) emits mask 0x03 then Int32 ItemID.
@@ -974,7 +974,7 @@ public partial class ObjectUpdateBuilder
             : WowGuid128.Empty);
     }
 
-    internal void WriteUpdatePlayerQuestLogEntry(WorldPacket data, QuestLog[] arr, int i)
+    internal void WriteUpdatePlayerQuestLogEntry(WorldPacket data, ReadOnlySpan<QuestLog> arr, int i)
     {
         // Per-element write at bit 36+i. Same shape as hand-port file:1576-1583 — uses
         // WriteCreate format (no inner mask, raw fields) per IsQuestLogChangesMaskSkipped = 1.
@@ -986,7 +986,7 @@ public partial class ObjectUpdateBuilder
             data.WriteUInt16((ushort)(quest?.ObjectiveProgress[obj] ?? 0));
     }
 
-    internal void WriteUpdatePlayerVisibleItem(WorldPacket data, System.Nullable<VisibleItem>[] arr, int i)
+    internal void WriteUpdatePlayerVisibleItem(WorldPacket data, ReadOnlySpan<VisibleItem?> arr, int i)
     {
         // Per-element write at bit 62+i. Inner 4-bit mask (0x0F = all 4 bits set) +
         // FlushBits + Int32 ItemID + UInt16 ItemAppearanceModID + UInt16 ItemVisual.

--- a/HermesProxy/World/Server/Packets/HotfixPackets.cs
+++ b/HermesProxy/World/Server/Packets/HotfixPackets.cs
@@ -79,8 +79,9 @@ class AvailableHotfixes : ServerPacket
         // a ~5 MB packet the client never even logs ("ClientAvailableHotfixes" line missing),
         // suggesting a parse-abort. A single pass over the (large) store — the previous code
         // walked all of GameData.Hotfixes twice, once to count and once to write.
+        // Enumerated directly: .Values would first copy the whole store under every lock.
         var advertised = new System.Collections.Generic.List<HotfixRecord>();
-        foreach (var hotfix in GameData.Hotfixes.Values)
+        foreach (var (_, hotfix) in GameData.Hotfixes)
         {
             if (TableFilter != null && !TableFilter.Contains(hotfix.TableHash))
                 continue;

--- a/HermesProxy/World/Server/Packets/UpdatePackets.cs
+++ b/HermesProxy/World/Server/Packets/UpdatePackets.cs
@@ -64,7 +64,10 @@ public class ObjectUpdate
             case ObjectType.Item:
             case ObjectType.Container:
                 ItemData = new ItemData();
-                ContainerData = new ContainerData();
+                // ContainerData is not allocated here. A legacy bag and a plain item share a guid
+                // type, so only the parse can tell them apart (from the mask size, or the create's
+                // object type); EnsureContainerData() materialises it on the first container field
+                // written, and every reader already treats null as "no container fields".
                 break;
             case ObjectType.Unit:
                 UnitData = new UnitData();
@@ -99,13 +102,20 @@ public class ObjectUpdate
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ActivePlayerData EnsureActivePlayerData() => ActivePlayerData ??= new ActivePlayerData();
 
+    /// <summary>
+    /// Materialises <see cref="ContainerData"/> on demand. Its 36 slots used to be allocated for
+    /// every item update, bag or not. Call it from write sites; read sites keep using the field.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ContainerData EnsureContainerData() => ContainerData ??= new ContainerData();
+
     public UpdateTypeModern Type;
     public WowGuid128 Guid;
     public GlobalSessionData GlobalSession;
     public CreateObjectData CreateData = null!;
     public ObjectData ObjectData;
     public ItemData ItemData = null!;
-    public ContainerData ContainerData = null!;
+    public ContainerData? ContainerData;
     public UnitData UnitData = null!;
     public PlayerData PlayerData = null!;
     public ActivePlayerData? ActivePlayerData;
@@ -488,7 +498,7 @@ public class ObjectUpdate
             for (int i = 0; i < 6; i++)
             {
                 if (UnitData.ModPowerRegen[i] == null)
-                    UnitData.ModPowerRegen[i] = 1;
+                    UnitData.EnsureModPowerRegen()[i] = 1;
             }
             if (UnitData.Flags2 == null)
                 UnitData.Flags2 = 2048;


### PR DESCRIPTION
Follow-up to #271. That PR fixed the object-update *builder*; this one goes after the rest of the receive path, where most of the proxy's allocation actually happens: parsing legacy update blocks, the per-object data classes, and the item hotfix lookups that run at login.

Everything below was measured, either with BenchmarkDotNet or with `--metrics` on an AzerothCore playerbots battleground (same character, same routine), against master at e02aa25d.

## Results

**Per-object construction** (BenchmarkDotNet, allocated bytes):

| object | before | after | |
|---|---|---|---|
| player | 3408 B | 1640 B | −52% |
| creature | 2288 B | 1312 B | −43% |
| item | 1560 B | 640 B | −59% |
| 100 mixed objects | 162.97 KB | 91.41 KB | −44% |

**Battleground** (marginal allocation per packet, busy minutes only):

| opcode | before | after | |
|---|---|---|---|
| `SMSG_COMPRESSED_UPDATE_OBJECT` | 26.26 KB | 18.85 KB | −25%¹ |
| `SMSG_UPDATE_OBJECT` | 7.69 KB | 6.54 KB | −15% |

¹ Compared against the baseline's first eight busy minutes. Later minutes of a match cost more, and the runs differed in length, so the raw −28% flatters it slightly.

**Login** (the same 18 item queries in both runs):

| | before | after | |
|---|---|---|---|
| `SMSG_ITEM_QUERY_SINGLE_RESPONSE`, total | 7154 KB | 263 KB | −96% |
| per query / worst query | 407 KB / 1.87 MB | 14.9 KB / 211 KB | |
| whole login minute | 160.9 MB | 152.6 MB | −8.3 MB |

## What changed

**Parsing legacy update blocks.** Every changed field of every object built two strings that were then discarded: one never read at all, one overwritten a few lines later. The update mask was copied once into a `BitArray`, which then reallocated itself when widened to the object's field range; it is now built once at its final size. Each field group allocated its own `List`, and those now share a pooled buffer.

**Per-object data.** Every item carried a 36-slot container block, and every creature and player carried arrays for resistances, stats, power costs, gear and so on, all allocated up front. A typical battleground update touches two or three fields. These arrays now read as a shared empty stand-in until something writes them. The design is chosen so the compiler does the safety work: readers, including the V1_14/V2_5 builders, compile unchanged, and every write that bypassed the new accessors became a compile error. All 61 were found that way rather than by search.

**Item hotfixes.** Looking up a hotfix record read `ConcurrentDictionary.Values`, which locks the whole store and copies it into a new list first. With ~61k hotfix records that is ~490 KB per lookup, measured at 488,997 B against 152 B now, and the item path looked records up twice per hotfix. It now walks the dictionary directly, in the same order.

**Combo points.** Setting the combo target built a full ~30 KB `ActivePlayerData` even though the V3_4_3 client reads the target from `UnitData`. That copy is now only written for the V1_14/V2_5 builders that use it.

## Verification

- Build clean, 1096/1096 tests, including the byte-equivalence checks between the generated and hand-written V3_4_3 writers, and a new `UpdateMaskTests` that pins the new mask construction to the old one over 2000 random masks.
- Release IL confirms the debug-only `PrintValue` calls are fully compiled out.
- Three battleground sessions on these changes: zero `OBJECT_UPDATE_FAILED`, zero exceptions, clean exits.

## Not covered

- **V1_14 / V2_5 were not played.** Their builders only read the changed data and compile unchanged; the V3_4_3 path is what was exercised.
- **The combo-point change was not exercised in-game.** The test character was a warrior. The reasoning that V3_4_3 output is unchanged: neither the V3_4_3 Values filter nor its ActivePlayer section ever read that `ActivePlayerData` copy.
- **Left as they were, on purpose:** `ModPowerRegen` and `AvgItemLevel` are still allocated on every update, because `InitializePlaceholders` writes defaults into them each time. Changing that would change what an update sends, which is a behaviour question.
- **Still open:** a recurring ~284 KB allocation lands on random small packets (`FORCE_RUN_SPEED_CHANGE`, `SET_PROFICIENCY`). It looks like a pooled-buffer miss, and pinning it down needs an allocation trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwHXGKmdGbXbAP4v5C8NTi
