### PR TITLE
fix: name three unmapped V3_4_3 client opcodes; silence oracle CA2265

### DIFF
--- a/HermesProxy.Tests/SourceGen/PlayerSectionEquivalenceTests.cs
+++ b/HermesProxy.Tests/SourceGen/PlayerSectionEquivalenceTests.cs
@@ -215,6 +215,9 @@ public class PlayerSectionEquivalenceTests
         Assert.Equal(HasAnyPlayerFieldSet_HandPort(update.PlayerData!), builder.HasAnyPlayerFieldSet());
     }
 
+    // CA2265: the oracle below still null-checks fields that are now spans. It is frozen
+    // (HermesProxy.SourceGen/CLAUDE.md), so the warning is silenced rather than fixed.
+#pragma warning disable CA2265
     // ---------------------------------------------------------------------
     // Inlined pre-Phase-5b hand-port — frozen oracle. Identical to bodies
     // removed from V3_4_3_54261/ObjectUpdateBuilder.cs (lines 749-856 Create /
@@ -426,4 +429,5 @@ public class PlayerSectionEquivalenceTests
                 if (p.VisibleItems[i] != null) return true;
         return false;
     }
+#pragma warning restore CA2265
 }

--- a/HermesProxy.Tests/SourceGen/UnitSectionEquivalenceTests.cs
+++ b/HermesProxy.Tests/SourceGen/UnitSectionEquivalenceTests.cs
@@ -173,6 +173,9 @@ public class UnitSectionEquivalenceTests
         Assert.Equal(expected.GetData(), actual.GetData());
     }
 
+    // CA2265: the oracle below still null-checks fields that are now spans. It is frozen
+    // (HermesProxy.SourceGen/CLAUDE.md), so the warning is silenced rather than fixed.
+#pragma warning disable CA2265
     // ---------------------------------------------------------------------
     // Inlined pre-Phase-5b WriteCreateUnitData hand-port — frozen byte oracle.
     // Reproduces V3_4_3_54261/ObjectUpdateBuilder.cs (lines 527-747 pre-delete).
@@ -377,6 +380,7 @@ public class UnitSectionEquivalenceTests
         if (hasChannelObject)
             data.WritePackedGuid128(unit.ChannelObject!.Value);
     }
+#pragma warning restore CA2265
 
     // =====================================================================
     // Update path tests — exercise bug-history regression vectors.

--- a/HermesProxy/World/Enums/V3_4_3_54261/Opcode.cs
+++ b/HermesProxy/World/Enums/V3_4_3_54261/Opcode.cs
@@ -992,6 +992,12 @@ public enum Opcode : uint
 	CMSG_REPORT_ENABLED_ADDONS = 14086u,
 	CMSG_REPORT_KEYBINDING_EXECUTION_COUNTS = 14088u,
 	CMSG_DISCARDED_TIME_SYNC_ACKS = 14913u,
+	// Sent by the client but had no entry here, so they logged as MSG_NULL_ACTION.
+	// Values from WowPacketParser's V3_4_3_51666 table, which it also uses for 54261.
+	// Still unhandled: naming them only fixes the log.
+	CMSG_GET_ITEM_PURCHASE_DATA = 13615u,
+	CMSG_REQUEST_PARTY_JOIN_UPDATES = 13816u,
+	CMSG_SUSPEND_TOKEN_RESPONSE = 14186u,
 	SMSG_ENABLE_BARBER_SHOP = 9916u, // 0x26BC
 	SMSG_BARBER_SHOP_RESULT = 9918u // 0x26BE
 }


### PR DESCRIPTION
## Summary

Names the last three client opcodes that were still logging as `MSG_NULL_ACTION`, and silences the final build warnings. The solution now builds with **0 warnings**.

## Three unmapped V3_4_3 client opcodes

| Wire | Name | What the client is asking |
|---|---|---|
| 13615 (0x352F) | `CMSG_GET_ITEM_PURCHASE_DATA` | refund info for an item (the sell-back tooltip) |
| 13816 (0x35F8) | `CMSG_REQUEST_PARTY_JOIN_UPDATES` | party / raid join updates |
| 14186 (0x376A) | `CMSG_SUSPEND_TOKEN_RESPONSE` | reply to `SMSG_SUSPEND_TOKEN`, which the proxy sends around teleports |

Values come from WowPacketParser's `V3_4_3_51666` table, which WPP also uses for build 54261. Six opcodes the proxy already maps (`CMSG_PLAYER_LOGIN`, `CMSG_SOCIAL_CONTRACT_REQUEST`, `CMSG_LOADING_SCREEN_NOTIFY`, `CMSG_REQUEST_PVP_REWARDS`, `CMSG_DB_QUERY_BULK`, `SMSG_UPDATE_OBJECT`) match that table exactly.

All three names already exist in the universal enum, so this is three lines in the V3_4_3 `Opcode.cs`. None has a handler, and an unhandled client packet is logged and dropped — never forwarded — so the only change is that the log names them. The item shop / purchase-data side isn't implemented in the proxy; handling `CMSG_GET_ITEM_PURCHASE_DATA` would be part of that separate work.

## Last CA2265 warnings

The remaining five sit in the frozen hand-port oracles in `PlayerSectionEquivalenceTests` and `UnitSectionEquivalenceTests`, which still null-check fields that are now spans. `HermesProxy.SourceGen/CLAUDE.md` says not to edit those copies, so they are wrapped in `#pragma warning disable/restore CA2265` with a note saying why. The oracle code itself is untouched.

## Testing

- `dotnet build -c Release --no-incremental`: 0 warnings, 0 errors
- `dotnet test`: 1096 / 1096 passed
- Auto-login session, V3_4_3 client → AzerothCore playerbots: `CMSG_GET_ITEM_PURCHASE_DATA` (13615) now logs by name, no `MSG_NULL_ACTION` left; 0 exceptions, 0 `OBJECT_UPDATE_FAILED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwHXGKmdGbXbAP4v5C8NTi
