### PR TITLE
Forward 3.3.5a walk-speed spline updates (opcode 0x301 mislabelled)

### DIFF
--- a/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/MovementHandler.cs
@@ -283,7 +283,6 @@ public partial class WorldClient
     [PacketHandler(Opcode.SMSG_MOVE_SPLINE_SET_SWIM_BACK_SPEED)]
     [PacketHandler(Opcode.SMSG_MOVE_SPLINE_SET_SWIM_SPEED)]
     [PacketHandler(Opcode.SMSG_MOVE_SPLINE_SET_TURN_RATE)]
-    [PacketHandler(Opcode.SMSG_MOVE_SPLINE_SET_WALK_BACK_SPEED)]
     [PacketHandler(Opcode.SMSG_MOVE_SPLINE_SET_WALK_SPEED)]
     void HandleMoveSplineSetSpeed(WorldPacket packet)
     {

--- a/HermesProxy/World/Enums/V3_3_5a_12340/Opcode.cs
+++ b/HermesProxy/World/Enums/V3_3_5a_12340/Opcode.cs
@@ -1075,7 +1075,7 @@ public enum Opcode : uint
     SMSG_MOVE_SPLINE_SET_SWIM_BACK_SPEED                  = 0x302,
     SMSG_MOVE_SPLINE_SET_SWIM_SPEED                       = 0x300,
     SMSG_MOVE_SPLINE_SET_TURN_RATE                        = 0x303,
-    SMSG_MOVE_SPLINE_SET_WALK_BACK_SPEED                  = 0x301,
+    SMSG_MOVE_SPLINE_SET_WALK_SPEED                       = 0x301,
     SMSG_MOVE_SPLINE_SET_WALK_MODE                        = 0x30E,
     SMSG_MOVE_SPLINE_SET_WATER_WALK                       = 0x309,
     SMSG_MOVE_SPLINE_START_SWIM                           = 0x30B,


### PR DESCRIPTION
## Summary

On a 3.3.5a backend, walk-speed changes for server-controlled units (pets, NPCs) never reached the V3_4_3 client. The proxy dropped every one of them:

```
WorldClient | C P<S | Handling SMSG_MOVE_SPLINE_SET_WALK_BACK_SPEED (769): No V3_4_3_54261 opcode mapping for SMSG_MOVE_SPLINE_SET_WALK_BACK_SPEED, packet dropped.
```

The cause is a mislabelled opcode. 3.3.5a has no walk-back spline opcode: 0x301 (769) is `SMSG_SPLINE_SET_WALK_SPEED`. Our V3_3_5a table called it `SMSG_MOVE_SPLINE_SET_WALK_BACK_SPEED`. V3_4_3 has no such opcode either, so the shared spline speed handler read the packet and then had nothing to translate it to.

## Evidence

**Live session.** V3_4_3 client on AzerothCore + mod-playerbots, running a Dungeon Finder group, about 19 minutes. The line above was logged 225 times. It was the most frequent warning in the log, ahead of every unhandled opcode.

**Payload.** In the legacy capture, the dropped packets are 12 bytes: a packed GUID and a float. One of them ends in `00 00 A0 3F`, which is 1.25f, half the 2.5 base walk speed. There is no walk-back speed in the 3.3.5a speed table.

**The handler itself works.** Run and swim speeds go through the same `HandleMoveSplineSetSpeed` and arrived correctly in the same session: the modern capture shows the pet getting run 14.49 and swim 5.43. Only walk was missing.

**What each source calls 0x301:**

| Source | Name for 0x301 |
|---|---|
| AzerothCore `Opcodes.h:799` | `SMSG_SPLINE_SET_WALK_SPEED`. `Unit.h:653` maps `MOVE_WALK` to it. |
| cMaNGOS mangos-wotlk `Opcodes.h:806` | `SMSG_SPLINE_SET_WALK_SPEED` |
| HermesProxy V1_12_1, V2_4_3 | `SMSG_MOVE_SPLINE_SET_WALK_SPEED` |
| HermesProxy V3_3_5a (before this PR) | `SMSG_MOVE_SPLINE_SET_WALK_BACK_SPEED` |
| WowPacketParser `V3_3_5a_12340/Opcodes.cs:973` | `SMSG_MOVE_SPLINE_SET_WALK_BACK_SPEED` |

Our V3_3_5a table was copied from WowPacketParser in 09a29b3b8, and WPP has the same mislabel. TrinityCore `wotlk_classic` also has no walk-back spline opcode for 3.4.3.

## Change

- `V3_3_5a_12340/Opcode.cs`: 0x301 is now `SMSG_MOVE_SPLINE_SET_WALK_SPEED`. The existing handler forwards it to the client as V3_4_3 `SMSG_MOVE_SPLINE_SET_WALK_SPEED` (11757).
- `MovementHandler.cs`: removed the `WALK_BACK_SPEED` registration, since no legacy table maps that name any more.

Only the V3_3_5a legacy table changes, and it is only used with the V3_4_3 client, so V1_14 and V2_5 are unaffected. The universal `Opcodes.cs` entry stays: its members are numbered implicitly, so removing it would renumber everything after it.

## Testing

- `dotnet test -c Release`: 1114/1114.
- Not playtested yet. The evidence above comes from the session that found the bug. The next AzerothCore session should log none of these drop lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwHXGKmdGbXbAP4v5C8NTi
