### PR TITLE
fix(trade): forward trade refusals to the initiator unchanged

### DIFF
--- a/HermesProxy/GlobalSessionData.cs
+++ b/HermesProxy/GlobalSessionData.cs
@@ -517,6 +517,9 @@ public sealed class GameSessionData
     // CreateObject's UnitData), so a separate authoritative tracker is required.
     public Dictionary<WowGuid128, Dictionary<byte, AuraInfo>> KnownAuras = [];
     public TradeSession? CurrentTrade = null;
+    // The client clears the trade slots it filled after the legacy server has already closed a
+    // completed trade, so a trade action with no session is expected only while this is set.
+    public bool TradeJustCompleted;
     public HashSet<uint> RequestedItemHotfixes = [];
     public HashSet<uint> RequestedItemSparseHotfixes = [];
 

--- a/HermesProxy/World/Client/PacketHandlers/TradeHandler.cs
+++ b/HermesProxy/World/Client/PacketHandlers/TradeHandler.cs
@@ -2,6 +2,7 @@
 using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Logging;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 using System;
@@ -18,34 +19,32 @@ public partial class WorldClient
         TradeStatusPkt trade = new();
         trade.Status = (TradeStatus)packet.ReadUInt32();
 
-        TradeSession? tradeSession = GetSession().GameState.CurrentTrade;
-        if (tradeSession == null)
+        var gameState = GetSession().GameState;
+        TradeSession? tradeSession = gameState.CurrentTrade;
+        gameState.TradeJustCompleted = trade.Status == TradeStatus.Complete;
+        WorldClientLogMessages.TradeStatusReceived(_melLog, _sourceFile, _netDirNone, trade.Status, gameState.CurrentPlayerInfo?.Name, tradeSession != null);
+
+        // Only the target of CMSG_INITIATE_TRADE is sent Proposed, so the initiator has no
+        // session until Initiated, and every refusal of its request (target busy, too far away,
+        // dead, ...) arrives without one. Those must reach the client with their own status,
+        // not a substituted Cancelled (#228). Verified on V3_4_3 only.
+        if (tradeSession == null && trade.Status is not (TradeStatus.Proposed or TradeStatus.Initiated)
+            && ModernVersion.Build != ClientVersionBuild.V3_4_3_54261)
         {
-            switch (trade.Status)
-            {
-                case TradeStatus.Initiated:
-                case TradeStatus.Proposed:
-                {
-                    tradeSession = new TradeSession();
-                    GetSession().GameState.CurrentTrade = tradeSession;
-                    break;
-                }
-                default:
-                {
-                    Log.Print(LogType.Error, $"Got SMSG_TRADE_STATUS without trade session (status: {trade.Status})");
-                    SendPacketToClient(new TradeStatusPkt { Status = TradeStatus.Cancelled });
-                    return;
-                }
-            }
-        } 
+            Log.Print(LogType.Error, $"Got SMSG_TRADE_STATUS without trade session (status: {trade.Status})");
+            SendPacketToClient(new TradeStatusPkt { Status = TradeStatus.Cancelled });
+            return;
+        }
 
         switch (trade.Status)
         {
             case TradeStatus.Proposed:
-                trade.Partner = tradeSession.Partner = packet.ReadGuid().To128(GetSession().GameState);
+                tradeSession ??= gameState.CurrentTrade = new TradeSession();
+                trade.Partner = tradeSession.Partner = packet.ReadGuid().To128(gameState);
                 trade.PartnerAccount = tradeSession.PartnerAccount = GetSession().GetGameAccountGuidForPlayer(trade.Partner);
                 break;
             case TradeStatus.Initiated:
+                tradeSession ??= gameState.CurrentTrade = new TradeSession();
                 if (LegacyVersion.AddedInVersion(ClientVersionBuild.V2_0_1_6180))
                     trade.Id = packet.ReadUInt32();
                 else

--- a/HermesProxy/World/Logging/WorldClientLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldClientLogMessages.cs
@@ -257,4 +257,20 @@ internal static partial class WorldClientLogMessages
         string SourceFile,
         string NetDir,
         uint Position);
+
+    /// <summary>
+    /// Names the receiving character because the two traders' SMSG_TRADE_STATUS lines otherwise
+    /// interleave in one log with nothing to tell the sessions apart.
+    /// </summary>
+    [LoggerMessage(
+        EventId = 222,
+        Level = LogLevel.Debug,
+        Message = "Trade status {Status} for {Player} (had trade session: {HadSession})")]
+    public static partial void TradeStatusReceived(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        TradeStatus Status,
+        string? Player,
+        bool HadSession);
 }

--- a/HermesProxy/World/Logging/WorldSocketLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldSocketLogMessages.cs
@@ -180,4 +180,24 @@ internal static partial class WorldSocketLogMessages
         byte FacialHair,
         uint HairStyleId,
         uint FacialHairId);
+
+    [LoggerMessage(
+        EventId = 118,
+        Level = LogLevel.Debug,
+        Message = "Dropped {Opcode}: the client is clearing the window of a trade that already completed.")]
+    public static partial void TradeActionAfterComplete(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        Opcode Opcode);
+
+    [LoggerMessage(
+        EventId = 119,
+        Level = LogLevel.Error,
+        Message = "Got {Opcode} without trade session")]
+    public static partial void TradeActionWithoutSession(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        Opcode Opcode);
 }

--- a/HermesProxy/World/Server/PacketHandlers/TradeHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/TradeHandler.cs
@@ -1,8 +1,8 @@
 ﻿using Framework.Constants;
-using Framework.Logging;
 using HermesProxy.Enums;
 using HermesProxy.World;
 using HermesProxy.World.Enums;
+using HermesProxy.World.Logging;
 using HermesProxy.World.Objects;
 using HermesProxy.World.Server.Packets;
 
@@ -25,7 +25,7 @@ public partial class WorldSocket
         var tradeSession = GetSession().GameState.CurrentTrade;
         if (tradeSession == null)
         {
-            Log.Print(LogType.Error, $"Got {trade.GetUniversalOpcode()} without trade session");
+            LogTradeActionWithoutSession(trade.GetUniversalOpcode());
             return;
         }
         tradeSession.ClientStateIndex++;
@@ -60,7 +60,7 @@ public partial class WorldSocket
         var tradeSession = GetSession().GameState.CurrentTrade;
         if (tradeSession == null)
         {
-            Log.Print(LogType.Error, $"Got {trade.GetUniversalOpcode()} without trade session");
+            LogTradeActionWithoutSession(trade.GetUniversalOpcode());
             return;
         }
         tradeSession.ClientStateIndex++;
@@ -76,7 +76,7 @@ public partial class WorldSocket
         var tradeSession = GetSession().GameState.CurrentTrade;
         if (tradeSession == null)
         {
-            Log.Print(LogType.Error, $"Got {trade.GetUniversalOpcode()} without trade session");
+            LogTradeActionWithoutSession(trade.GetUniversalOpcode());
             return;
         }
         tradeSession.ClientStateIndex++;
@@ -88,5 +88,13 @@ public partial class WorldSocket
         packet.WriteUInt8(containerSlot);
         packet.WriteUInt8(slot);
         SendPacketToServer(packet);
+    }
+
+    void LogTradeActionWithoutSession(Opcode opcode)
+    {
+        if (GetSession().GameState.TradeJustCompleted)
+            WorldSocketLogMessages.TradeActionAfterComplete(_melLog, _sourceFile, _netDirRecv, opcode);
+        else
+            WorldSocketLogMessages.TradeActionWithoutSession(_melLog, _sourceFile, _netDirRecv, opcode);
     }
 }


### PR DESCRIPTION
Fixes #228.

## Problem

After the target of a trade request refused it as busy (a mailbox window open, for example), the player who asked could not trade with anyone until they relogged.

Only the target of `CMSG_INITIATE_TRADE` is sent `Proposed`, so the initiator has no proxy trade session until `Initiated`. When the target's client answers with `CMSG_BUSY_TRADE`, AzerothCore calls `TradeCancel(true, TRADE_STATUS_BUSY)`, which sends `PlayerBusy` to **both** players. The target's copy went through normally. The initiator's copy hit the no-session branch of `HandleTradeStatus`, which logged `Got SMSG_TRADE_STATUS without trade session` and sent the client a made-up `Cancelled` in its place. Every other refusal of a trade request (too far away, target dead, …) reaches the initiator the same way.

The issue suspected that the back-to-back pair tore one session down twice. With the character named on each line, the two packets turn out to go to different sessions, one each.

## Change

- `HandleTradeStatus` forwards the status the server sent. A session is still created only on `Proposed` or `Initiated`. Gated to V3_4_3; other clients keep the old path because they were not tested.
- After a trade with an item in it completes, the client sends `CMSG_CLEAR_TRADE_ITEM` for the slot it filled. The proxy has already dropped the session by then, so every such trade logged an error. `GameSessionData.TradeJustCompleted` records that the last trade status was `Complete`. While it is set, a trade action without a session logs at Debug, and the next trade status clears it. Any other trade action without a session still logs an error.
- New Debug line `Trade status {Status} for {Player} (had trade session: …)`, so the two traders' sessions can be told apart in one log. The `CMSG_*_TRADE_*` guard messages moved to `[LoggerMessage]`.

## Testing

Live: two V3_4_3 (54261) clients on one proxy against AzerothCore playerbots (3.3.5a), both directions, counted from the proxy logs:

| | Run 1 | Run 2 (with the Debug change) |
|---|---|---|
| Busy refusals, initiator shown "Testa is busy right now." | 7 | 2 |
| Trade windows opened | 10 | 5 |
| Trades completed | 3 | 3 |
| `CMSG_CLEAR_TRADE_ITEM` after `Complete` | 2, logged as errors | 2, logged at Debug |
| Other errors | 0 | 0 |

- Every busy refusal was followed by a trade that opened normally a few seconds later, with no relog, including after four refusals in a row. Item and gold arrived on the other character.
- Walking apart with a trade window open: the client cancels the trade itself and the server confirms. No `TooFarAway` status arrived; the client seems to check range before it sends `CMSG_INITIATE_TRADE`.
- The Debug flag reset was exercised: a completed item trade, two busy refusals, then another completed item trade, and each completion logged at Debug.

The old build was not re-run, so the wedge itself is known only from the log in #228.

`dotnet build` clean, `dotnet test` 1114 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bsz5TdvtRMNLUYLbg1AcLW
