### PR TITLE
fix(io): count pending bits in SpanPacketWriter.Position

### DIFF
--- a/Framework/IO/SpanPacketWriter.cs
+++ b/Framework/IO/SpanPacketWriter.cs
@@ -44,8 +44,11 @@ public ref struct SpanPacketWriter
         _bitPosition = 8;
     }
 
-    public readonly int Position => _position;
-    public readonly int Remaining => _buffer.Length - _position;
+    // Counts a partially filled bit byte. WriteToSpan implementations return Position, and a
+    // packet that ends in bits — or in bits followed by an empty WriteString, which does not
+    // flush — would otherwise lose its last byte. ByteBuffer.GetData flushes for the same reason.
+    public readonly int Position => _bitPosition == 8 ? _position : _position + 1;
+    public readonly int Remaining => _buffer.Length - Position;
 
     #region Integer Write Methods
 
@@ -253,9 +256,12 @@ public ref struct SpanPacketWriter
         if (value)
             _bitValue |= (byte)(1 << _bitPosition);
 
+        // Stored on every bit, not just a full byte, so Position can count a partial one unflushed.
+        _buffer[_position] = _bitValue;
+
         if (_bitPosition == 0)
         {
-            _buffer[_position++] = _bitValue;
+            ++_position;
             _bitPosition = 8;
             _bitValue = 0;
         }
@@ -284,6 +290,10 @@ public ref struct SpanPacketWriter
                 _bitValue = 0;
             }
         }
+
+        // Store the partial byte too, so Position can count it unflushed.
+        if (_bitPosition != 8)
+            _buffer[_position] = _bitValue;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/HermesProxy.Tests/Framework/SpanPacketTests.cs
+++ b/HermesProxy.Tests/Framework/SpanPacketTests.cs
@@ -283,6 +283,34 @@ public class SpanPacketWriterTests
         writer.WriteUInt8(3);
         Assert.Equal(13, writer.Position);
     }
+
+    [Fact]
+    public void Position_CountsPendingBits()
+    {
+        Span<byte> span = stackalloc byte[4];
+        var writer = new SpanPacketWriter(span);
+
+        // An 11-bit length followed by an empty string, as GuildEventMotd writes it (#156).
+        // WriteString("") does not flush, so the last 3 bits must still be counted.
+        writer.WriteBits(0x5FFu, 11);
+        writer.WriteString("");
+
+        Assert.Equal(2, writer.Position);
+        Assert.Equal(new byte[] { 0xBF, 0xE0 }, span[..writer.Position].ToArray());
+    }
+
+    [Fact]
+    public void Position_CountsTrailingSingleBit()
+    {
+        Span<byte> span = stackalloc byte[4];
+        var writer = new SpanPacketWriter(span);
+
+        writer.WriteUInt8(0x11);
+        writer.WriteBit(true);
+
+        Assert.Equal(2, writer.Position);
+        Assert.Equal(new byte[] { 0x11, 0x80 }, span[..writer.Position].ToArray());
+    }
 }
 
 public class SpanPacketReaderTests

--- a/HermesProxy.Tests/World/Server/SpanWriteParityTests.cs
+++ b/HermesProxy.Tests/World/Server/SpanWriteParityTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Framework.IO;
+using HermesProxy.World;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+/// <summary>
+/// WritePacketData ships WriteToSpan's bytes and only falls back to Write() when WriteToSpan
+/// reports MaxSize exceeded, so the two bodies must agree byte for byte. Nothing else notices
+/// when they drift: the client just receives a packet the Write() body does not describe (#156).
+/// Packets are built from default field values, so this pins fixed layout and empty
+/// collections rather than every populated shape.
+/// </summary>
+public class SpanWriteParityTests
+{
+    private static readonly Assembly ProxyAssembly = typeof(ServerPacket).Assembly;
+
+    private static readonly FieldInfo WorldPacketField =
+        typeof(ServerPacket).GetField("_worldPacket", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private static readonly NullabilityInfoContext Nullability = new();
+
+    public static TheoryData<string, bool> SpanWritablePackets()
+    {
+        var data = new TheoryData<string, bool>();
+        var types = ProxyAssembly.GetTypes()
+            .Where(t => !t.IsAbstract
+                        && typeof(ServerPacket).IsAssignableFrom(t)
+                        && typeof(ISpanWritable).IsAssignableFrom(t)
+                        && t.GetConstructor(Type.EmptyTypes) != null)
+            .OrderBy(t => t.FullName, StringComparer.Ordinal);
+
+        foreach (var type in types)
+        {
+            data.Add(type.FullName!, false);
+            // String fields default to "" or null depending on the packet; blanking them all
+            // reaches the bits-then-empty-WriteString shape, which WriteString does not flush.
+            data.Add(type.FullName!, true);
+        }
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(SpanWritablePackets))]
+    public void WriteToSpan_MatchesWrite(string typeName, bool blankStrings)
+    {
+        AssertParity(ProxyAssembly.GetType(typeName, throwOnError: true)!, blankStrings);
+    }
+
+    // LootRollWire writes DungeonEncounterID only on V3_4_3, which the test process never runs
+    // as, so the theory above cannot reach that branch. It is where LootRemoved's span body
+    // gained the field and LootRollsComplete's lost it, while both Write() bodies were right.
+    [Theory]
+    [InlineData(typeof(LootRollBroadcast))]
+    [InlineData(typeof(LootRollWon))]
+    [InlineData(typeof(LootRollsComplete))]
+    [InlineData(typeof(LootRemoved))]
+    public void WriteToSpan_MatchesWrite_WithDungeonEncounterId(Type type)
+    {
+        LootRollWire.ForceDungeonEncounterIdForTests = true;
+        try
+        {
+            AssertParity(type, blankStrings: false);
+        }
+        finally
+        {
+            LootRollWire.ForceDungeonEncounterIdForTests = null;
+        }
+    }
+
+    private static void AssertParity(Type type, bool blankStrings)
+    {
+        // Defaults first: a null sub-object is often an absent optional (a WriteBit(x != null)
+        // gate), even when declared `= null!`, and that shape is worth pinning. Packets whose
+        // sub-object is mandatory throw on it, and are retried with those filled in.
+        try
+        {
+            AssertParity(type, blankStrings, fillSubObjects: false);
+        }
+        catch (NullReferenceException)
+        {
+            AssertParity(type, blankStrings, fillSubObjects: true);
+        }
+    }
+
+    private static void AssertParity(Type type, bool blankStrings, bool fillSubObjects)
+    {
+        var viaSpan = Create(type, blankStrings, fillSubObjects);
+        var viaWrite = Create(type, blankStrings, fillSubObjects);
+
+        var spanWritable = (ISpanWritable)viaSpan;
+        // Exactly MaxSize rather than a rounded-up pool rental, so an undercounted MaxSize fails too.
+        var buffer = new byte[spanWritable.MaxSize];
+        int written = spanWritable.WriteToSpan(buffer);
+        if (written < 0)
+            return; // WritePacketData sends Write() itself in this case; nothing can diverge.
+
+        viaWrite.Write();
+        byte[] expected = ((WorldPacket)WorldPacketField.GetValue(viaWrite)!).GetData();
+
+        Assert.Equal(Convert.ToHexString(expected), Convert.ToHexString(buffer, 0, written));
+    }
+
+    private static ServerPacket Create(Type type, bool blankStrings, bool fillSubObjects)
+    {
+        ServerPacket packet;
+        try
+        {
+            packet = (ServerPacket)Activator.CreateInstance(type)!;
+        }
+        catch (TargetInvocationException e) when (e.InnerException is UnmappedOpcodeException)
+        {
+            Assert.Skip($"{type.Name} has no opcode in {ModernVersion.Build}");
+            throw;
+        }
+
+        if (blankStrings)
+        {
+            foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (field.FieldType == typeof(string) && !field.IsInitOnly)
+                    field.SetValue(packet, "");
+            }
+            foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (property.PropertyType == typeof(string) && property.CanWrite
+                    && property.GetIndexParameters().Length == 0)
+                    property.SetValue(packet, "");
+            }
+        }
+
+        if (fillSubObjects)
+            FillSubObjects(packet, depth: 0);
+
+        return packet;
+    }
+
+    private static void FillSubObjects(object target, int depth)
+    {
+        if (depth > 3)
+            return;
+
+        foreach (var field in target.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (field.IsInitOnly
+                || field.FieldType == typeof(string)
+                || !field.FieldType.IsClass
+                || field.FieldType.GetConstructor(Type.EmptyTypes) == null
+                || Nullability.Create(field).WriteState != NullabilityState.NotNull)
+                continue;
+
+            var value = field.GetValue(target);
+            if (value == null)
+            {
+                value = Activator.CreateInstance(field.FieldType)!;
+                field.SetValue(target, value);
+            }
+            FillSubObjects(value, depth + 1);
+        }
+    }
+}

--- a/HermesProxy/World/Server/Packets/LootPackets.cs
+++ b/HermesProxy/World/Server/Packets/LootPackets.cs
@@ -312,8 +312,6 @@ class LootRemoved : ServerPacket, ISpanWritable
         writer.WritePackedGuid128(Owner.Low, Owner.High);
         writer.WritePackedGuid128(LootObj.Low, LootObj.High);
         writer.WriteUInt8(LootListID);
-        if (LootRollWire.WritesDungeonEncounterId)
-            writer.WriteInt32(0);                    // DungeonEncounterID
         return writer.Position;
     }
 
@@ -449,12 +447,16 @@ class LootRoll : ClientPacket
 /// SMSG_LOOT_ROLL and SMSG_LOOT_ROLL_WON carry it at offset 17 (after RollType), and
 /// SMSG_LOOT_ROLLS_COMPLETE at offset 8 (after LootListID). 3.3.5a has no dungeon-encounter
 /// concept on this wire and it is zero in every native packet, so it is always written as 0.
-/// SMSG_LOOT_START_ROLL does NOT have this field. Issue #162.
+/// SMSG_LOOT_START_ROLL and SMSG_LOOT_REMOVED do NOT have this field. Issue #162.
 /// </summary>
 internal static class LootRollWire
 {
+    // ModernVersion.Build is readonly and the test process runs as one fixed build, so the
+    // span/Write parity test needs this to reach the V3_4_3 branch. Production never sets it.
+    internal static bool? ForceDungeonEncounterIdForTests;
+
     public static bool WritesDungeonEncounterId =>
-        ModernVersion.Build == ClientVersionBuild.V3_4_3_54261;
+        ForceDungeonEncounterIdForTests ?? ModernVersion.Build == ClientVersionBuild.V3_4_3_54261;
 
     public static int DungeonEncounterIdBytes => WritesDungeonEncounterId ? 4 : 0;
 }
@@ -639,6 +641,8 @@ class LootRollsComplete : ServerPacket, ISpanWritable
         var writer = new SpanPacketWriter(buffer);
         writer.WritePackedGuid128(LootObj.Low, LootObj.High);
         writer.WriteUInt8(LootListID);
+        if (LootRollWire.WritesDungeonEncounterId)
+            writer.WriteInt32(0);                    // DungeonEncounterID
         return writer.Position;
     }
 


### PR DESCRIPTION
## Summary

`SpanPacketWriter.Position` now includes a partially filled bit byte, so no `WriteToSpan` can drop trailing bits any more. The same test coverage exposed a V3_4_3 layout swap between two loot packets, which is fixed here as well.

## The bug (#156)

Every `ISpanWritable` returns `writer.Position`, and `WritePacketData` sends exactly that many bytes. `Position` only advanced on whole bytes, so pending bits vanished whenever nothing flushed them — a packet ending in bits, or bits followed by an empty `WriteString` (which returns before `FlushBits`). The `Write()` fallback was never affected because `ByteBuffer.GetData` flushes, which is why #152's `FlushBits()` in `Write()` changed nothing on the wire.

Rather than add `FlushBits()` at each call site, the writer stores the partial byte as bits are written and `Position` counts it. Every existing and future span writer is covered, and no byte inside a packet moves.

Affected, each one byte short before this change: `GuildEventMotd`, `GuildEventPlayerJoined`, `GuildBankTextQueryResult`, `ChatServerMessage`, `ChatPlayerNotfound`, `PrintNotification`, `GroupNewLeader`, `QuestConfirmAccept`, `GenerateRandomCharacterNameResult`, `SetTimeZoneInformation`. In normal play only an empty guild MOTD and an empty guild bank tab text actually send the empty string; the others always carry a name or text. Several classes the issue listed (`GuildCommandResult`, the other guild events, `ChannelNotify*`, `DuelWinner`, `PartyCommandResult`) use a whole-byte length and were never affected.

## Loot packets swapped on V3_4_3

`LootRemoved.WriteToSpan` wrote the `DungeonEncounterID` meant for `LootRollsComplete`, so `SMSG_LOOT_REMOVED` carried 4 stray bytes and `SMSG_LOOT_ROLLS_COMPLETE` was 4 bytes short. Both `Write()` bodies were correct and match TrinityCore `wotlk_classic`. This came in with #162.

## Tests

- New `SpanWriteParityTests`: every `ISpanWritable` `ServerPacket` must produce the same bytes from `WriteToSpan` as from `Write()`, with default fields and with all strings blank (548 cases). With the writer change reverted it fails for exactly the ten packets above.
- The loot packets are also run with `DungeonEncounterID` forced on through a test-only `LootRollWire` override, because the test process is pinned to one client build.
- Two `SpanPacketWriter` unit tests for pending bits.
- Full suite: 1664 pass.

## Playtest — AzerothCore playerbots, V3_4_3 → 3.3.5a

Checked against the proxy's own sniff with WowPacketParser:

| Packet | Bytes | Result |
|---|---|---|
| `SMSG_GUILD_EVENT_MOTD` ×3 (`No message set.`, `gooday`, 55 chars) | 17 / 8 / 57 | 2 + text, parses clean |
| `SMSG_LOOT_REMOVED` | 19 | no stray `DungeonEncounterID` |
| `SMSG_LOOT_ROLLS_COMPLETE` | 13 | includes `DungeonEncounterID`, parses clean |
| `SMSG_LOOT_ROLL_WON`, `SMSG_LOOT_ROLL`, `SMSG_START_LOOT_ROLL` | — | unchanged; full group roll completed |

Comparing WPP errors per opcode against a large pre-change sniff shows no opcode getting worse, and no new "1 byte remaining" warnings. The remaining WPP complaints are parser gaps on its side, e.g. its 3.4.3 `SMSG_LOOT_ROLL` handler does not read `DungeonEncounterID`.

Not reached in the playtest: an empty guild MOTD (AzerothCore gives new guilds `No message set.`) and an empty bank tab text. Both are covered by the parity test and the writer unit tests.

## Cost

BenchmarkDotNet on the M4, master vs this branch: `WriteBit` ×256 109 → 134 ns (about 0.1 ns per bit), `WriteBits` ×64 101 → 94 ns, a movement-shaped mix 117 → 123 ns. No allocations either way.

Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bsz5TdvtRMNLUYLbg1AcLW
