### PR TITLE
fix(guild): forward one CMSG_GUILD_RANK per rank-permission burst

### DIFF
--- a/HermesProxy.Tests/World/Server/GuildRankPermissionsTests.cs
+++ b/HermesProxy.Tests/World/Server/GuildRankPermissionsTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using HermesProxy.World;
+using HermesProxy.World.Server;
+using HermesProxy.World.Server.Packets;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+public class GuildRankPermissionsTests
+{
+    // CMSG_GUILD_SET_RANK_PERMISSIONS for the Officer rank, verbatim from a native Wrathion 3.4.3
+    // capture (the fourth of five sent by one Apply). OldFlags precedes the 7-bit name here, which
+    // is the reverse of TrinityCore wotlk_classic's reader.
+    private static readonly byte[] NativeOfficer = Convert.FromHexString(
+        "01000000" + "01000000" + "BFFFDD00" + "01000000"   // RankID, RankOrder, Flags, WithdrawGoldLimit
+        + "07000000" + "01000000"                            // tab 0: flags, withdraw item limit
+        + new string('0', 80)                                // tabs 1-5
+        + "BFFFDD00"                                         // OldFlags
+        + "0E" + "4F666669636572");                          // name length 7 in the top 7 bits, "Officer"
+
+    private static WorldPacket FrameClientBody(byte[] body)
+    {
+        var framed = new byte[body.Length + 2];
+        body.CopyTo(framed, 2);
+        return new WorldPacket(framed);
+    }
+
+    [Fact]
+    public void Read_NativeWrathionPacket_MatchesCapturedFields()
+    {
+        using var rank = new GuildSetRankPermissions(FrameClientBody(NativeOfficer));
+        rank.Read();
+
+        Assert.Equal(1u, rank.RankID);
+        Assert.Equal(1u, rank.RankOrder);
+        Assert.Equal(0x00DDFFBFu, rank.Flags);
+        Assert.Equal(1, rank.WithdrawGoldLimit);
+        Assert.Equal(7u, rank.TabFlags[0]);
+        Assert.Equal(1u, rank.TabWithdrawItemLimit[0]);
+        Assert.All(rank.TabFlags.Skip(1), flags => Assert.Equal(0u, flags));
+        Assert.Equal(0x00DDFFBFu, rank.OldFlags);
+        Assert.Equal("Officer", rank.RankName);
+    }
+
+    [Fact]
+    public void BuildLegacyGuildRank_WritesThe335aLayout()
+    {
+        using var rank = new GuildSetRankPermissions(FrameClientBody(NativeOfficer));
+        rank.Read();
+
+        byte[] expected = Convert.FromHexString(
+            "01000000" + "BFFFDD00"                          // rank id, rights
+            + "4F666669636572" + "00"                        // "Officer\0"
+            + "01000000"                                     // gold per day
+            + "07000000" + "01000000"                        // tab 0: rights, slots per day
+            + new string('0', 80));                          // tabs 1-5
+
+        using var legacy = WorldSocket.BuildLegacyGuildRank(rank);
+        Assert.Equal(expected, legacy.GetData());
+    }
+}

--- a/HermesProxy.Tests/World/Server/LatestPerKeyCoalescerTests.cs
+++ b/HermesProxy.Tests/World/Server/LatestPerKeyCoalescerTests.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using HermesProxy.World.Server;
+using Xunit;
+
+namespace HermesProxy.Tests.World.Server;
+
+public class LatestPerKeyCoalescerTests
+{
+    [Fact]
+    public void Offer_OpensABatchOnlyForTheFirstValue()
+    {
+        var coalescer = new LatestPerKeyCoalescer<uint, string>();
+
+        Assert.True(coalescer.Offer(1, "a"));
+        Assert.False(coalescer.Offer(1, "b"));
+        Assert.False(coalescer.Offer(2, "c"));
+    }
+
+    [Fact]
+    public void Drain_KeepsTheNewestPerKey()
+    {
+        var coalescer = new LatestPerKeyCoalescer<uint, string>();
+        coalescer.Offer(1, "rank1-a");
+        coalescer.Offer(2, "rank2-a");
+        coalescer.Offer(1, "rank1-b");
+
+        var drained = coalescer.Drain(out int offered);
+
+        Assert.Equal(["rank1-b", "rank2-a"], drained.Order());
+        Assert.Equal(3, offered);
+    }
+
+    // The native capture's shape: one Apply, five packets for the same rank.
+    [Fact]
+    public void Drain_CollapsesABurstForOneKeyToItsLastValue()
+    {
+        var coalescer = new LatestPerKeyCoalescer<uint, int>();
+        for (int tabFlags = 1; tabFlags <= 5; tabFlags++)
+            coalescer.Offer(1, tabFlags);
+
+        Assert.Equal([5], coalescer.Drain(out int offered));
+        Assert.Equal(5, offered);
+    }
+
+    [Fact]
+    public void Drain_EmptiesTheBatch_SoTheNextOfferOpensANewOne()
+    {
+        var coalescer = new LatestPerKeyCoalescer<uint, string>();
+        coalescer.Offer(1, "a");
+        coalescer.Drain(out _);
+
+        Assert.Empty(coalescer.Drain(out int offered));
+        Assert.Equal(0, offered);
+        Assert.True(coalescer.Offer(1, "b"));
+    }
+}

--- a/HermesProxy/World/Logging/WorldSocketLogMessages.cs
+++ b/HermesProxy/World/Logging/WorldSocketLogMessages.cs
@@ -200,4 +200,25 @@ internal static partial class WorldSocketLogMessages
         string SourceFile,
         string NetDir,
         Opcode Opcode);
+
+    [LoggerMessage(
+        EventId = 120,
+        Level = LogLevel.Debug,
+        Message = "Forwarded {Sent} CMSG_GUILD_RANK for {Received} CMSG_GUILD_SET_RANK_PERMISSIONS from one burst")]
+    public static partial void GuildRankPermissionsCoalesced(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        int Received,
+        int Sent);
+
+    [LoggerMessage(
+        EventId = 121,
+        Level = LogLevel.Error,
+        Message = "Forwarding coalesced guild rank permissions failed")]
+    public static partial void GuildRankPermissionsFlushFailed(
+        ILogger logger,
+        string SourceFile,
+        string NetDir,
+        System.Exception exception);
 }

--- a/HermesProxy/World/Server/LatestPerKeyCoalescer.cs
+++ b/HermesProxy/World/Server/LatestPerKeyCoalescer.cs
@@ -1,0 +1,35 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace HermesProxy.World.Server;
+
+/// <summary>
+/// Keeps only the newest value per key until the batch is drained. For modern-client bursts of
+/// full-state packets about one thing, where the legacy server only needs the last one.
+/// </summary>
+internal sealed class LatestPerKeyCoalescer<TKey, TValue> where TKey : notnull
+{
+    private readonly ConcurrentDictionary<TKey, TValue> _pending = new();
+    private int _armed, _offered;
+
+    /// <returns>True for the first value since the last <see cref="Drain"/>: the caller schedules one.</returns>
+    public bool Offer(TKey key, TValue value)
+    {
+        _pending[key] = value;
+        Interlocked.Increment(ref _offered);
+        return Interlocked.Exchange(ref _armed, 1) == 0;
+    }
+
+    /// <param name="offered">How many values were offered into the batch, replaced ones included.</param>
+    public List<TValue> Drain(out int offered)
+    {
+        Interlocked.Exchange(ref _armed, 0);                // reset first: a racing Offer re-arms
+        offered = Interlocked.Exchange(ref _offered, 0);
+        var values = new List<TValue>();
+        foreach (var key in _pending.Keys)
+            if (_pending.TryRemove(key, out var latest))    // takes whatever is newest at removal
+                values.Add(latest);
+        return values;                                      // no defined order between keys
+    }
+}

--- a/HermesProxy/World/Server/PacketHandlers/GuildHandler.cs
+++ b/HermesProxy/World/Server/PacketHandlers/GuildHandler.cs
@@ -118,8 +118,62 @@ public partial class WorldSocket
         }
     }
 
+    // One Apply in the 3.4.3 guild control panel sends a CMSG_GUILD_SET_RANK_PERMISSIONS per
+    // changed setting, all in the same millisecond and each carrying the rank's complete state:
+    // a native Wrathion capture shows five for one Apply. A 3.3.5a client sends one
+    // CMSG_GUILD_RANK, and AzerothCore kicks after three in one second (antidos_opcode_policies,
+    // opcode 561). Only the last of a burst matters, so hold them briefly and forward the newest
+    // per rank. Issue #283.
+    private const int RankPermissionsCoalesceMs = 100;
+    private readonly LatestPerKeyCoalescer<uint, GuildSetRankPermissions> _pendingRankPermissions = new();
+    // Armed on the packet thread and disposed from it, the timer callback or OnClose, so every
+    // swap goes through Interlocked.
+    private System.Threading.Timer? _rankPermissionsTimer;
+
     [PacketHandler(Opcode.CMSG_GUILD_SET_RANK_PERMISSIONS)]
     void HandleGuildSetRankPermissions(GuildSetRankPermissions rank)
+    {
+        // The burst was only observed, and the fix only tested, on the 3.4.3 client.
+        if (ModernVersion.Build != ClientVersionBuild.V3_4_3_54261)
+        {
+            SendPacketToServer(BuildLegacyGuildRank(rank));
+            return;
+        }
+
+        if (_pendingRankPermissions.Offer(rank.RankID, rank))
+        {
+            var timer = new System.Threading.Timer(OnRankPermissionsDue, null, RankPermissionsCoalesceMs, System.Threading.Timeout.Infinite);
+            System.Threading.Interlocked.Exchange(ref _rankPermissionsTimer, timer)?.Dispose();
+        }
+    }
+
+    private void OnRankPermissionsDue(object? state)
+    {
+        System.Threading.Interlocked.Exchange(ref _rankPermissionsTimer, null)?.Dispose();
+        FlushRankPermissions();
+    }
+
+    private void FlushRankPermissions()
+    {
+        // Runs on a timer thread or from OnClose. An exception escaping a timer callback has no
+        // handler above it and would take the whole proxy down.
+        try
+        {
+            var ranks = _pendingRankPermissions.Drain(out int received);
+            if (ranks.Count == 0)
+                return;
+
+            WorldSocketLogMessages.GuildRankPermissionsCoalesced(_melLog, _sourceFile, _netDirRecv, received, ranks.Count);
+            foreach (var rank in ranks)
+                SendPacketToServer(BuildLegacyGuildRank(rank));
+        }
+        catch (Exception ex)
+        {
+            WorldSocketLogMessages.GuildRankPermissionsFlushFailed(_melLog, _sourceFile, _netDirRecv, ex);
+        }
+    }
+
+    internal static WorldPacket BuildLegacyGuildRank(GuildSetRankPermissions rank)
     {
         WorldPacket packet = new WorldPacket(Opcode.CMSG_GUILD_SET_RANK_PERMISSIONS);
         packet.WriteUInt32(rank.RankID);
@@ -134,7 +188,7 @@ public partial class WorldSocket
                 packet.WriteUInt32(rank.TabWithdrawItemLimit[i]);
             }
         }
-        SendPacketToServer(packet);
+        return packet;
     }
 
     [PacketHandler(Opcode.CMSG_GUILD_ADD_RANK)]

--- a/HermesProxy/World/Server/WorldSocket.cs
+++ b/HermesProxy/World/Server/WorldSocket.cs
@@ -673,6 +673,9 @@ public partial class WorldSocket : SocketBase, BnetServices.INetwork
 
     public override void OnClose()
     {
+        // A rank edit still inside its coalescing window goes out now rather than being lost.
+        System.Threading.Interlocked.Exchange(ref _rankPermissionsTimer, null)?.Dispose();
+        FlushRankPermissions();
         base.OnClose();
     }
 


### PR DESCRIPTION
## Summary

Applying guild rank permissions no longer disconnects on AzerothCore. The proxy now collapses the 3.4.3 client's burst of `CMSG_GUILD_SET_RANK_PERMISSIONS` into a single `CMSG_GUILD_RANK` per rank.

## Cause

One Apply in the 3.4.3 guild control panel sends a packet per changed setting — five in our repro, all in the same millisecond, each with the rank's full state. A native Wrathion capture shows the identical burst (2, 5 and 5 packets for three Applies), and the native server simply answers each one. A 3.3.5a client only ever sends one `CMSG_GUILD_RANK`, and AzerothCore limits that opcode: `antidos_opcode_policies` has `561 | 1 | 3`, i.e. kick after three in one world second. Forwarding the burst one to one tripped it.

TrinityCore 3.3.5a has the same limit hardcoded: `WorldSession::DosProtection::GetMaxPacketCounterAllowed` puts `CMSG_GUILD_RANK` in the group capped at 3, and the default `PacketSpoof.Policy = 1` kicks. So this was not AzerothCore-specific.

## Fix

- New `LatestPerKeyCoalescer<TKey, TValue>`: a `ConcurrentDictionary` holding the newest value per key, plus an `Interlocked` flag that reports the first value since the last drain, so exactly one timer is armed per burst. The drain clears the flag before removing entries, so an `Offer` racing it either lands in that drain or arms the next timer.
- `HandleGuildSetRankPermissions` offers each packet by `RankID`. The first packet of a burst arms a 100 ms timer; the flush forwards one `CMSG_GUILD_RANK` per pending rank.
- The timer follows the ready-check deadline pattern: swapped through `Interlocked`, and the callback catches everything so nothing can escape onto a timer thread. `OnClose` flushes anything still pending instead of dropping it.
- Gated to `V3_4_3_54261`, the only client the burst was observed on. Other builds forward immediately, as before.
- Two `[LoggerMessage]` entries (120 Debug for the flush, 121 Error for a failed one).

The send from the timer thread goes through `WorldClient.SendPacket`, which serialises on `_sendLock` — the keep-alive ping already sends from a timer thread the same way.

## Layout

The capture answers the field-order question from the issue: `OldFlags` precedes the 7-bit rank name on the wire, exactly as `GuildSetRankPermissions.Read` already does. TrinityCore `wotlk_classic` has them the other way round. No layout change was needed; a test now pins it to the captured bytes.

## Tests

- `GuildRankPermissionsTests`: parses the verbatim 76-byte packet from the Wrathion capture, and checks the 68-byte 3.3.5a `CMSG_GUILD_RANK` built from it.
- `LatestPerKeyCoalescerTests`: batch opening, newest-per-key, a five-packet burst collapsing to the last, draining.
- Full suite: 1670 pass.

## Playtest — AzerothCore playerbots, V3_4_3 → 3.3.5a

Same repro as the issue (Officer rank, several bank-tab changes, Apply):

- Proxy log: 5 × `CMSG_GUILD_SET_RANK_PERMISSIONS` in, `Forwarded 1 CMSG_GUILD_RANK for 5 CMSG_GUILD_SET_RANK_PERMISSIONS from one burst`, one 68-byte `CMSG_GUILD_RANK` out.
- The server replied with the rank-update guild event (sent on as `SMSG_GUILD_EVENT_RANKS_UPDATED`), the client refreshed ranks and roster, and the session stayed up.
- The forwarded packet carried the final state (tab 0 rights 7 / unlimited, tab 1 rights 7 / 2 per day), and `guild_bank_right` in the AzerothCore database holds exactly those values.

## Playtest — TrinityCore 3.3.5a (NPCBots build), V3_4_3 → 3.3.5a

Final build, two Applies on the Officer rank a few seconds apart:

| Apply | Received | Forwarded | Final state sent |
|---|---|---|---|
| 1 | 4 | 1 | gold/day 1, tab 0 rights 3 / 1 slot |
| 2 | 5 | 1 | gold/day 2, tab 0 rights 3 / 1, tab 1 rights 7 / 2 |

The legacy sniff holds exactly two `CMSG_GUILD_RANK`, so the timer re-armed for the second burst. The server answered each with the rank-update event, the session stayed up, and the TrinityCore `characters` database stores Apply 2's state (`BankMoneyPerDay` 2, tab 0 3/1, tab 1 7/2).

Fixes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bsz5TdvtRMNLUYLbg1AcLW
