### PR TITLE
Serialize SSLSocket writes; pooled BNet RPC frames

### DIFF
--- a/Framework/Networking/SSLSocket.cs
+++ b/Framework/Networking/SSLSocket.cs
@@ -17,6 +17,7 @@
 
 using Framework.Logging;
 using System;
+using System.Buffers;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -37,6 +38,11 @@ public abstract class SSLSocket : ISocket, IDisposable
     internal SslStream _stream;
     IPEndPoint? _remoteEndPoint;
     byte[]? _receiveBuffer;
+
+    // SslStream throws NotSupportedException for a WriteAsync that starts while another is pending,
+    // and callers send without awaiting, so writes queue here. SemaphoreSlim releases async waiters
+    // in arrival order, which keeps frames in the order they were sent.
+    readonly SemaphoreSlim _writeLock = new(1, 1);
 
     protected SSLSocket(Socket socket)
     {
@@ -136,18 +142,49 @@ public abstract class SSLSocket : ISocket, IDisposable
 
     public abstract Task ReadHandler(byte[] data, int receivedLength);
 
-    public async Task AsyncWrite(byte[] data)
-    {
-        if (!IsOpen())
-            return;
+    public Task AsyncWrite(byte[] data) => AsyncWrite(data, data.Length, returnToPool: false);
 
+    /// <summary>
+    /// Writes the first <paramref name="length"/> bytes of <paramref name="buffer"/> once any write
+    /// already in flight has finished. With <paramref name="returnToPool"/> this call owns the
+    /// buffer and hands it back to <see cref="ArrayPool{T}.Shared"/> after the write completes or fails.
+    /// </summary>
+    public async Task AsyncWrite(byte[] buffer, int length, bool returnToPool)
+    {
+        await _writeLock.WaitAsync();
         try
         {
-            await _stream.WriteAsync(data, 0, data.Length);
+            if (IsOpen())
+                await _stream.WriteAsync(buffer.AsMemory(0, length));
         }
         catch (Exception ex)
         {
             Log.outException(ex);
+        }
+        finally
+        {
+            _writeLock.Release();
+            if (returnToPool)
+                ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Closes once the writes queued before this call are on the wire, so a final notification is
+    /// not cut off. Closes anyway after <paramref name="timeout"/>: a peer that stopped reading must
+    /// not be able to hold the connection open.
+    /// </summary>
+    public async Task CloseSocketAfterWrites(TimeSpan timeout)
+    {
+        bool acquired = await _writeLock.WaitAsync(timeout);
+        try
+        {
+            CloseSocket();
+        }
+        finally
+        {
+            if (acquired)
+                _writeLock.Release();
         }
     }
 

--- a/HermesProxy.Benchmarks/BnetRpcCodecBenchmarks.cs
+++ b/HermesProxy.Benchmarks/BnetRpcCodecBenchmarks.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using Bgs.Protocol;
 using Bgs.Protocol.Authentication.V1;
 using Bgs.Protocol.GameUtilities.V1;
@@ -100,8 +101,16 @@ public class BnetRpcCodecBenchmarks
     }
 
     [Benchmark]
-    public byte[] FrameRealmListResponse() => BnetTcpSession.BuildRpcFrame(NewHeader(), _realmListResponse);
+    public int FrameRealmListResponse() => FrameAndReturn(_realmListResponse);
 
     [Benchmark]
-    public byte[] FrameLogonResult() => BnetTcpSession.BuildRpcFrame(NewHeader(), _logonResult);
+    public int FrameLogonResult() => FrameAndReturn(_logonResult);
+
+    // Rent then return, as SendRpcMessage does once SSLSocket.AsyncWrite has sent the frame.
+    private static int FrameAndReturn(IMessage message)
+    {
+        var frame = BnetTcpSession.RentRpcFrame(NewHeader(), message, out int length);
+        ArrayPool<byte>.Shared.Return(frame);
+        return length;
+    }
 }

--- a/HermesProxy.Benchmarks/CLAUDE.md
+++ b/HermesProxy.Benchmarks/CLAUDE.md
@@ -28,7 +28,7 @@ dotnet run --project HermesProxy.Benchmarks -c Release -- --list flat
 | `ByteBufferBenchmarks.cs` | `ByteBuffer` read/write performance |
 | `SpanPacketBenchmarks.cs` | `SpanPacketReader`/`SpanPacketWriter` vs `ByteBuffer` |
 | `BnetPacketParserBenchmarks.cs` | BNet packet parsing performance |
-| `BnetRpcCodecBenchmarks.cs` | BNet RPC request parse (span `MergeFrom`) and response framing (`BuildRpcFrame`) on login-shaped messages |
+| `BnetRpcCodecBenchmarks.cs` | BNet RPC request parse (span `MergeFrom`) and response framing (`RentRpcFrame`) on login-shaped messages |
 | `ExtensionsBenchmarks.cs` | Extension method performance |
 | `PacketDispatchBenchmarks.cs` | Inbound dispatch on real `ClientPacket`s: Activator path vs direct vs `SpanPacketReader` floor |
 | `SendPipelineBenchmarks.cs` | `ServerPacket` construct → `WritePacketData` → framed + encrypted wire bytes, per stage |

--- a/HermesProxy.Tests/BnetServer/BnetRpcFrameTests.cs
+++ b/HermesProxy.Tests/BnetServer/BnetRpcFrameTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Linq;
 using Bgs.Protocol;
@@ -33,7 +34,7 @@ public class BnetRpcFrameTests
     }
 
     [Fact]
-    public void BuildRpcFrame_WithMessage_MatchesLengthPrefixedHeaderThenPayload()
+    public void RentRpcFrame_WithMessage_MatchesLengthPrefixedHeaderThenPayload()
     {
         var message = NewLogonResult();
         var expectedHeader = NewHeader();
@@ -41,26 +42,32 @@ public class BnetRpcFrameTests
         var headerBytes = expectedHeader.ToByteArray();
         var payloadBytes = message.ToByteArray();
 
-        var frame = BnetTcpSession.BuildRpcFrame(NewHeader(), message);
-
-        Assert.Equal(2 + headerBytes.Length + payloadBytes.Length, frame.Length);
-        Assert.Equal(headerBytes.Length, BinaryPrimitives.ReadUInt16BigEndian(frame));
-        Assert.Equal(headerBytes, frame.AsSpan(2, headerBytes.Length).ToArray());
-        Assert.Equal(payloadBytes, frame.AsSpan(2 + headerBytes.Length).ToArray());
+        var frame = BnetTcpSession.RentRpcFrame(NewHeader(), message, out int length);
+        try
+        {
+            Assert.Equal(2 + headerBytes.Length + payloadBytes.Length, length);
+            Assert.Equal(headerBytes.Length, BinaryPrimitives.ReadUInt16BigEndian(frame));
+            Assert.Equal(headerBytes, frame.AsSpan(2, headerBytes.Length).ToArray());
+            Assert.Equal(payloadBytes, frame.AsSpan(2 + headerBytes.Length, payloadBytes.Length).ToArray());
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(frame);
+        }
     }
 
     [Fact]
-    public void BuildRpcFrame_WithMessage_RoundTripsThroughParseFromSpan()
+    public void RentRpcFrame_WithMessage_RoundTripsThroughParseFromSpan()
     {
         var message = NewLogonResult();
 
-        var frame = BnetTcpSession.BuildRpcFrame(NewHeader(), message);
-        var result = BnetPacketParser.ParseFromSpan(frame);
+        var frame = BnetTcpSession.RentRpcFrame(NewHeader(), message, out int length);
+        var result = BnetPacketParser.ParseFromSpan(frame.AsSpan(0, length));
 
         try
         {
             Assert.True(result.Success);
-            Assert.Equal(frame.Length, result.TotalLength);
+            Assert.Equal(length, result.TotalLength);
             Assert.Equal(42u, result.Header!.Token);
             Assert.Equal(0x71240E35u, result.Header.ServiceHash);
             Assert.Equal(5u, result.Header.MethodId);
@@ -69,21 +76,29 @@ public class BnetRpcFrameTests
         finally
         {
             result.ReturnPayload();
+            ArrayPool<byte>.Shared.Return(frame);
         }
     }
 
     [Fact]
-    public void BuildRpcFrame_WithoutMessage_LeavesSizeUnsetAndCarriesNoPayload()
+    public void RentRpcFrame_WithoutMessage_LeavesSizeUnsetAndCarriesNoPayload()
     {
         var header = NewHeader();
 
-        var frame = BnetTcpSession.BuildRpcFrame(header, null);
-        var result = BnetPacketParser.ParseFromSpan(frame);
+        var frame = BnetTcpSession.RentRpcFrame(header, null, out int length);
+        try
+        {
+            var result = BnetPacketParser.ParseFromSpan(frame.AsSpan(0, length));
 
-        Assert.False(header.HasSize);
-        Assert.Equal(2 + header.CalculateSize(), frame.Length);
-        Assert.True(result.Success);
-        Assert.Equal(0, result.PayloadLength);
-        Assert.Null(result.PayloadArray);
+            Assert.False(header.HasSize);
+            Assert.Equal(2 + header.CalculateSize(), length);
+            Assert.True(result.Success);
+            Assert.Equal(0, result.PayloadLength);
+            Assert.Null(result.PayloadArray);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(frame);
+        }
     }
 }

--- a/HermesProxy.Tests/BnetServer/BnetTcpSessionWriteTests.cs
+++ b/HermesProxy.Tests/BnetServer/BnetTcpSessionWriteTests.cs
@@ -1,0 +1,47 @@
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Bgs.Protocol;
+using Bgs.Protocol.GameUtilities.V1;
+using BNetServer.Networking;
+using Framework.Constants;
+using Google.Protobuf;
+using HermesProxy.Tests.Framework;
+using Xunit;
+
+namespace HermesProxy.Tests.BnetServer;
+
+public class BnetTcpSessionWriteTests
+{
+    [Fact]
+    public async Task SendRpcMessage_BehindAStalledFrame_DeliversBothFramesInOrder()
+    {
+        await TlsLoopback.With(s => new BnetTcpSession(s), tinyBuffers: true, async (session, client) =>
+        {
+            var bulk = new ClientResponse();
+            bulk.Attribute.Add(new Bgs.Protocol.Attribute
+            {
+                Name = "Param_RealmList",
+                Value = new Variant { BlobValue = ByteString.CopyFrom(new byte[4 * 1024 * 1024]) },
+            });
+
+            // Back to back, as HandleLogon does: a listener request, then the RPC response. The
+            // first frame cannot drain, so the second starts while it is still being written.
+            session.SendRpcMessage(0xFE, OriginalHash.GameUtilitiesService, 1, 1, BattlenetRpcErrorCode.Ok, bulk);
+            session.SendRpcMessage(0xFE, OriginalHash.GameUtilitiesService, 1, 2, BattlenetRpcErrorCode.Ok, null);
+
+            var tokens = new List<uint>();
+            for (int i = 0; i < 2; i++)
+            {
+                var prefix = await TlsLoopback.ReadExactly(client, 2);
+                var header = Header.Parser.ParseFrom(
+                    await TlsLoopback.ReadExactly(client, BinaryPrimitives.ReadUInt16BigEndian(prefix)));
+                if (header.Size > 0)
+                    Assert.Equal(bulk, ClientResponse.Parser.ParseFrom(await TlsLoopback.ReadExactly(client, (int)header.Size)));
+                tokens.Add(header.Token);
+            }
+
+            Assert.Equal(new uint[] { 1, 2 }, tokens);
+        });
+    }
+}

--- a/HermesProxy.Tests/Framework/SslSocketWriteTests.cs
+++ b/HermesProxy.Tests/Framework/SslSocketWriteTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Buffers;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Framework.Networking;
+using Xunit;
+
+namespace HermesProxy.Tests.Framework;
+
+internal sealed class TestSslSocket(Socket socket) : SSLSocket(socket)
+{
+    public override void Accept() { }
+
+    public override Task ReadHandler(byte[] data, int receivedLength) => Task.CompletedTask;
+}
+
+/// <summary>
+/// A real TLS connection over loopback. With <c>tinyBuffers</c> both socket buffers are shrunk and
+/// the client does not read until the test asks it to, so a large server write stays pending —
+/// the backpressure a slow or congested client produces.
+/// </summary>
+internal static class TlsLoopback
+{
+    private static readonly Lazy<X509Certificate2> Certificate = new(() =>
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=hermes-test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var ephemeral = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+        // SChannel refuses an ephemeral key for a server credential; a PFX round trip persists it.
+        return X509CertificateLoader.LoadPkcs12(ephemeral.Export(X509ContentType.Pfx), null);
+    });
+
+    public static async Task With<TSocket>(Func<Socket, TSocket> create, bool tinyBuffers,
+        Func<TSocket, SslStream, Task> test) where TSocket : SSLSocket
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        using var tcp = new TcpClient();
+        if (tinyBuffers)
+            tcp.ReceiveBufferSize = 1024;
+        await tcp.ConnectAsync((IPEndPoint)listener.LocalEndpoint, ct);
+        var serverSocket = await listener.AcceptSocketAsync(ct);
+        if (tinyBuffers)
+            serverSocket.SendBufferSize = 1024;
+
+        var server = create(serverSocket);
+        try
+        {
+            using var client = new SslStream(tcp.GetStream(), false, (_, _, _, _) => true);
+            // AsyncHandshake parks in AsyncRead once authenticated, so it is started, not awaited.
+            _ = server.AsyncHandshake(Certificate.Value);
+            await client.AuthenticateAsClientAsync(
+                new SslClientAuthenticationOptions { TargetHost = "hermes-test" }, ct);
+            while (!server._stream.IsAuthenticated)
+                await Task.Delay(10, ct);
+
+            await test(server, client);
+        }
+        finally
+        {
+            server.CloseSocket();
+            server.Dispose();
+        }
+    }
+
+    public static byte[] Pattern(int length, byte seed)
+    {
+        var bytes = new byte[length];
+        for (int i = 0; i < length; i++)
+            bytes[i] = (byte)(i * 31 + seed);
+        return bytes;
+    }
+
+    public static async Task<byte[]> ReadExactly(SslStream client, int length)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(15));
+        var received = new byte[length];
+        await client.ReadExactlyAsync(received, timeout.Token);
+        return received;
+    }
+
+    /// <summary>Waits until the first write is genuinely stuck behind a full peer window.</summary>
+    public static async Task AssertStalled(Task write)
+    {
+        await Task.Delay(200, TestContext.Current.CancellationToken);
+        Assert.False(write.IsCompleted, "precondition: the bulk write should be waiting on the peer");
+    }
+}
+
+public class SslSocketWriteTests
+{
+    private const int BulkSize = 4 * 1024 * 1024;
+
+    [Fact]
+    public async Task AsyncWrite_WhileAnotherWriteIsStalled_QueuesBehindItInOrder()
+    {
+        await TlsLoopback.With(s => new TestSslSocket(s), tinyBuffers: true, async (server, client) =>
+        {
+            var bulk = TlsLoopback.Pattern(BulkSize, seed: 1);
+            var tail = TlsLoopback.Pattern(16, seed: 200);
+
+            var first = server.AsyncWrite(bulk);
+            await TlsLoopback.AssertStalled(first);
+            // SslStream throws NotSupportedException for a WriteAsync that starts while another is
+            // pending; unserialised, this frame was logged and dropped.
+            var second = server.AsyncWrite(tail);
+
+            var received = await TlsLoopback.ReadExactly(client, bulk.Length + tail.Length);
+            await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+
+            Assert.True(received.AsSpan(0, bulk.Length).SequenceEqual(bulk));
+            Assert.True(received.AsSpan(bulk.Length).SequenceEqual(tail));
+        });
+    }
+
+    [Fact]
+    public async Task AsyncWrite_PooledBuffer_SendsOnlyTheRequestedLength()
+    {
+        await TlsLoopback.With(s => new TestSslSocket(s), tinyBuffers: false, async (server, client) =>
+        {
+            var head = TlsLoopback.Pattern(10, seed: 7);
+            var tail = TlsLoopback.Pattern(16, seed: 200);
+            var rented = ArrayPool<byte>.Shared.Rent(64);
+            head.CopyTo(rented, 0);
+            rented.AsSpan(head.Length).Fill(0xEE);
+
+            await server.AsyncWrite(rented, head.Length, returnToPool: true);
+            await server.AsyncWrite(tail);
+
+            var received = await TlsLoopback.ReadExactly(client, head.Length + tail.Length);
+            Assert.True(received.AsSpan(0, head.Length).SequenceEqual(head));
+            Assert.True(received.AsSpan(head.Length).SequenceEqual(tail));
+        });
+    }
+
+    [Fact]
+    public async Task CloseSocketAfterWrites_DeliversQueuedWritesBeforeClosing()
+    {
+        await TlsLoopback.With(s => new TestSslSocket(s), tinyBuffers: true, async (server, client) =>
+        {
+            var bulk = TlsLoopback.Pattern(BulkSize, seed: 1);
+            var tail = TlsLoopback.Pattern(16, seed: 200);
+
+            var first = server.AsyncWrite(bulk);
+            await TlsLoopback.AssertStalled(first);
+            _ = server.AsyncWrite(tail);
+            var close = server.CloseSocketAfterWrites(TimeSpan.FromSeconds(30));
+
+            Assert.True(server.IsOpen());
+            var received = await TlsLoopback.ReadExactly(client, bulk.Length + tail.Length);
+            await close.WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+
+            Assert.False(server.IsOpen());
+            Assert.True(received.AsSpan(bulk.Length).SequenceEqual(tail));
+        });
+    }
+
+    [Fact]
+    public async Task CloseSocketAfterWrites_ClosesAnywayWhenThePeerStopsReading()
+    {
+        await TlsLoopback.With(s => new TestSslSocket(s), tinyBuffers: true, async (server, client) =>
+        {
+            var first = server.AsyncWrite(TlsLoopback.Pattern(BulkSize, seed: 1));
+            await TlsLoopback.AssertStalled(first);
+
+            await server.CloseSocketAfterWrites(TimeSpan.FromMilliseconds(200))
+                .WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+
+            Assert.False(server.IsOpen());
+            // Once the socket is gone the stalled write fails and is swallowed rather than hanging.
+            await first.WaitAsync(TimeSpan.FromSeconds(15), TestContext.Current.CancellationToken);
+        });
+    }
+}

--- a/HermesProxy/BnetServer/Networking/BnetTcpSession.cs
+++ b/HermesProxy/BnetServer/Networking/BnetTcpSession.cs
@@ -441,15 +441,19 @@ public class BnetTcpSession : SSLSocket, BnetServices.INetwork
         header.ServiceHash = (uint)service;
         header.MethodId = methodId;
 
-        AsyncWrite(BuildRpcFrame(header, message));
+        var frame = RentRpcFrame(header, message, out int length);
+        _ = AsyncWrite(frame, length, returnToPool: true);
     }
 
+    // RequestDisconnect sends a DisconnectNotification and then closes; closing on the spot could
+    // cut that frame off mid-write. Error paths call SSLSocket.CloseSocket directly and stay immediate.
+    void BnetServices.INetwork.CloseSocket() => _ = CloseSocketAfterWrites(TimeSpan.FromSeconds(5));
+
     /// <summary>
-    /// Frame layout: big-endian u16 header length, header, payload. Sets <c>header.Size</c>.
+    /// Rents a buffer from <see cref="ArrayPool{T}.Shared"/> and writes the frame into it: big-endian
+    /// u16 header length, header, payload. Sets <c>header.Size</c>. The caller owns the rental.
     /// </summary>
-    // A fresh exact-size array rather than a pooled rental: SSLSocket.AsyncWrite does not await
-    // the stream write, so the buffer would go back to the pool while still being sent.
-    internal static byte[] BuildRpcFrame(Header header, IMessage? message)
+    internal static byte[] RentRpcFrame(Header header, IMessage? message, out int length)
     {
         int payloadSize = 0;
         if (message != null)
@@ -459,10 +463,11 @@ public class BnetTcpSession : SSLSocket, BnetServices.INetwork
         }
 
         int headerSize = header.CalculateSize();
-        var frame = new byte[2 + headerSize + payloadSize];
+        length = 2 + headerSize + payloadSize;
+        var frame = ArrayPool<byte>.Shared.Rent(length);
         BinaryPrimitives.WriteUInt16BigEndian(frame, (ushort)headerSize);
         header.WriteTo(frame.AsSpan(2, headerSize));
-        message?.WriteTo(frame.AsSpan(2 + headerSize));
+        message?.WriteTo(frame.AsSpan(2 + headerSize, payloadSize));
         return frame;
     }
 }

--- a/HermesProxy/BnetServer/Services/BnetServices.cs
+++ b/HermesProxy/BnetServer/Services/BnetServices.cs
@@ -128,6 +128,8 @@ public partial class BnetServices
     public interface INetwork
     {
         public void SendRpcMessage(uint serviceId, OriginalHash service, uint methodId, uint token, BattlenetRpcErrorCode status, IMessage? message);
+
+        /// <summary>Closes the connection once the messages already sent have gone out.</summary>
         public void CloseSocket();
 
         IPEndPoint? GetRemoteIpEndPoint();


### PR DESCRIPTION
## Summary

Follow-up to #275. Outgoing BNet frames could collide on the `SslStream`, and they couldn't come from a pool because nothing awaited the write.

- **Overlapping writes.** `SslStream` rejects a `WriteAsync` that starts while another is pending (`NotSupportedException: This method may not be called when another write operation is pending`, confirmed on .NET 10). `SendRpcMessage` started writes without awaiting them, and the logon handlers send two frames back to back: the listener request, then the RPC response. When the socket's send buffer was full, the second frame was caught, logged, and dropped, and the client waited forever for that reply. None of the last 261 logs show it, because small frames usually complete before the next one starts, but a peer that stops reading reproduces it every time.
- **Fix.** `SSLSocket` queues writes behind a `SemaphoreSlim(1,1)`. Async waiters are released in arrival order, so frames keep their send order. With no queue and a socket that accepts the bytes straight away, a send allocates nothing.
- **Pooled frames.** A new `AsyncWrite(buffer, length, returnToPool)` takes ownership of a rented buffer and returns it once the write finishes or fails. `BnetTcpSession.RentRpcFrame` replaces `BuildRpcFrame` and writes each frame into an `ArrayPool` rental.
- **Disconnect.** The client sends `ConnectionService.RequestDisconnect` on every login, right after RealmJoin. The handler sends a `DisconnectNotification` and closes. `BnetTcpSession`'s `INetwork.CloseSocket` now waits for queued writes first, capped at 5 s so a peer that stopped reading can't hold the session open. Parse and buffer error paths still close immediately.

`BnetRestApiSession` keeps its awaited `AsyncWrite(byte[])` and now goes through the same queue. `WorldSocket` uses blocking sends and is unaffected.

## Benchmarks

Mac mini M4, .NET 10.0.11 arm64, BenchmarkDotNet ShortRun. Each iteration rents and returns the frame, as a send does.

| Benchmark | master | this PR | time | allocated |
|---|---|---|---|---|
| Frame realm-list response | 198.8 ns | 164.8 ns | −17% | 1944 → 272 B |
| Frame `LogonResult` | 100.1 ns | 100.0 ns | ±0 | 424 → 272 B |

The 272 B left over is the `Header` object built for each frame.

## Testing

- `SslSocketWriteTests` run over real TLS on loopback, with tiny socket buffers and a client that holds off reading:
  - A write started behind a stalled 4 MB write arrives intact and in order. This test fails on master: the frame is dropped and the read times out.
  - A pooled buffer sends only the requested length.
  - `CloseSocketAfterWrites` delivers queued data before it closes.
  - `CloseSocketAfterWrites` still closes when the peer has stopped reading.
- `BnetTcpSessionWriteTests`: two `SendRpcMessage` calls behind a stalled frame arrive in order.
- `dotnet test`: 1103/1103. The new socket tests also pass 5 runs in a row.
- Playtest on cMangos with V3_4_3, V1_14.2 and V2_5_3 clients: BNet logon, including both back-to-back send pairs, then realm list, realm join, the `RequestDisconnect` close, and entering the world. No write or read exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwHXGKmdGbXbAP4v5C8NTi
