### PR TITLE
fix(guid): send item guids back with the high the backend uses

### DIFF
--- a/HermesProxy.Tests/World/LegacyItemGuidHighTests.cs
+++ b/HermesProxy.Tests/World/LegacyItemGuidHighTests.cs
@@ -1,0 +1,151 @@
+using System;
+using HermesProxy.World;
+using HermesProxy.World.Enums;
+using Xunit;
+
+namespace HermesProxy.Tests.World;
+
+/// <summary>
+/// Issue #278: cMaNGOS WotLK uses 0x4700 for item guids, every other supported core uses 0x4000.
+/// The proxy accepted both inbound but rebuilt every item as 0x4000, so item-guid packets from
+/// the client (quest-starting items, vendor sells, repairs) named a guid that backend could not
+/// find, and it silently did nothing.
+///
+/// <para>
+/// <see cref="LegacyItemGuidHigh"/> is process-global state and xunit.runner.json runs test
+/// classes in parallel, so every mutating test lives in this one class — xUnit serialises tests
+/// within a class — and each one resets first rather than assuming a pristine default.
+/// </para>
+/// </summary>
+[CollectionDefinition("LegacyItemGuidHigh", DisableParallelization = true)]
+public class LegacyItemGuidHighCollection;
+
+[Collection("LegacyItemGuidHigh")]
+public class LegacyItemGuidHighTests : IDisposable
+{
+    public LegacyItemGuidHighTests() => LegacyItemGuidHigh.Reset();
+
+    public void Dispose() => LegacyItemGuidHigh.Reset();
+
+    [Fact]
+    public void Default_IsStandardItemHigh()
+    {
+        Assert.Equal(HighGuidTypeLegacy.Item, LegacyItemGuidHigh.Current);
+    }
+
+    // The regression the issue is about: an item that arrives as 0x4700 must go back as 0x4700.
+    [Fact]
+    public void ItemArrivingAs4700_GoesBackAs4700()
+    {
+        // Arrange — the Riding Training Pamphlet from the issue: counter 579.
+        var legacy = new WowGuid64(HighGuidTypeLegacy.ItemContainer, 579);
+
+        // Act — ingest (server → client), then rebuild (client → server).
+        var modern = legacy.To128(null!);
+        var backToLegacy = modern.To64();
+
+        // Assert
+        Assert.Equal(HighGuidTypeLegacy.ItemContainer, backToLegacy.GetHighGuidTypeLegacy());
+        Assert.Equal(579ul, backToLegacy.GetCounter());
+        Assert.Equal(legacy, backToLegacy);
+    }
+
+    // TrinityCore / AzerothCore / cMaNGOS classic / cMaNGOS TBC must be untouched by the fix.
+    [Fact]
+    public void ItemArrivingAs4000_GoesBackAs4000()
+    {
+        // Arrange
+        var legacy = new WowGuid64(HighGuidTypeLegacy.Item, 579);
+
+        // Act
+        var backToLegacy = legacy.To128(null!).To64();
+
+        // Assert
+        Assert.Equal(HighGuidTypeLegacy.Item, backToLegacy.GetHighGuidTypeLegacy());
+        Assert.Equal(579ul, backToLegacy.GetCounter());
+        Assert.Equal(legacy, backToLegacy);
+    }
+
+    // With no 0x4700 ever seen, rebuilding must still produce the standard high — a modern item
+    // guid that the proxy minted itself (no legacy original) is the common case here.
+    [Fact]
+    public void ModernItemGuid_WithNothingObserved_RebuildsAsStandardHigh()
+    {
+        // Arrange
+        var modern = WowGuid128.Create(HighGuidType703.Item, 42);
+
+        // Act
+        var legacy = modern.To64();
+
+        // Assert
+        Assert.Equal(HighGuidTypeLegacy.Item, legacy.GetHighGuidTypeLegacy());
+        Assert.Equal(42ul, legacy.GetCounter());
+    }
+
+    // Latching: proxy-built item guids carry the 0x4000 default, and converting one must not
+    // undo what the backend told us, or the rebuilt high would depend on conversion order.
+    [Fact]
+    public void ObservingStandardHighAfter4700_DoesNotRevert()
+    {
+        // Arrange
+        LegacyItemGuidHigh.Observe(HighGuidTypeLegacy.ItemContainer);
+
+        // Act
+        LegacyItemGuidHigh.Observe(HighGuidTypeLegacy.Item);
+
+        // Assert
+        Assert.Equal(HighGuidTypeLegacy.ItemContainer, LegacyItemGuidHigh.Current);
+        Assert.Equal(
+            HighGuidTypeLegacy.ItemContainer,
+            WowGuid128.Create(HighGuidType703.Item, 7).To64().GetHighGuidTypeLegacy());
+    }
+
+    [Theory]
+    [InlineData(HighGuidTypeLegacy.Creature)]
+    [InlineData(HighGuidTypeLegacy.Player)]
+    [InlineData(HighGuidTypeLegacy.GameObject)]
+    [InlineData(HighGuidTypeLegacy.Corpse)]
+    public void ObservingNonItemHigh_IsIgnored(HighGuidTypeLegacy high)
+    {
+        // Act
+        LegacyItemGuidHigh.Observe(high);
+
+        // Assert
+        Assert.Equal(HighGuidTypeLegacy.Item, LegacyItemGuidHigh.Current);
+    }
+
+    // Converting a non-item guid must not disturb the learned high either.
+    [Fact]
+    public void ConvertingCreatureGuid_DoesNotChangeItemHigh()
+    {
+        // Arrange
+        LegacyItemGuidHigh.Observe(HighGuidTypeLegacy.ItemContainer);
+        var creature = new WowGuid64(HighGuidTypeLegacy.Creature, 25000, 42);
+
+        // Act
+        _ = WowGuid64.Create(WowGuid128.Create(HighGuidType703.Creature, 0, 25000, 42));
+        _ = creature.GetHighType();
+
+        // Assert
+        Assert.Equal(HighGuidTypeLegacy.ItemContainer, LegacyItemGuidHigh.Current);
+    }
+
+    // Both highs must still read as items on the modern side, which is what makes the ingest
+    // side work at all.
+    [Theory]
+    [InlineData(HighGuidTypeLegacy.Item)]
+    [InlineData(HighGuidTypeLegacy.ItemContainer)]
+    public void BothHighs_ConvertToModernItemGuid(HighGuidTypeLegacy high)
+    {
+        // Arrange
+        var legacy = new WowGuid64(high, 461);
+
+        // Act
+        var modern = legacy.To128(null!);
+
+        // Assert
+        Assert.Equal(HighGuidType.Item, modern.GetHighType());
+        Assert.True(modern.IsItem());
+        Assert.Equal(461ul, modern.GetCounter());
+    }
+}

--- a/HermesProxy/World/Enums/ObjectType.cs
+++ b/HermesProxy/World/Enums/ObjectType.cs
@@ -137,7 +137,7 @@ public enum HighGuidTypeLegacy
 {
     None                    = -1,
     Item                    = 0x4000,                       // blizz 4000
-    ItemContainer           = 0x4700,                       // cmangos uses 0x4700 for equipped/container items in CreateObject burst
+    ItemContainer           = 0x4700,                       // cmangos WotLK uses 0x4700 for EVERY item (HIGHGUID_ITEM = HIGHGUID_CONTAINER = 0x470), not just equipped/container ones
     Player                  = 0x0000,                       // blizz 0000
     GameObject              = 0xF110,                       // blizz F110
     Transport               = 0xF120,                       // blizz F120 (for GAMEOBJECT_TYPE_TRANSPORT)

--- a/HermesProxy/World/LegacyItemGuidHigh.cs
+++ b/HermesProxy/World/LegacyItemGuidHigh.cs
@@ -1,0 +1,92 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Framework.Logging;
+using HermesProxy.World.Enums;
+using HermesProxy.World.Logging;
+
+namespace HermesProxy.World;
+
+/// <summary>
+/// The high-guid part the legacy backend uses for items, learned from what it sends.
+///
+/// <para>
+/// Item guids are the one case where legacy cores disagree. TrinityCore, AzerothCore, cMaNGOS
+/// classic, cMaNGOS TBC and VMaNGOS all use <c>HIGHGUID_ITEM = 0x4000</c>, but cMaNGOS WotLK
+/// uses <c>HIGHGUID_ITEM = HIGHGUID_CONTAINER = 0x470</c> (mangos-wotlk
+/// <c>src/game/Entities/ObjectGuid.h:61</c>), so its items arrive as <c>0x4700…</c>.
+/// </para>
+///
+/// <para>
+/// The proxy already accepted both on the way in — <see cref="HighGuid.FromLegacy"/> maps
+/// ItemContainer to Item — but rebuilt every item as 0x4000 on the way back, so every client
+/// packet naming an item by guid missed on cMaNGOS WotLK. Its handlers switch on the guid's
+/// high part (<c>GetObjectByTypeMask</c>, <c>GetItemByGuid</c>), find nothing under 0x4000, and
+/// silently do nothing. That is issue #278: right-clicking a quest-starting item such as the
+/// Riding Training Pamphlet never opened its quest, and selling, repairing, mailing and
+/// socketing were all predicted to fail the same way.
+/// </para>
+///
+/// <para>
+/// Learning it beats gating on the backend build: the value is a property of the core, not of
+/// the version it reports, and forks are free to differ. Cores that use 0x4000 never send
+/// 0x4700, so they never leave the default and need no version gate.
+/// </para>
+/// </summary>
+public static class LegacyItemGuidHigh
+{
+    private static readonly Microsoft.Extensions.Logging.ILogger _melServer =
+        Log.CreateMelLogger(Log.CategoryServer);
+
+    // Process-global rather than per-session: WowGuid64.Create(WowGuid128) is static and has no
+    // session to consult, and roughly 146 To64() call sites would have to thread one through to
+    // change that. One proxy process serves one configured backend, so the value is the same for
+    // every session in it.
+    //
+    // Held as int because Interlocked works on int, not on an enum-typed field.
+    private static int _current = (int)HighGuidTypeLegacy.Item;
+
+    /// <summary>The high to rebuild item guids with. Defaults to the standard 0x4000.</summary>
+    public static HighGuidTypeLegacy Current
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (HighGuidTypeLegacy)Volatile.Read(ref _current);
+    }
+
+    /// <summary>
+    /// Records the high an item guid arrived with. Latches: once 0x4700 has been seen it stays,
+    /// and a later 0x4000 never flips it back. A core's item high is fixed, so one sighting
+    /// settles it — while proxy-built item guids (which use the 0x4000 default) would otherwise
+    /// flip the value back and forth mid-session and make the rebuilt guid depend on whichever
+    /// item was converted last.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Observe(HighGuidTypeLegacy high)
+    {
+        if (high != HighGuidTypeLegacy.ItemContainer)
+            return;
+
+        if (Volatile.Read(ref _current) != (int)HighGuidTypeLegacy.ItemContainer)
+            Latch();
+    }
+
+    // Off the inlined path: this runs once per session, on the first item the backend sends.
+    //
+    // The compare-and-swap is what keeps it once: the fast-path check above is a plain read, so
+    // two receive threads decoding the first item batch can both reach here, and only the one
+    // that actually flips the value logs. Both would write the same value, so the swap is about
+    // the log line and not about correctness of the stored high.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Latch()
+    {
+        int previous = Interlocked.CompareExchange(
+            ref _current,
+            (int)HighGuidTypeLegacy.ItemContainer,
+            (int)HighGuidTypeLegacy.Item);
+
+        if (previous == (int)HighGuidTypeLegacy.Item)
+            GuidLogMessages.LearnedLegacyItemHigh(_melServer, (uint)HighGuidTypeLegacy.ItemContainer);
+    }
+
+    /// <summary>Restores the 0x4000 default. For tests, which share one process.</summary>
+    internal static void Reset() => Volatile.Write(ref _current, (int)HighGuidTypeLegacy.Item);
+}

--- a/HermesProxy/World/Logging/GuidLogMessages.cs
+++ b/HermesProxy/World/Logging/GuidLogMessages.cs
@@ -29,4 +29,13 @@ internal static partial class GuidLogMessages
         Message = "[HighGuid703] Unknown 703 high-guid 0x{High:X2} ({High}) — treating as Null. " +
                   "Object will be skipped on the modern side.")]
     public static partial void Unknown703HighGuid(ILogger logger, byte high);
+
+    // Fires at most once per session, on the first item guid a 0x4700 backend sends. Information
+    // rather than Debug because it changes what every later item-guid packet puts on the wire, so
+    // it is worth having in a user's log when an item action misbehaves.
+    [LoggerMessage(
+        EventId = 1302,
+        Level = LogLevel.Information,
+        Message = "[ItemGuid] Backend uses high-guid 0x{High:X4} for items; rebuilding item guids with it.")]
+    public static partial void LearnedLegacyItemHigh(ILogger logger, uint high);
 }

--- a/HermesProxy/World/WowGuid128.cs
+++ b/HermesProxy/World/WowGuid128.cs
@@ -19,7 +19,7 @@ public readonly record struct WowGuid128(ulong Low, ulong High)
     public static WowGuid128 Create(WowGuid64 guid, GameSessionData gamestate) => guid.GetHighType() switch
     {
         HighGuidType.Player => Create(HighGuidType703.Player, guid.GetCounter()),
-        HighGuidType.Item => Create(HighGuidType703.Item, guid.GetCounter()),
+        HighGuidType.Item => CreateItem(guid),
         HighGuidType.Transport => TransportCreate(guid.GetCounter(), guid.GetEntry()),
         HighGuidType.MOTransport => TransportCreate(guid.GetCounter() | MoTransportCounterFlag, guid.GetEntry()),
         HighGuidType.RaidGroup => Create(HighGuidType703.RaidGroup, guid.GetCounter()),
@@ -31,6 +31,15 @@ public readonly record struct WowGuid128(ulong Low, ulong High)
         HighGuidType.Corpse => Create(HighGuidType703.Corpse, 0, guid.GetEntry(), guid.GetCounter()),
         _ => WowGuid128.Empty,
     };
+    // Every legacy item guid the backend sends reaches the modern side through here, which makes
+    // it the one place that sees which high the server uses for items before the guid is
+    // normalised to a modern Item guid. WowGuid64.Create reads it back when rebuilding (#278).
+    static WowGuid128 CreateItem(WowGuid64 guid)
+    {
+        LegacyItemGuidHigh.Observe(guid.GetHighGuidTypeLegacy());
+        return Create(HighGuidType703.Item, guid.GetCounter());
+    }
+
     public static WowGuid128 Create(HighGuidType703 type, ulong counter)
     {
         switch (type)

--- a/HermesProxy/World/WowGuid64.cs
+++ b/HermesProxy/World/WowGuid64.cs
@@ -25,7 +25,9 @@ public readonly record struct WowGuid64(ulong Low)
     {
         HighGuidType.Uniq => WowGuid128.ConvertUniqGuid(guid),
         HighGuidType.Player => new WowGuid64(HighGuidTypeLegacy.Player, (uint)guid.GetCounter()),
-        HighGuidType.Item => new WowGuid64(HighGuidTypeLegacy.Item, (uint)guid.GetCounter()),
+        // Not hard-coded to 0x4000: cMaNGOS WotLK uses 0x4700 for items, and an item guid sent
+        // back under the wrong high finds nothing on that backend (#278). See LegacyItemGuidHigh.
+        HighGuidType.Item => new WowGuid64(LegacyItemGuidHigh.Current, (uint)guid.GetCounter()),
         HighGuidType.Transport => (guid.GetCounter() & WowGuid128.MoTransportCounterFlag) != 0
                             ? new WowGuid64(HighGuidTypeLegacy.MOTransport, (uint)(guid.GetCounter() & ~WowGuid128.MoTransportCounterFlag))
                             : new WowGuid64(HighGuidTypeLegacy.Transport, guid.GetEntry(), (uint)guid.GetCounter()),


### PR DESCRIPTION
Fixes #278.

## The bug

cMaNGOS WotLK sets `HIGHGUID_ITEM = HIGHGUID_CONTAINER = 0x470` (mangos-wotlk `src/game/Entities/ObjectGuid.h:61`), so its item guids arrive as `0x4700…`. Every other supported core uses `0x4000`:

| Core | `HIGHGUID_ITEM` |
|---|---|
| cMaNGOS WotLK | `0x470` → 0x4700 |
| cMaNGOS classic | `0x4000` |
| cMaNGOS TBC | `0x4000` |
| VMaNGOS | `0x4000` |
| TrinityCore / AzerothCore | `0x4000` |

The proxy accepted both inbound — `HighGuid.FromLegacy` maps `ItemContainer` to `Item` — but rebuilt every item as 0x4000 outbound. So each client packet naming an item by guid reached cMaNGOS WotLK under a high it does not use; its handlers switch on the guid's high part, find nothing, and silently do nothing. Right-clicking the Riding Training Pamphlet never opened its quest, and sell, repair, mail and socket were predicted to fail the same way.

## The fix

`LegacyItemGuidHigh` learns the high from the first 0x4700 item the backend sends, hooked in `WowGuid128.CreateItem` — the single point every inbound item guid passes through — and `WowGuid64.Create` rebuilds items with it. That covers all ~146 `To64()` call sites at once, including the session-aware `To64(GameSessionData)` overload, which falls through to the same factory for non-Pet types.

Learning beats gating on the backend build: the value is a property of the core, not of the version it reports, and forks are free to differ. Cores that use 0x4000 never send 0x4700, so they never leave the default — the fix self-gates and needs no version guard.

It latches. Proxy-built item guids carry the 0x4000 default, and letting those flip it back would make the rebuilt high depend on whichever item was converted last. The flip uses `Interlocked.CompareExchange` so the log line fires once even when two receive threads decode the first item batch together.

## Wire evidence

From the legacy-side sniff of a live cMaNGOS WotLK session — what the server actually received:

```
ClientToServer: CMSG_QUEST_GIVER_ACCEPT_QUEST
GUID: Full: 0x4700000000000243 Type: Item Low: 579
Quest ID: 14085
```

cMaNGOS answered `CMSG_QUEST_GIVER_QUERY_QUEST` with `SMSG_QUEST_GIVER_QUEST_DETAILS` instead of the `SMSG_GOSSIP_COMPLETE` brush-off recorded in the issue, accepted the quest, and replied `SMSG_QUEST_GIVER_INVALID_QUEST` to a second attempt — the "already on that quest" path. Every `Full: 0x4000` guid left in that capture is server-to-client and none is an item, so nothing bypasses the rebuild.

The proxy also logs the latch once per session, from the login item burst and before the player can click anything:

```
[ItemGuid] Backend uses high-guid 0x4700 for items; rebuilding item guids with it.
```

## Testing

- 12 new tests: round-trip in both directions, latch behaviour, non-item highs ignored, and both highs reading as modern item guids. They live in a `DisableParallelization` collection because the learned high is process-global and `xunit.runner.json` runs collections in parallel.
- Full suite green: 1844 passed.
- Playtested on cMaNGOS WotLK with a V3_4_3 client.

## Not covered

Two acceptance items from the issue are still untested rather than fixed-and-verified: **selling to a vendor** and **repairing a single item**. Both go through the same rebuild, so they are expected to work, but this PR does not prove it.

Separately, accepting a quest on cMaNGOS WotLK puts it on the server but the client quest log only shows it after a relog. That is inbound player update fields rather than outbound item guids, so it is not from this change — before this fix an item-started quest could not be accepted at all, which is why it surfaced now. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bsz5TdvtRMNLUYLbg1AcLW
