### PR TITLE
perf(update): back UpdateMask with uint[] blocks, drop DynamicUpdateMask

### DIFF
--- a/HermesProxy.Benchmarks/CLAUDE.md
+++ b/HermesProxy.Benchmarks/CLAUDE.md
@@ -34,6 +34,7 @@ dotnet run --project HermesProxy.Benchmarks -c Release -- --list flat
 | `SendPipelineBenchmarks.cs` | `ServerPacket` construct → `WritePacketData` → framed + encrypted wire bytes, per stage |
 | `PackedGuidBenchmarks.cs` | `WorldPacket` vs `PackedGuidHelper` packed-GUID encode/decode |
 | `MovementHandlerPrologueBenchmarks.cs` | `HandlePlayerMove` opcode translation: string/reflection round trip vs the prebuilt map |
+| `UpdateMaskBenchmarks.cs` | V1_14/V2_5 `UpdateFieldsArray` / `DynamicUpdateFieldsArray` write path vs the previous `BitArray`-backed mask (verbatim `Legacy*` copies) |
 
 ## Conventions
 

--- a/HermesProxy.Benchmarks/UpdateMaskBenchmarks.cs
+++ b/HermesProxy.Benchmarks/UpdateMaskBenchmarks.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Framework.IO;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+
+namespace HermesProxy.Benchmarks;
+
+// The V1_14/V2_5 flat update-field path, side by side with the BitArray-backed UpdateMask it
+// replaced (verbatim copies at the bottom of this file). Each iteration is what a cached-object
+// Values update does: clear the mask, dirty a few fields, serialize.
+// FieldCount covers the V1_14_1 Item (80), Unit (218) and ActivePlayer (4674) arrays.
+[MemoryDiagnoser]
+[ShortRunJob]
+public class UpdateFieldsWriteBenchmarks
+{
+    private const int DirtyFields = 16;
+
+    [Params(80, 218, 4674)]
+    public int FieldCount;
+
+    private int[] _dirty = null!;
+    private UpdateFieldsArray _fields = null!;
+    private LegacyUpdateFieldsArray _legacy = null!;
+    private ByteBuffer _packet = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var rng = new Random(42);
+        _dirty = Enumerable.Range(0, FieldCount).OrderBy(_ => rng.Next()).Take(DirtyFields).Order().ToArray();
+        _fields = new UpdateFieldsArray((uint)FieldCount);
+        _legacy = new LegacyUpdateFieldsArray((uint)FieldCount);
+        foreach (var index in _dirty)
+        {
+            _fields.m_updateValues[index].UnsignedValue = (uint)index * 7 + 1;
+            _legacy.Values[index].UnsignedValue = (uint)index * 7 + 1;
+        }
+        _packet = new ByteBuffer();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _packet.Dispose();
+
+    [Benchmark(Baseline = true)]
+    public uint Legacy_ClearSetWrite()
+    {
+        _packet.Clear();
+        _legacy.Mask.Clear();
+        foreach (var index in _dirty)
+            _legacy.Mask.SetBit(index);
+        _legacy.WriteToPacket(_packet);
+        return _packet.GetSize();
+    }
+
+    [Benchmark]
+    public uint ClearSetWrite()
+    {
+        _packet.Clear();
+        _fields.m_updateMask.Clear();
+        foreach (var index in _dirty)
+            _fields.m_updateMask.SetBit(index);
+        _fields.WriteToPacket(_packet);
+        return _packet.GetSize();
+    }
+}
+
+// Every V1_14/V2_5 ObjectUpdateBuilder constructs a DynamicUpdateFieldsArray and serializes it.
+// None is the common case (no dynamic field touched); ChannelObject is the WowGuid128 generic
+// path (UNIT_DYNAMIC_FIELD_CHANNEL_OBJECTS); Gems is the largest array the builders write (30).
+[MemoryDiagnoser]
+[ShortRunJob]
+public class DynamicUpdateFieldsBenchmarks
+{
+    public enum Scenario { None, ChannelObject, Gems }
+
+    [Params(Scenario.None, Scenario.ChannelObject, Scenario.Gems)]
+    public Scenario Case;
+
+    private readonly WowGuid128 _guid = new(0x1122334455667788, 0xAABBCCDDEEFF0011);
+    private uint[] _gems = null!;
+    private ByteBuffer _packet = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _gems = new uint[30];
+        _gems[0] = 41401;
+        _gems[10] = 41398;
+        _gems[20] = 40111;
+        _packet = new ByteBuffer();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _packet.Dispose();
+
+    [Benchmark(Baseline = true)]
+    public uint Legacy_BuildAndWrite()
+    {
+        _packet.Clear();
+        var fields = new LegacyDynamicUpdateFieldsArray(18, UpdateTypeModern.Values);
+        switch (Case)
+        {
+            case Scenario.ChannelObject:
+                fields.SetUpdateField(2, _guid, DynamicFieldChangeType.ValueAndSizeChanged);
+                break;
+            case Scenario.Gems:
+                fields.SetUpdateField(3, _gems, DynamicFieldChangeType.ValueAndSizeChanged);
+                break;
+        }
+        fields.WriteToPacket(_packet);
+        return _packet.GetSize();
+    }
+
+    [Benchmark]
+    public uint BuildAndWrite()
+    {
+        _packet.Clear();
+        var fields = new DynamicUpdateFieldsArray(18, UpdateTypeModern.Values);
+        switch (Case)
+        {
+            case Scenario.ChannelObject:
+                fields.SetUpdateField<WowGuid128>(2, _guid, DynamicFieldChangeType.ValueAndSizeChanged);
+                break;
+            case Scenario.Gems:
+                fields.SetUpdateField(3, _gems, DynamicFieldChangeType.ValueAndSizeChanged);
+                break;
+        }
+        fields.WriteToPacket(_packet);
+        return _packet.GetSize();
+    }
+}
+
+// Verbatim copies of the pre-change UpdateMask, DynamicUpdateMask and the two write paths that
+// used them; only the WowGuid128 branch of the generic dynamic setter is kept.
+internal class LegacyUpdateMask
+{
+    public LegacyUpdateMask(uint valuesCount = 0)
+    {
+        _fieldCount = valuesCount;
+        _blockCount = (valuesCount + 32 - 1) / 32;
+
+        _mask = new BitArray((int)valuesCount, false);
+    }
+
+    public void SetCount(int valuesCount)
+    {
+        _fieldCount = (uint)valuesCount;
+        _blockCount = (uint)(valuesCount + 32 - 1) / 32;
+
+        _mask = new BitArray(valuesCount, false);
+    }
+
+    public virtual void AppendToPacket(ByteBuffer data)
+    {
+        data.WriteUInt8((byte)_blockCount);
+        var maskArray = new byte[_blockCount << 2];
+
+        _mask.CopyTo(maskArray, 0);
+        data.WriteBytes(maskArray);
+    }
+
+    public bool GetBit(int index) => _mask.Get(index);
+
+    public void SetBit(int index) => _mask.Set(index, true);
+
+    public void Clear() => _mask.SetAll(false);
+
+    uint _fieldCount;
+    protected uint _blockCount;
+    protected BitArray _mask;
+}
+
+internal sealed class LegacyDynamicUpdateMask : LegacyUpdateMask
+{
+    public LegacyDynamicUpdateMask(uint valuesCount) : base(valuesCount) { }
+
+    public void EncodeDynamicFieldChangeType(DynamicFieldChangeType changeType, UpdateTypeModern updateType)
+    {
+        DynamicFieldChangeType = (uint)(_blockCount | ((uint)(changeType & HermesProxy.World.Objects.DynamicFieldChangeType.ValueAndSizeChanged) * ((3 - (int)updateType) / 3)));
+    }
+
+    public override void AppendToPacket(ByteBuffer data)
+    {
+        data.WriteUInt16((ushort)DynamicFieldChangeType);
+        if (ValueCount != null)
+            data.WriteInt32((int)ValueCount);
+
+        var maskArray = new byte[_blockCount << 2];
+
+        _mask.CopyTo(maskArray, 0);
+        data.WriteBytes(maskArray);
+    }
+
+    public uint DynamicFieldChangeType;
+    public int? ValueCount;
+}
+
+internal sealed class LegacyUpdateFieldsArray
+{
+    public LegacyUpdateFieldsArray(uint size)
+    {
+        ValuesCount = size;
+        Values = new UpdateValues[size];
+        Mask = new LegacyUpdateMask(size);
+    }
+
+    public readonly uint ValuesCount;
+    public readonly UpdateValues[] Values;
+    public readonly LegacyUpdateMask Mask;
+
+    public void WriteToPacket(ByteBuffer buffer)
+    {
+        var fieldBuffer = new ByteBuffer();
+        for (var index = 0; index < ValuesCount; ++index)
+        {
+            if (Mask.GetBit(index))
+            {
+                fieldBuffer.WriteUInt32(Values[index].UnsignedValue);
+            }
+        }
+        Mask.AppendToPacket(buffer);
+        buffer.WriteBytes(fieldBuffer);
+    }
+}
+
+internal sealed class LegacyDynamicUpdateFieldsArray
+{
+    public LegacyDynamicUpdateFieldsArray(uint size, UpdateTypeModern updateType)
+    {
+        m_updateType = updateType;
+        m_updateMask = new LegacyUpdateMask(size);
+        m_fieldBuffer = new();
+    }
+
+    readonly UpdateTypeModern m_updateType;
+    readonly LegacyUpdateMask m_updateMask;
+    readonly ByteBuffer m_fieldBuffer;
+
+    public void WriteToPacket(ByteBuffer buffer)
+    {
+        m_updateMask.AppendToPacket(buffer);
+        buffer.WriteBytes(m_fieldBuffer);
+    }
+
+    public void SetUpdateField(int index, uint[] values, DynamicFieldChangeType changeType)
+    {
+        var valueBuffer = new ByteBuffer();
+        m_updateMask.SetBit(index);
+
+        var arrayMask = new LegacyDynamicUpdateMask((uint)values.Length);
+        arrayMask.EncodeDynamicFieldChangeType(changeType, m_updateType);
+        if (m_updateType == UpdateTypeModern.Values && changeType == DynamicFieldChangeType.ValueAndSizeChanged)
+        {
+            arrayMask.ValueCount = values.Length;
+            arrayMask.SetCount(values.Length);
+        }
+
+        for (var v = 0; v < values.Length; ++v)
+        {
+            arrayMask.SetBit(v);
+            valueBuffer.WriteUInt32(values[v]);
+        }
+
+        arrayMask.AppendToPacket(m_fieldBuffer);
+        m_fieldBuffer.WriteBytes(valueBuffer);
+    }
+
+    public void SetUpdateField(object index, WowGuid128 guid, DynamicFieldChangeType changeType)
+    {
+        uint[] values = new uint[4];
+        values[0] = (uint)guid.GetLowValue();
+        values[1] = (uint)(guid.GetLowValue() >> 32);
+        values[2] = (uint)guid.GetHighValue();
+        values[3] = (uint)(guid.GetHighValue() >> 32);
+        SetUpdateField((int)index, values, changeType);
+    }
+}

--- a/HermesProxy.Tests/World/UpdateMaskWireTests.cs
+++ b/HermesProxy.Tests/World/UpdateMaskWireTests.cs
@@ -1,0 +1,418 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Framework.IO;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Objects;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+// The outbound UpdateMask used to be backed by System.Collections.BitArray. The oracle
+// reimplements that version's serialization so these tests pin the V1_14/V2_5 wire bytes to what
+// it produced, independent of whatever block math the current implementation uses.
+internal static class LegacyUpdateMaskOracle
+{
+    public static int BlockCount(int fieldCount) => (fieldCount + 31) / 32;
+
+    public static byte[] MaskBytes(int fieldCount, IEnumerable<int> setBits)
+    {
+        var mask = new BitArray(fieldCount);
+        foreach (var bit in setBits)
+            mask.Set(bit, true);
+
+        var bytes = new byte[BlockCount(fieldCount) * 4];
+        mask.CopyTo(bytes, 0);
+        return bytes;
+    }
+
+    public static byte[] AppendToPacket(int fieldCount, IEnumerable<int> setBits)
+    {
+        var mask = MaskBytes(fieldCount, setBits);
+        var result = new byte[1 + mask.Length];
+        result[0] = (byte)BlockCount(fieldCount);
+        mask.CopyTo(result, 1);
+        return result;
+    }
+
+    // One DynamicUpdateFieldsArray entry as DynamicUpdateMask + the value loop wrote it,
+    // including the original change-type expression.
+    public static byte[] DynamicEntry(uint[] values, DynamicFieldChangeType changeType, UpdateTypeModern updateType)
+    {
+        var blockCount = (uint)BlockCount(values.Length);
+        var header = (uint)(blockCount | ((uint)(changeType & DynamicFieldChangeType.ValueAndSizeChanged) * ((3 - (int)updateType) / 3)));
+
+        return Capture(buffer =>
+        {
+            buffer.WriteUInt16((ushort)header);
+            if (updateType == UpdateTypeModern.Values && changeType == DynamicFieldChangeType.ValueAndSizeChanged)
+                buffer.WriteInt32(values.Length);
+            buffer.WriteBytes(MaskBytes(values.Length, Enumerable.Range(0, values.Length)));
+            foreach (var value in values)
+                buffer.WriteUInt32(value);
+        });
+    }
+
+    public static byte[] Capture(Action<ByteBuffer> write)
+    {
+        using var buffer = new ByteBuffer();
+        write(buffer);
+        return buffer.GetData();
+    }
+
+    public static byte[] Concat(params byte[][] parts) => parts.SelectMany(p => p).ToArray();
+
+    public static byte[] UInt32s(IEnumerable<uint> values) => Capture(buffer =>
+    {
+        foreach (var value in values)
+            buffer.WriteUInt32(value);
+    });
+}
+
+public class UpdateMaskWireTests
+{
+    private static readonly double[] Densities = [0.0, 0.05, 0.5, 1.0];
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(8)]
+    [InlineData(31)]
+    [InlineData(32)]
+    [InlineData(33)]
+    [InlineData(63)]
+    [InlineData(64)]
+    [InlineData(65)]
+    [InlineData(80)]    // V1_14_1 ITEM_END
+    [InlineData(218)]   // V1_14_1 UNIT_END
+    [InlineData(760)]   // V1_14_1 PLAYER_END
+    [InlineData(4674)]  // V1_14_1 ACTIVE_PLAYER_END
+    public void AppendToPacket_RandomBits_MatchesBitArrayLayout(int fieldCount)
+    {
+        foreach (var density in Densities)
+        {
+            var rng = new Random(fieldCount * 31 + (int)(density * 100));
+            var bits = Enumerable.Range(0, fieldCount).Where(_ => rng.NextDouble() < density).ToArray();
+            var mask = new UpdateMask((uint)fieldCount);
+            foreach (var bit in bits)
+                mask.SetBit(bit);
+
+            var actual = LegacyUpdateMaskOracle.Capture(mask.AppendToPacket);
+
+            Assert.Equal(LegacyUpdateMaskOracle.AppendToPacket(fieldCount, bits), actual);
+        }
+    }
+
+    [Fact]
+    public void AppendToPacket_EachBitAlone_MatchesBitArrayLayout()
+    {
+        const int fieldCount = 97;
+        for (var bit = 0; bit < fieldCount; ++bit)
+        {
+            var mask = new UpdateMask(fieldCount);
+            mask.SetBit(bit);
+
+            var actual = LegacyUpdateMaskOracle.Capture(mask.AppendToPacket);
+
+            Assert.Equal(LegacyUpdateMaskOracle.AppendToPacket(fieldCount, [bit]), actual);
+        }
+    }
+
+    [Fact]
+    public void GetBit_AfterSetBit_OnlyThatBitIsSet()
+    {
+        var mask = new UpdateMask(100);
+
+        mask.SetBit(33);
+
+        for (var i = 0; i < 100; ++i)
+            Assert.Equal(i == 33, mask.GetBit(i));
+    }
+
+    [Fact]
+    public void Clear_AfterSettingBits_WritesEmptyMask()
+    {
+        var mask = new UpdateMask(4674);
+        mask.SetBit(0);
+        mask.SetBit(31);
+        mask.SetBit(32);
+        mask.SetBit(4673);
+
+        mask.Clear();
+
+        Assert.False(mask.GetBit(0));
+        Assert.False(mask.GetBit(4673));
+        Assert.Equal(LegacyUpdateMaskOracle.AppendToPacket(4674, []), LegacyUpdateMaskOracle.Capture(mask.AppendToPacket));
+    }
+
+    [Fact]
+    public void GetCount_ReturnsFieldCount()
+    {
+        Assert.Equal(218u, new UpdateMask(218).GetCount());
+    }
+
+    // 33 fields leave 31 spare bits in the second block; the bound is the field count, as it
+    // was with BitArray, not the block capacity.
+    [Theory]
+    [InlineData(33)]
+    [InlineData(63)]
+    [InlineData(-1)]
+    public void SetBit_OutsideFieldCount_Throws(int index)
+    {
+        var mask = new UpdateMask(33);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => mask.SetBit(index));
+    }
+
+    [Theory]
+    [InlineData(33)]
+    [InlineData(63)]
+    [InlineData(-1)]
+    public void GetBit_OutsideFieldCount_Throws(int index)
+    {
+        var mask = new UpdateMask(33);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => mask.GetBit(index));
+    }
+}
+
+public class UpdateFieldsArrayWireTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(32)]
+    [InlineData(33)]
+    [InlineData(80)]
+    [InlineData(218)]
+    [InlineData(4674)]
+    public void WriteToPacket_RandomDirtyFields_MatchesBitArrayLayout(int fieldCount)
+    {
+        var rng = new Random(fieldCount);
+        var fields = new UpdateFieldsArray((uint)fieldCount);
+        var dirty = new SortedDictionary<int, uint>();
+        for (var n = 0; n < Math.Max(1, fieldCount / 10); ++n)
+        {
+            var index = rng.Next(fieldCount);
+            var value = (uint)rng.Next() | 1u;
+            fields.SetUpdateField<uint>(index, value);
+            dirty[index] = value;
+        }
+
+        var actual = LegacyUpdateMaskOracle.Capture(fields.WriteToPacket);
+
+        var expected = LegacyUpdateMaskOracle.Concat(
+            LegacyUpdateMaskOracle.AppendToPacket(fieldCount, dirty.Keys),
+            LegacyUpdateMaskOracle.UInt32s(dirty.Values));
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void WriteToPacket_FieldsInLastPartialBlock_WrittenInIndexOrder()
+    {
+        var fields = new UpdateFieldsArray(70);
+        fields.SetUpdateField<uint>(69, 0x69u);
+        fields.SetUpdateField<uint>(64, 0x64u);
+        fields.SetUpdateField<uint>(31, 0x31u);
+        fields.SetUpdateField<uint>(0, 0x01u);
+
+        var actual = LegacyUpdateMaskOracle.Capture(fields.WriteToPacket);
+
+        var expected = LegacyUpdateMaskOracle.Concat(
+            LegacyUpdateMaskOracle.AppendToPacket(70, [0, 31, 64, 69]),
+            LegacyUpdateMaskOracle.UInt32s([0x01u, 0x31u, 0x64u, 0x69u]));
+        Assert.Equal(expected, actual);
+    }
+
+    // The V1_14/V2_5 builders reuse a cached UpdateFieldsArray and Clear() its mask per update:
+    // values stay, only the fields touched since the clear go out.
+    [Fact]
+    public void WriteToPacket_AfterMaskClear_WritesOnlyFieldsSetSinceClear()
+    {
+        var fields = new UpdateFieldsArray(218);
+        fields.SetUpdateField<uint>(10, 100u);
+        fields.SetUpdateField<uint>(20, 200u);
+        fields.m_updateMask.Clear();
+
+        fields.SetUpdateField<uint>(20, 201u);
+        var actual = LegacyUpdateMaskOracle.Capture(fields.WriteToPacket);
+
+        var expected = LegacyUpdateMaskOracle.Concat(
+            LegacyUpdateMaskOracle.AppendToPacket(218, [20]),
+            LegacyUpdateMaskOracle.UInt32s([201u]));
+        Assert.Equal(expected, actual);
+        Assert.Equal(100u, fields.GetUpdateField<uint>(10));
+    }
+
+    [Fact]
+    public void WriteToPacket_CalledTwice_WritesSameBytes()
+    {
+        var fields = new UpdateFieldsArray(80);
+        fields.SetUpdateField(4, new WowGuid128(0x1122334455667788, 0xAABBCCDDEEFF0011));
+
+        var first = LegacyUpdateMaskOracle.Capture(fields.WriteToPacket);
+        var second = LegacyUpdateMaskOracle.Capture(fields.WriteToPacket);
+
+        Assert.Equal(first, second);
+    }
+}
+
+public class DynamicUpdateFieldsArrayWireTests
+{
+    public static TheoryData<int, DynamicFieldChangeType, UpdateTypeModern> Cases()
+    {
+        var data = new TheoryData<int, DynamicFieldChangeType, UpdateTypeModern>();
+        foreach (var count in new[] { 0, 1, 2, 4, 30, 31, 32, 33, 64, 65 })
+            foreach (var changeType in Enum.GetValues<DynamicFieldChangeType>())
+                foreach (var updateType in Enum.GetValues<UpdateTypeModern>())
+                    data.Add(count, changeType, updateType);
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void SetUpdateField_ValueArray_MatchesDynamicUpdateMaskLayout(int valueCount, DynamicFieldChangeType changeType, UpdateTypeModern updateType)
+    {
+        const int fieldCount = 18;  // V1_14_1 ACTIVE_PLAYER_DYNAMIC_END
+        const int index = 13;
+        var values = Enumerable.Range(0, valueCount).Select(i => 0xA0000000u | (uint)i).ToArray();
+        var fields = new DynamicUpdateFieldsArray(fieldCount, updateType);
+
+        fields.SetUpdateField(index, values, changeType);
+        var actual = LegacyUpdateMaskOracle.Capture(fields.WriteToPacket);
+
+        var expected = LegacyUpdateMaskOracle.Concat(
+            LegacyUpdateMaskOracle.AppendToPacket(fieldCount, [index]),
+            LegacyUpdateMaskOracle.DynamicEntry(values, changeType, updateType));
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void SetUpdateField_TwoFields_EntriesInCallOrder()
+    {
+        var gems = new uint[30];
+        gems[0] = 1; gems[10] = 2; gems[20] = 3;
+        var fields = new DynamicUpdateFieldsArray(18, UpdateTypeModern.Values);
+
+        fields.SetUpdateField(10, new uint[] { 7, 8 }, DynamicFieldChangeType.ValueChanged);
+        fields.SetUpdateField(3, gems, DynamicFieldChangeType.ValueAndSizeChanged);
+        var actual = LegacyUpdateMaskOracle.Capture(fields.WriteToPacket);
+
+        var expected = LegacyUpdateMaskOracle.Concat(
+            LegacyUpdateMaskOracle.AppendToPacket(18, [3, 10]),
+            LegacyUpdateMaskOracle.DynamicEntry([7, 8], DynamicFieldChangeType.ValueChanged, UpdateTypeModern.Values),
+            LegacyUpdateMaskOracle.DynamicEntry(gems, DynamicFieldChangeType.ValueAndSizeChanged, UpdateTypeModern.Values));
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void WriteToPacket_NoFieldsSet_WritesEmptyMaskOnly()
+    {
+        var fields = new DynamicUpdateFieldsArray(18, UpdateTypeModern.Values);
+
+        var actual = LegacyUpdateMaskOracle.Capture(fields.WriteToPacket);
+
+        Assert.Equal(LegacyUpdateMaskOracle.AppendToPacket(18, []), actual);
+    }
+
+    [Fact]
+    public void SetUpdateFieldGeneric_EachType_MatchesValueArrayOverload()
+    {
+        var guid = new WowGuid128(0x1122334455667788, 0xAABBCCDDEEFF0011);
+        AssertGenericMatches(-5, [unchecked((uint)-5)]);
+        AssertGenericMatches(0xDEADBEEFu, [0xDEADBEEFu]);
+        AssertGenericMatches(3.5f, [BitConverter.SingleToUInt32Bits(3.5f)]);
+        AssertGenericMatches(0x123456789ABCDEF0ul, [0x9ABCDEF0u, 0x12345678u]);
+        AssertGenericMatches(guid,
+        [
+            (uint)guid.GetLowValue(), (uint)(guid.GetLowValue() >> 32),
+            (uint)guid.GetHighValue(), (uint)(guid.GetHighValue() >> 32),
+        ]);
+    }
+
+    private static void AssertGenericMatches<T>(T value, uint[] expectedValues) where T : new()
+    {
+        var generic = new DynamicUpdateFieldsArray(3, UpdateTypeModern.Values);
+        generic.SetUpdateField(2, value, DynamicFieldChangeType.ValueAndSizeChanged);
+
+        var expected = LegacyUpdateMaskOracle.Concat(
+            LegacyUpdateMaskOracle.AppendToPacket(3, [2]),
+            LegacyUpdateMaskOracle.DynamicEntry(expectedValues, DynamicFieldChangeType.ValueAndSizeChanged, UpdateTypeModern.Values));
+        Assert.Equal(expected, LegacyUpdateMaskOracle.Capture(generic.WriteToPacket));
+    }
+}
+
+// Each Values update on the V1_14/V2_5 path goes through these. The BitArray version allocated
+// on every call: a temp ByteBuffer, its GetData() copy and the mask byte[] per WriteToPacket;
+// per dynamic field a DynamicUpdateMask with two BitArrays, a temp ByteBuffer, its copy, the mask
+// byte[] and, on the generic path, the uint[] of values.
+public class UpdateMaskAllocationTests
+{
+    private static long AllocatedBy(Action action)
+    {
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        action();
+        return GC.GetAllocatedBytesForCurrentThread() - before;
+    }
+
+    [Fact]
+    public void UpdateFieldsArrayClearSetWrite_WarmPacket_AllocatesNothing()
+    {
+        const int fieldCount = 4674;  // V1_14_1 ACTIVE_PLAYER_END
+        var fields = new UpdateFieldsArray(fieldCount);
+        for (var index = 0; index < fieldCount; index += 300)
+            fields.SetUpdateField<uint>(index, (uint)index + 1);
+        using var packet = new ByteBuffer();
+        fields.WriteToPacket(packet);
+        packet.Clear();
+
+        var allocated = AllocatedBy(() =>
+        {
+            fields.m_updateMask.Clear();
+            for (var index = 0; index < fieldCount; index += 300)
+                fields.m_updateMask.SetBit(index);
+            fields.WriteToPacket(packet);
+        });
+
+        Assert.Equal(0, allocated);
+    }
+
+    [Fact]
+    public void DynamicSetUpdateFieldGenericAndWrite_BufferRented_AllocatesNothing()
+    {
+        var guid = new WowGuid128(0x1122334455667788, 0xAABBCCDDEEFF0011);
+        // Builders pass the field index as a boxed enum; box it once, outside the measurement.
+        object channelIndex = 2;
+        using var packet = new ByteBuffer();
+        var warmup = new DynamicUpdateFieldsArray(18, UpdateTypeModern.Values);
+        warmup.SetUpdateField(channelIndex, guid, DynamicFieldChangeType.ValueAndSizeChanged);
+        warmup.WriteToPacket(packet);
+        packet.Clear();
+
+        var fields = new DynamicUpdateFieldsArray(18, UpdateTypeModern.Values);
+        fields.SetUpdateField(3, new uint[30], DynamicFieldChangeType.ValueAndSizeChanged);
+
+        var allocated = AllocatedBy(() =>
+        {
+            fields.SetUpdateField(channelIndex, guid, DynamicFieldChangeType.ValueAndSizeChanged);
+            fields.WriteToPacket(packet);
+        });
+
+        Assert.Equal(0, allocated);
+    }
+
+    [Fact]
+    public void DynamicWriteToPacket_NoFieldSet_AllocatesNothing()
+    {
+        using var packet = new ByteBuffer();
+        new DynamicUpdateFieldsArray(18, UpdateTypeModern.Values).WriteToPacket(packet);
+        packet.Clear();
+        var fields = new DynamicUpdateFieldsArray(18, UpdateTypeModern.Values);
+
+        var allocated = AllocatedBy(() => fields.WriteToPacket(packet));
+
+        Assert.Equal(0, allocated);
+    }
+}

--- a/HermesProxy/World/Objects/UpdateFieldsArray.cs
+++ b/HermesProxy/World/Objects/UpdateFieldsArray.cs
@@ -37,16 +37,16 @@ public class UpdateFieldsArray
 
     public void WriteToPacket(ByteBuffer buffer)
     {
-        var fieldBuffer = new ByteBuffer();
-        for (var index = 0; index < ValuesCount; ++index)
-        {
-            if (m_updateMask.GetBit(index))
-            {
-                fieldBuffer.WriteUInt32(m_updateValues[index].UnsignedValue);
-            }
-        }
         m_updateMask.AppendToPacket(buffer);
-        buffer.WriteBytes(fieldBuffer);
+
+        // Values follow the mask in ascending field order; walking set bits skips clean blocks,
+        // which is most of a 4674-field ActivePlayer array on a typical Values update.
+        var blocks = m_updateMask.Blocks;
+        for (var block = 0; block < blocks.Length; ++block)
+        {
+            for (var bits = blocks[block]; bits != 0; bits &= bits - 1)
+                buffer.WriteUInt32(m_updateValues[(block << 5) + BitOperations.TrailingZeroCount(bits)].UnsignedValue);
+        }
     }
 
     public void SetUpdateField<T>(object index, T value, byte offset = 0) where T : new()
@@ -293,86 +293,78 @@ public class DynamicUpdateFieldsArray
 {
     public DynamicUpdateFieldsArray(uint size, UpdateTypeModern updateType)
     {
-        ValuesCount = size;
         m_updateType = updateType;
         m_updateMask = new UpdateMask(size);
-        m_fieldBuffer = new();
     }
-    uint ValuesCount;
     UpdateTypeModern m_updateType;
     UpdateMask m_updateMask;
-    ByteBuffer m_fieldBuffer;
+    // Every builder constructs one of these, but most updates set no dynamic field — only rent
+    // the pooled buffer once one does.
+    ByteBuffer? m_fieldBuffer;
 
     public void WriteToPacket(ByteBuffer buffer)
     {
         m_updateMask.AppendToPacket(buffer);
-        buffer.WriteBytes(m_fieldBuffer);
+        if (m_fieldBuffer != null)
+            buffer.WriteBytes(m_fieldBuffer.GetDataSpan());
     }
 
-    public void SetUpdateField(int index, uint[] values, DynamicFieldChangeType changeType)
+    public void SetUpdateField(int index, ReadOnlySpan<uint> values, DynamicFieldChangeType changeType)
     {
-        var valueBuffer = new ByteBuffer();
         m_updateMask.SetBit(index);
+        var data = m_fieldBuffer ??= new ByteBuffer();
 
-        var arrayMask = new DynamicUpdateMask((uint)values.Length);
-        arrayMask.EncodeDynamicFieldChangeType(changeType, m_updateType);
-        if (m_updateType == UpdateTypeModern.Values && changeType == DynamicFieldChangeType.ValueAndSizeChanged)
-        {
-            arrayMask.ValueCount = values.Length;
-            arrayMask.SetCount(values.Length);
-        } 
+        // The size-changed flag and explicit count only exist on Values updates; creates always
+        // carry the full array.
+        var blockCount = UpdateMask.BlockCount(values.Length);
+        var sizeChanged = m_updateType == UpdateTypeModern.Values && changeType == DynamicFieldChangeType.ValueAndSizeChanged;
+        data.WriteUInt16((ushort)(sizeChanged ? blockCount | (int)DynamicFieldChangeType.ValueAndSizeChanged : blockCount));
+        if (sizeChanged)
+            data.WriteInt32(values.Length);
 
-        for (var v = 0; v < values.Length; ++v)
-        {
-            arrayMask.SetBit(v);
-            valueBuffer.WriteUInt32(values[v]);
-        }
+        // Every element is sent, so the element mask is all ones up to values.Length.
+        for (var remaining = values.Length; remaining > 0; remaining -= 32)
+            data.WriteUInt32(remaining >= 32 ? uint.MaxValue : (1u << remaining) - 1);
 
-        arrayMask.AppendToPacket(m_fieldBuffer);
-        m_fieldBuffer.WriteBytes(valueBuffer);
+        UpdateMask.WriteUInt32s(data, values);
     }
 
     public void SetUpdateField<T>(object index, T value, DynamicFieldChangeType changeType) where T : new()
     {
+        Span<uint> values = stackalloc uint[4];
+        int count;
         if (value is int intValue)
         {
-            uint[] values = new uint[1];
-            UpdateValues union = new();
-            union.SignedValue = intValue;
-            values[0] = union.UnsignedValue;
-            SetUpdateField((int)index, values, changeType);
+            values[0] = new UpdateValues { SignedValue = intValue }.UnsignedValue;
+            count = 1;
         }
         else if (value is uint uintValue)
         {
-            uint[] values = new uint[1];
             values[0] = uintValue;
-            SetUpdateField((int)index, values, changeType);
+            count = 1;
         }
         else if (value is float floatValue)
         {
-            uint[] values = new uint[1];
-            UpdateValues union = new();
-            union.FloatValue = floatValue;
-            values[0] = union.UnsignedValue;
-            SetUpdateField((int)index, values, changeType);
+            values[0] = new UpdateValues { FloatValue = floatValue }.UnsignedValue;
+            count = 1;
         }
         else if (value is ulong ulongValue)
         {
-            uint[] values = new uint[2];
             values[0] = MathFunctions.Pair64_LoPart(ulongValue);
             values[1] = MathFunctions.Pair64_HiPart(ulongValue);
-            SetUpdateField((int)index, values, changeType);
+            count = 2;
         }
         else if (value is WowGuid128 guid)
         {
-            uint[] values = new uint[4];
             values[0] = MathFunctions.Pair64_LoPart(guid.GetLowValue());
             values[1] = MathFunctions.Pair64_HiPart(guid.GetLowValue());
             values[2] = MathFunctions.Pair64_LoPart(guid.GetHighValue());
             values[3] = MathFunctions.Pair64_HiPart(guid.GetHighValue());
-            SetUpdateField((int)index, values, changeType);
+            count = 4;
         }
         else
             throw new Exception($"Unhandled type {typeof(T).Name} in SetUpdateField!");
+
+        SetUpdateField((int)index, values[..count], changeType);
     }
 }

--- a/HermesProxy/World/Objects/UpdateMask.cs
+++ b/HermesProxy/World/Objects/UpdateMask.cs
@@ -1,91 +1,81 @@
-﻿using Framework.IO;
-using HermesProxy.World.Enums;
+using Framework.IO;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace HermesProxy.World.Objects;
 
-public class UpdateMask
+// Dirty-field mask for the V1_14/V2_5 flat update-field path. Same block math as
+// Framework.Util.StackBitMask, but heap-backed: it accumulates across SetUpdateField calls and is
+// cached with its UpdateFieldsArray in ObjectCacheModern, which a ref struct cannot be.
+// Block j bit k written little-endian lands at byte 4j + k/8, bit k%8 — the layout the previous
+// BitArray.CopyTo(byte[]) implementation produced.
+public sealed class UpdateMask
 {
-    public UpdateMask(uint valuesCount = 0)
+    private readonly uint[] _blocks;
+    private readonly uint _fieldCount;
+
+    public UpdateMask(uint valuesCount)
     {
         _fieldCount = valuesCount;
-        _blockCount = (valuesCount + 32 - 1) / 32;
-
-        _mask = new BitArray((int)valuesCount, false);
-    }
-
-    public void SetCount(int valuesCount)
-    {
-        _fieldCount = (uint)valuesCount;
-        _blockCount = (uint)(valuesCount + 32 - 1) / 32;
-
-        _mask = new BitArray(valuesCount, false);
+        _blocks = new uint[BlockCount((int)valuesCount)];
     }
 
     public uint GetCount() { return _fieldCount; }
 
-    public virtual void AppendToPacket(ByteBuffer data)
-    {
-        data.WriteUInt8((byte)_blockCount);
-        var maskArray = new byte[_blockCount << 2];
+    public ReadOnlySpan<uint> Blocks => _blocks;
 
-        _mask.CopyTo(maskArray, 0);
-        data.WriteBytes(maskArray);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int BlockCount(int fieldCount) => (fieldCount + 31) >> 5;
+
+    public void AppendToPacket(ByteBuffer data)
+    {
+        data.WriteUInt8((byte)_blocks.Length);
+        WriteUInt32s(data, _blocks);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool GetBit(int index)
     {
-        return _mask.Get(index);
+        CheckIndex(index);
+        return (_blocks[index >> 5] & (1u << (index & 31))) != 0;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SetBit(int index)
     {
-        _mask.Set(index, true);
+        CheckIndex(index);
+        _blocks[index >> 5] |= 1u << (index & 31);
     }
 
-    void UnsetBit(int index)
+    public void Clear() => Array.Clear(_blocks);
+
+    // The wire wants little-endian uint32s, which on a little-endian host are the span's own bytes.
+    internal static void WriteUInt32s(ByteBuffer data, ReadOnlySpan<uint> values)
     {
-        _mask.Set(index, false);
+        if (BitConverter.IsLittleEndian)
+        {
+            data.WriteBytes(MemoryMarshal.AsBytes(values));
+            return;
+        }
+
+        foreach (var value in values)
+            data.WriteUInt32(value);
     }
 
-    public void Clear()
+    // BitArray bounded indices by its length; the last block's spare bits must stay unreachable
+    // or a stray SetBit would put a field on the wire that has no value behind it.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void CheckIndex(int index)
     {
-        _mask.SetAll(false);
+        if ((uint)index >= _fieldCount)
+            ThrowIndexOutOfRange(index);
     }
 
-    uint _fieldCount;
-    protected uint _blockCount;
-    protected BitArray _mask;
-}
-
-public class DynamicUpdateMask : UpdateMask
-{
-    public DynamicUpdateMask(uint valuesCount) : base(valuesCount) { }
-
-    public void EncodeDynamicFieldChangeType(DynamicFieldChangeType changeType, UpdateTypeModern updateType)
-    {
-        DynamicFieldChangeType = (uint)(_blockCount | ((uint)(changeType & HermesProxy.World.Objects.DynamicFieldChangeType.ValueAndSizeChanged) * ((3 - (int)updateType /*this part evaluates to 0 if update type is not VALUES*/) / 3)));
-    }
-
-    public override void AppendToPacket(ByteBuffer data)
-    {
-        data.WriteUInt16((ushort)DynamicFieldChangeType);
-        if (ValueCount != null)
-            data.WriteInt32((int)ValueCount);
-
-        var maskArray = new byte[_blockCount << 2];
-
-        _mask.CopyTo(maskArray, 0);
-        data.WriteBytes(maskArray);
-    }
-
-    public uint DynamicFieldChangeType;
-    public int? ValueCount;
+    [DoesNotReturn]
+    private static void ThrowIndexOutOfRange(int index) =>
+        throw new ArgumentOutOfRangeException(nameof(index), index, null);
 }
 
 public enum DynamicFieldChangeType


### PR DESCRIPTION
## Summary

The V1_14 / V2_5 flat update-field write path no longer allocates per update. `UpdateMask` is backed by a `uint[]` instead of `BitArray`, and `DynamicUpdateMask` is gone. The bytes on the wire are unchanged.

## Why

Every Values update on these clients paid for garbage that the data never needed:

- `UpdateMask.AppendToPacket` copied the `BitArray` into a fresh `byte[]` on every call.
- `UpdateFieldsArray.WriteToPacket` tested every field index (4674 for an ActivePlayer) with `GetBit`, wrote the values into a temporary `ByteBuffer`, and spliced it in through `GetData()`, which copies again.
- Each dynamic field built a `DynamicUpdateMask` with two `BitArray`s, a temporary `ByteBuffer`, its `GetData()` copy and the mask array; the generic setter added a `uint[]` for the values.
- Every builder constructs a `DynamicUpdateFieldsArray`, and each one rented a pooled field buffer even when no dynamic field was set, which is the common case.

`Framework.Util.StackBitMask` has the right bit math but can't replace the class: it is a `ref struct`, and this mask accumulates across `SetUpdateField` calls while its `UpdateFieldsArray` sits in `ObjectCacheModern` between updates.

## Change

- `UpdateMask`: blocks in a `uint[]`, same index math as `StackBitMask`. `AppendToPacket` writes the blocks as bytes. Indices outside the field count still throw, as `BitArray` did; the last block's spare bits must stay unreachable.
- `UpdateFieldsArray.WriteToPacket`: writes the mask, then walks the set bits (`TrailingZeroCount`) and writes each value straight into the packet.
- `DynamicUpdateFieldsArray`: every element of a dynamic field is always sent, so the element mask is all ones and is written directly along with the header (`ValueAndSizeChanged` flag and count on Values updates only, as before). The generic setter uses `stackalloc`; the array overload takes `ReadOnlySpan<uint>`, which the `uint[]` callers convert to implicitly. The field buffer is rented on first use.

V3_4_3 is untouched: `UpdatePackets` picks the builder by client build, the V3_4_3 builder never references these types, and `ObjectCacheModern` is only filled by the V1_14/V2_5 builders.

## Tests

`UpdateMaskWireTests` (129 tests):

- An oracle rebuilds the old `BitArray` serialization. The tests were run against the old implementation first and passed, then against the new one.
- Masks of 0 to 4674 fields at four densities, every single bit of a 97-field mask, `UpdateFieldsArray` writes including the cached clear-then-set cycle, and every dynamic-field size × change type × update type combination (90 cases), plus the generic setter for each type.
- Three allocation tests assert 0 bytes for `UpdateFieldsArray` clear/set/write, the generic dynamic setter plus write, and a dynamic write with no field set.

Full suite on the M4: 1793 pass, 6 skipped, 0 failed.

## Benchmarks — Mac mini M4, BenchmarkDotNet ShortRun

`UpdateMaskBenchmarks` keeps verbatim copies of the old classes, so both run in the same pass.

`UpdateFieldsArray`: clear mask, set 16 fields, write (V1_14_1 Item / Unit / ActivePlayer sizes)

| Fields | Before | After | Alloc before | Alloc after |
|---|---:|---:|---:|---:|
| 80 | 325 ns | 46 ns | 197 B | 0 B |
| 218 | 437 ns | 48 ns | 360 B | 0 B |
| 4674 | 3327 ns | 91 ns | 1011 B | 0 B |

`DynamicUpdateFieldsArray`: construct, set, write

| Case | Before | After | Alloc before | Alloc after |
|---|---:|---:|---:|---:|
| no dynamic field | 300 ns | 12 ns | 265 B | 104 B |
| channel object (GUID) | 504 ns | 253 ns | 535 B | 162 B |
| gems (30 values) | 665 ns | 252 ns | 819 B | 162 B |

What remains in the dynamic case is the array, its mask and, once a field is set, the pooled field buffer.

## Playtest — Classic Era 1.14.2 → cMaNGOS vanilla

Login, relog onto a second character, inventory moves, a channelled spell, combat. 611 `SMSG_UPDATE_OBJECT` forwarded; the proxy log has no errors beyond the usual BNet close at login and the socket close at exit. WPP decodes `UNIT_DYNAMIC_FIELD_CHANNEL_OBJECTS` with its four elements.

## Playtest — TBC 2.5.3 → cMaNGOS TBC

Login, gemmed gear, socketing a gem, a channelled spell. 316 `SMSG_UPDATE_OBJECT` forwarded, same clean log. WPP decodes `ITEM_DYNAMIC_FIELD_GEMS` as the full 30-element array with the gem in slots 0, 10 and 20, and the gem tooltips are correct in the client.

WPP reports some `UPDATE_OBJECT` errors on these sniffs. They are its own state: the character-list handler stores the first listed character as a `Player`, and the later ActivePlayer create never updates the stored type, so that character's ActivePlayer fields are misnamed and partial multi-word updates throw. Every error is on that character, sessions on other characters parse clean, and a master sniff of the same character from earlier the same day shows the same errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bsz5TdvtRMNLUYLbg1AcLW
