### PR TITLE
fix(spell): clear auto-repeat state on client cancel

### DIFF
--- a/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/SpellHandler.cs
@@ -466,6 +466,12 @@ public partial class WorldSocket
     [PacketHandler(Opcode.CMSG_CANCEL_AUTO_REPEAT_SPELL)]
     void HandleCancelAutoRepeatSpell(CancelAutoRepeatSpell spell)
     {
+        // The client has already dropped auto-repeat, so its next Auto Shot is a new cast.
+        // Don't wait for SMSG_CANCEL_AUTO_REPEAT: cMaNGOS WotLK never sends it for a client
+        // cancel, and the stale entry made HandleCastSpell reject every later Auto Shot as
+        // SpellInProgress (#277).
+        GetSession().GameState.CurrentClientAutoRepeatCast = null;
+
         WorldPacket packet = new WorldPacket(Opcode.CMSG_CANCEL_AUTO_REPEAT_SPELL);
         SendPacketToServer(packet);
     }

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -6,9 +6,11 @@ Bugs and quirks that have workarounds. For things HermesProxy structurally canno
 
 # Classic Era (1.14.x)
 
-## Priest wand `Shoot` cancels in melee range (1.14.x client)
+## Wand `Shoot` stops in melee range (1.14.x client)
 
-On modern 1.14.x Classic clients the `autoRangedCombat` CVar (default ON) treats wands as ranged weapons and auto-cancels `Shoot` the moment a mob enters melee range, then switches you into auto-attack. Vanilla 1.12 emulators (VMaNGOS, Kronos, CMaNGOS) never expected this — the wand simply dies, you can't finish the mob with it, and you get stuck swinging.
+Modern 1.14.x Classic clients have an `autoRangedCombat` setting, on by default, that swaps ranged attacks for melee once the target is in melee range. When a mob reaches you while you wand it, the client stops `Shoot` and starts auto-attack on its own. Pressing `Shoot` again restarts the wand, but the client switches back to melee a second or two later. The 1.12 client has no such setting, so on vanilla servers (VMaNGOS, Kronos, CMaNGOS) you can't finish a mob with your wand once it closes in.
+
+This is the client's choice, not a proxy or server bug: the client sends the melee attack and the wand cancel itself, and the proxy forwards them unchanged.
 
 **Workaround — run once in chat:**
 ```
@@ -19,7 +21,9 @@ Or make it persistent by adding this line to `WTF/Config.wtf` before launch:
 SET autoRangedCombat "0"
 ```
 
-Priest characters logging in on 1.14+ Classic Era clients receive a one-time chat reminder from the proxy on world-enter. Other classes that occasionally use a wand are affected the same way — apply the same CVar fix if you notice it. Tracked in [#80](https://github.com/Xian55/HermesProxy/issues/80).
+With the setting off, the wand keeps firing in melee range. This affects any wand user. Priests on 1.14+ clients also get a chat reminder from the proxy each time they log in.
+
+Moving still interrupts a wand, as it always has on vanilla servers — walk, strafe or jump and you need to press `Shoot` again. That is unrelated to this setting. Background in [#80](https://github.com/Xian55/HermesProxy/issues/80).
 
 ---
 


### PR DESCRIPTION
Fixes #277.

## Problem

On cMaNGOS WotLK a hunter's Auto Shot worked until it was cancelled once. After that, every Auto Shot was answered by the proxy itself with `SpellInProgress` and never reached the server.

The proxy remembers the running auto-repeat spell in `CurrentClientAutoRepeatCast` and refuses a second one while it is set. It was only cleared by `SMSG_CANCEL_AUTO_REPEAT` or a `SMSG_CAST_FAILED` for that spell. TrinityCore and AzerothCore answer the client's cancel with `SMSG_CANCEL_AUTO_REPEAT`; mangos-wotlk deliberately does not (`SpellHandler.cpp:617` interrupts with `SMSG_SPELL_FAILURE` only), so the entry was never cleared.

## Change

`HandleCancelAutoRepeatSpell` now clears `CurrentClientAutoRepeatCast` before forwarding the cancel. By then the client has already dropped auto-repeat, so its next Auto Shot is a new cast. Backends that do send `SMSG_CANCEL_AUTO_REPEAT` still have it forwarded unchanged. No version gate: this is proxy bookkeeping only.

The issue also proposed clearing it on the player's own `SMSG_SPELL_FAILURE`. That is left out. In mangos-wotlk every other interrupt path sends `SMSG_CANCEL_AUTO_REPEAT` (only the client-cancel handler passes `false`), so it added nothing, and in a 2.5.3 playtest a late failure raced a same-second recast and wiped the new cast's state.

`docs/known-issues.md`: the 1.14.x wand entry now says the melee switch comes from the client's `autoRangedCombat` setting (the client sends the attack and the cancel itself), that it affects any wand user, and that the priest reminder fires on every login.

## Testing

Live playtests, hunter unless noted, counted from the proxy logs:

| Backend | Client cancels | Server `SMSG_CANCEL_AUTO_REPEAT` | Auto-repeat casts forwarded | Rejected by the proxy |
|---|---|---|---|---|
| cMaNGOS WotLK (3.4.3) | 3 | 0 | 3 / 3 | 0 (was 6 of 7 before) |
| AzerothCore playerbots (3.4.3) | 7 | 7 | 7 / 7 | 0 |
| cMaNGOS TBC (2.5.3) | 3 | 4 | 4 / 4 | 0 |
| cMaNGOS vanilla (1.14.2), hunter | 3 | 3 | 4 / 4 | 0 |
| cMaNGOS vanilla (1.14.2), priest wand | 13 | 16 | 16 / 16 | 0 |

A native Wrathion capture (3.4.3 client and server, no proxy) was used to check the remaining reports. Auto Shot pressed out of range stays armed without sending anything, and after a shot has landed it is the client that cancels once the target goes out of range. Both are native behaviour and match what the proxy shows.

`dotnet build` clean, `dotnet test` 1114 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bsz5TdvtRMNLUYLbg1AcLW
